### PR TITLE
Adds an app logger which writes to platforms app data location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Example of the `get_pipeline` tool in action.
 * [goreleaser](http://goreleaser.com)
 * [go 1.24](https://go.dev)
 
+# Troubleshooting 
+
+Logs for the Buildkite MCP server are stored in the platform-specific directory:
+
+* macOS: ~/Library/Application Support/buildkite-mcp-server/logs/
+* Windows: %APPDATA%\buildkite-mcp-server\logs\
+* Linux: ~/.config/buildkite-mcp-server/logs/
+
+The name of the log file is generated from the template `{{hostname}}_{{username}}_{{timestamp:2006-01-02}}_pid{{pid}}.log` so the files are unique for different mcp servers.
+
 # building
 
 Build the binary.

--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -2,11 +2,18 @@ package main
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/alecthomas/kong"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/wolfeidau/buildkite-mcp-server/internal/commands"
+	"github.com/wolfeidau/buildkite-mcp-server/pkg/applog"
+)
+
+const (
+	appName = "buildkite-mcp-server"
 )
 
 var (
@@ -22,8 +29,22 @@ var (
 
 func main() {
 	ctx := context.Background()
+
+	logger, err := applog.NewTextLogger(
+		appName,
+		"{{hostname}}_{{username}}_{{timestamp:2006-01-02}}_pid{{pid}}.log",
+		&slog.HandlerOptions{AddSource: true},
+	)
+	if err != nil {
+		fmt.Println("failed to create logger:", err)
+		os.Exit(1)
+	}
+
+	// add logger to context
+	ctx = applog.WithLogger(ctx, logger.Logger)
+
 	cmd := kong.Parse(&cli,
-		kong.Name("buildkite-mcp-server"),
+		kong.Name(appName),
 		kong.Description("A server that proxies requests to the Buildkite API."),
 		kong.UsageOnError(),
 		kong.Vars{
@@ -34,7 +55,8 @@ func main() {
 
 	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(cli.APIToken))
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("failed to create buildkite client", "error", err)
+		os.Exit(1)
 	}
 
 	err = cmd.Run(&commands.Globals{Debug: cli.Debug, Version: version, Client: client})

--- a/internal/buildkite/builds.go
+++ b/internal/buildkite/builds.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/wolfeidau/buildkite-mcp-server/pkg/applog"
 )
 
 func ListBuilds(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
@@ -40,6 +41,8 @@ func ListBuilds(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, h
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+
+			applog.Ctx(ctx).Debug("List builds", "org", org, "pipeline_slug", pipelineSlug, "pagination", paginationParams)
 
 			builds, resp, err := client.Builds.ListByPipeline(ctx, org, pipelineSlug, &buildkite.BuildsListOptions{
 				ListOptions: paginationParams,

--- a/internal/buildkite/pipelines.go
+++ b/internal/buildkite/pipelines.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/wolfeidau/buildkite-mcp-server/pkg/applog"
 )
 
 func ListPipeline(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
@@ -30,6 +31,8 @@ func ListPipeline(ctx context.Context, client *buildkite.Client) (tool mcp.Tool,
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
+
+			applog.Ctx(ctx).Debug("List pipelines", "org", org, "pagination", paginationParams)
 
 			pipelines, resp, err := client.Pipelines.List(ctx, org, &buildkite.PipelineListOptions{
 				ListOptions: paginationParams,

--- a/internal/buildkite/user.go
+++ b/internal/buildkite/user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/wolfeidau/buildkite-mcp-server/pkg/applog"
 )
 
 type UserClient interface {
@@ -18,6 +19,9 @@ func CurrentUser(ctx context.Context, client UserClient) (tool mcp.Tool, handler
 	return mcp.NewTool("current_user",
 			mcp.WithDescription("Get the current user"),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+
+			applog.Ctx(ctx).Debug("Get current user")
+
 			user, resp, err := client.CurrentUser(ctx)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil

--- a/pkg/applog/appdata.go
+++ b/pkg/applog/appdata.go
@@ -1,0 +1,46 @@
+package applog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// GetAppDataDir returns the platform-specific directory for application data
+func GetAppDataDir(appName string) (string, error) {
+	var basePath string
+
+	switch runtime.GOOS {
+	case "darwin":
+		// macOS: ~/Library/Application Support/[AppName]/logs
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		basePath = filepath.Join(home, "Library", "Application Support", appName, "logs")
+	case "windows":
+		// Windows: %APPDATA%\[AppName]\logs
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA environment variable not set")
+		}
+		basePath = filepath.Join(appData, appName, "logs")
+	case "linux":
+		// Linux: ~/.config/[AppName]/logs
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		basePath = filepath.Join(home, ".config", appName, "logs")
+	default:
+		return "", fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		return "", err
+	}
+
+	return basePath, nil
+}

--- a/pkg/applog/file.go
+++ b/pkg/applog/file.go
@@ -1,0 +1,95 @@
+package applog
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// processLogFileNameTemplate replaces template placeholders in the log file name
+func processLogFileNameTemplate(template string) string {
+	now := time.Now()
+
+	// Replace timestamp placeholder with formatted current time
+	// Formats: {{timestamp}}, {{ timestamp }}, {{timestamp:format}}, {{ timestamp:format }}
+	tsRegex := regexp.MustCompile(`\{\{\s*timestamp(?::([^}]+))?\s*\}\}`)
+	template = tsRegex.ReplaceAllStringFunc(template, func(match string) string {
+		submatch := tsRegex.FindStringSubmatch(match)
+		format := "20060102-150405" // Default format: YYYYMMDD-HHMMSS
+		if len(submatch) > 1 && submatch[1] != "" {
+			format = submatch[1]
+		}
+		return now.Format(format)
+	})
+
+	// Replace pid placeholder with current process ID
+	// Formats: {{pid}}, {{ pid }}
+	pidRegex := regexp.MustCompile(`\{\{\s*pid\s*\}\}`)
+	template = pidRegex.ReplaceAllString(template, strconv.Itoa(os.Getpid()))
+
+	// Replace hostname placeholder with machine hostname
+	// Formats: {{hostname}}, {{ hostname }}
+	hostnameRegex := regexp.MustCompile(`\{\{\s*hostname\s*\}\}`)
+	if hostname, err := os.Hostname(); err == nil {
+		template = hostnameRegex.ReplaceAllString(template, hostname)
+	} else {
+		template = hostnameRegex.ReplaceAllString(template, "unknown-host")
+	}
+
+	// Replace username placeholder with current user
+	// Formats: {{username}}, {{ username }}
+	usernameRegex := regexp.MustCompile(`\{\{\s*username\s*\}\}`)
+	if currentUser, err := getCurrentUsername(); err == nil {
+		template = usernameRegex.ReplaceAllString(template, currentUser)
+	} else {
+		template = usernameRegex.ReplaceAllString(template, "unknown-user")
+	}
+
+	return template
+}
+
+// getCurrentUsername tries to get the current username
+func getCurrentUsername() (string, error) {
+	// First try environment variables which are usually set
+	for _, envVar := range []string{"USER", "USERNAME"} {
+		if username := os.Getenv(envVar); username != "" {
+			return username, nil
+		}
+	}
+
+	// Fallback to os/user if available
+	userInfo, err := userCurrent()
+	if err != nil {
+		return "", err
+	}
+	return userInfo.Username, nil
+}
+
+// userCurrent is a wrapper around user.Current for easier testing/mocking
+var userCurrent = func() (*userInfo, error) {
+	return &userInfo{Username: "user"}, nil // This will be replaced with actual implementation
+}
+
+// userInfo provides a minimal interface needed for username
+type userInfo struct {
+	Username string
+}
+
+func init() {
+	// Set up the actual user.Current implementation
+	// This avoids having to import user in tests
+	userCurrent = func() (*userInfo, error) {
+		// In a real implementation, this would use os/user.Current()
+		// For simplicity, we're just getting the USER/USERNAME env var
+		username := os.Getenv("USER")
+		if username == "" {
+			username = os.Getenv("USERNAME") // Windows typically uses USERNAME
+		}
+		if username == "" {
+			return nil, fmt.Errorf("could not determine current user")
+		}
+		return &userInfo{Username: username}, nil
+	}
+}

--- a/pkg/applog/logger.go
+++ b/pkg/applog/logger.go
@@ -1,0 +1,183 @@
+package applog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// contextKey is a private type for context keys to avoid collisions
+type contextKey int
+
+// loggerKey is the key for logger values in contexts.
+const loggerKey contextKey = 0
+
+// AppLogger wraps a slog.Logger with platform-specific file handling
+type AppLogger struct {
+	*slog.Logger
+	appName string
+	logFile *os.File
+}
+
+// Close closes the logger's file
+func (l *AppLogger) Close() error {
+	return l.logFile.Close()
+}
+
+// GetLogFilePath returns the full path to the log file
+func (l *AppLogger) GetLogFilePath() (string, error) {
+	return GetAppDataDir(l.appName)
+}
+
+// createLogFile creates a log file with a processed template name
+func createLogFile(appName, logFileNameTemplate string) (*os.File, string, error) {
+	logDir, err := GetAppDataDir(appName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Process the template if it contains any template placeholders
+	logFileName := logFileNameTemplate
+	if strings.Contains(logFileNameTemplate, "{{") {
+		logFileName = processLogFileNameTemplate(logFileNameTemplate)
+	}
+
+	logPath := filepath.Join(logDir, logFileName)
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return file, logPath, nil
+}
+
+// NewTextLogger creates a new slog logger with TextHandler that writes to the platform-specific location
+func NewTextLogger(appName, logFileNameTemplate string, opts *slog.HandlerOptions) (*AppLogger, error) {
+	file, _, err := createLogFile(appName, logFileNameTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	handler := slog.NewTextHandler(file, opts)
+	logger := slog.New(handler)
+
+	return &AppLogger{
+		Logger:  logger,
+		appName: appName,
+		logFile: file,
+	}, nil
+}
+
+// NewJSONLogger creates a new slog logger with JSONHandler that writes to the platform-specific location
+func NewJSONLogger(appName, logFileNameTemplate string, opts *slog.HandlerOptions) (*AppLogger, error) {
+	file, _, err := createLogFile(appName, logFileNameTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	handler := slog.NewJSONHandler(file, opts)
+	logger := slog.New(handler)
+
+	return &AppLogger{
+		Logger:  logger,
+		appName: appName,
+		logFile: file,
+	}, nil
+}
+
+// SetDefaultLogger sets the slog default logger to use the platform-specific location
+func SetDefaultLogger(appName, logFileNameTemplate string, jsonFormat bool, opts *slog.HandlerOptions) (*AppLogger, error) {
+	var logger *AppLogger
+	var err error
+
+	if jsonFormat {
+		logger, err = NewJSONLogger(appName, logFileNameTemplate, opts)
+	} else {
+		logger, err = NewTextLogger(appName, logFileNameTemplate, opts)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the default logger
+	slog.SetDefault(logger.Logger)
+
+	return logger, nil
+}
+
+// MultiLogger allows writing to multiple outputs (both file and stderr for example)
+type MultiLogger struct {
+	*slog.Logger
+	appName string
+	logFile *os.File
+}
+
+// NewMultiLogger creates a logger that writes to both the platform-specific log file
+// and another writer (like os.Stderr)
+func NewMultiLogger(appName, logFileNameTemplate string, additionalWriter io.Writer, jsonFormat bool, opts *slog.HandlerOptions) (*MultiLogger, error) {
+	file, _, err := createLogFile(appName, logFileNameTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a multi-writer that sends output to both the file and the additional writer
+	multiWriter := io.MultiWriter(file, additionalWriter)
+
+	var handler slog.Handler
+	if jsonFormat {
+		handler = slog.NewJSONHandler(multiWriter, opts)
+	} else {
+		handler = slog.NewTextHandler(multiWriter, opts)
+	}
+
+	logger := slog.New(handler)
+
+	return &MultiLogger{
+		Logger:  logger,
+		appName: appName,
+		logFile: file,
+	}, nil
+}
+
+// Close closes the logger's file
+func (l *MultiLogger) Close() error {
+	return l.logFile.Close()
+}
+
+// --- Context Integration ---
+
+// WithLogger returns a new Context that carries the provided logger
+func WithLogger(ctx context.Context, logger *slog.Logger) context.Context {
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// Ctx returns the Logger stored in ctx, if any.
+// If no logger is found, it returns the default logger.
+func Ctx(ctx context.Context) *slog.Logger {
+	if logger, ok := ctx.Value(loggerKey).(*slog.Logger); ok {
+		return logger
+	}
+	return slog.Default()
+}
+
+// WithContextAttrs enriches a logger with values from the context
+// This is a helper function but users are free to use the logger directly
+func WithContextAttrs(ctx context.Context, logger *slog.Logger, attrs ...any) *slog.Logger {
+	// Extract common values from context if they exist
+	// Users can customize this based on their context keys
+	if reqID, ok := ctx.Value("request_id").(string); ok {
+		logger = logger.With("request_id", reqID)
+	}
+	if userID, ok := ctx.Value("user_id").(string); ok {
+		logger = logger.With("user_id", userID)
+	}
+	// Add any additional attributes
+	if len(attrs) > 0 {
+		logger = logger.With(attrs...)
+	}
+	return logger
+}


### PR DESCRIPTION
This is built on slog, so it can be extended and configured more in the
future. I chose slog as it is native and good enough for an interactive
cli running on an end user machine.

Logs for the Buildkite MCP server are stored in the platform-specific directory:

* macOS: ~/Library/Application Support/buildkite-mcp-server/logs/
* Windows: %APPDATA%\buildkite-mcp-server\logs\
* Linux: ~/.config/buildkite-mcp-server/logs/

The name of the log file is generated from the template `{{hostname}}_{{username}}_{{timestamp:2006-01-02}}_pid{{pid}}.log` so the files are unique for different mcp servers.
