### PR TITLE
Add YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ extensions:
     timeout: 300
 ```
 
+YAML configuration is required by [Goose](https://block.github.io/goose/).
+
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Create a buildkite api token with read access to pipelines.
 }
 ```
 
+```yaml
+extensions:
+  fetch:
+    name: Buildkite
+    cmd: buildkite-mcp-server
+    args: [stdio]
+    enabled: true
+    envs: { "BUILDKITE_API_TOKEN": "bkua_xxxxxxxx" }
+    type: stdio
+    timeout: 300
+```
+
 
 ## Disclaimer
 


### PR DESCRIPTION
## Changes

- Adds a YAML config example
    - YAML config is used by [goose](https://block.github.io/goose/docs/getting-started/using-extensions#config-entry)
