### PR TITLE
feat: add an action for getting job logs

### DIFF
--- a/internal/buildkite/job_logs.go
+++ b/internal/buildkite/job_logs.go
@@ -1,0 +1,76 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_job_logs",
+			mcp.WithDescription("Get the logs of a job in a Buildkite build"),
+			mcp.WithString("org",
+				mcp.Required(),
+				mcp.Description("The organization slug for the owner of the pipeline"),
+			),
+			mcp.WithString("pipeline_slug",
+				mcp.Required(),
+				mcp.Description("The slug of the pipeline"),
+			),
+			mcp.WithString("build_number",
+				mcp.Required(),
+				mcp.Description("The build number"),
+			),
+			mcp.WithString("job_uuid",
+				mcp.Required(),
+				mcp.Description("The UUID of the job"),
+			),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			org, err := requiredParam[string](request, "org")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			pipelineSlug, err := requiredParam[string](request, "pipeline_slug")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			buildNumber, err := requiredParam[string](request, "build_number")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			jobUUID, err := requiredParam[string](request, "job_uuid")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			joblog, resp, err := client.Jobs.GetJobLog(ctx, org, pipelineSlug, buildNumber, jobUUID)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read response body: %w", err)
+				}
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get issue: %s", string(body))), nil
+			}
+
+			r, err := json.Marshal(joblog)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal issue: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/internal/buildkite/job_logs_test.go
+++ b/internal/buildkite/job_logs_test.go
@@ -1,0 +1,69 @@
+package buildkite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetJobLogs(t *testing.T) {
+	// Test the tool definition
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, _ := GetJobLogs(context.Background(), nil)
+
+		assert.Equal(t, "get_job_logs", tool.Name)
+		assert.Contains(t, tool.Description, "Get the logs of a job")
+	})
+
+	t.Run("MissingParameters", func(t *testing.T) {
+		assert := require.New(t)
+		_, handler := GetJobLogs(context.Background(), &buildkite.Client{})
+
+		// Test missing org parameter
+		req := createMCPRequest(t, map[string]any{
+			"pipeline_slug": "test-pipeline",
+			"build_number":  "123",
+			"job_uuid":      "job-123",
+		})
+		result, err := handler(context.Background(), req)
+		assert.NoError(err)
+		assert.NotNil(result)
+		assert.NotEmpty(result.Content)
+
+		// Test missing pipeline_slug parameter
+		req = createMCPRequest(t, map[string]any{
+			"org":          "test-org",
+			"build_number": "123",
+			"job_uuid":     "job-123",
+		})
+		result, err = handler(context.Background(), req)
+		assert.NoError(err)
+		assert.NotNil(result)
+		assert.NotEmpty(result.Content)
+
+		// Test missing build_number parameter
+		req = createMCPRequest(t, map[string]any{
+			"org":           "test-org",
+			"pipeline_slug": "test-pipeline",
+			"job_uuid":      "job-123",
+		})
+		result, err = handler(context.Background(), req)
+		assert.NoError(err)
+		assert.NotNil(result)
+		assert.NotEmpty(result.Content)
+
+		// Test missing job_uuid parameter
+		req = createMCPRequest(t, map[string]any{
+			"org":           "test-org",
+			"pipeline_slug": "test-pipeline",
+			"build_number":  "123",
+		})
+		result, err = handler(context.Background(), req)
+		assert.NoError(err)
+		assert.NotNil(result)
+		assert.NotEmpty(result.Content)
+	})
+}

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -7,11 +7,9 @@ import (
 	"github.com/wolfeidau/buildkite-mcp-server/internal/buildkite"
 )
 
-type StdioCmd struct {
-}
+type StdioCmd struct{}
 
 func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
-
 	s := server.NewMCPServer(
 		"github-mcp-server",
 		globals.Version,

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -23,6 +23,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 	s.AddTool(buildkite.ListBuilds(ctx, globals.Client))
 	s.AddTool(buildkite.GetBuild(ctx, globals.Client))
 	s.AddTool(buildkite.CurrentUser(ctx, globals.Client.User))
+	s.AddTool(buildkite.GetJobLogs(ctx, globals.Client))
 
 	return server.ServeStdio(s)
 }


### PR DESCRIPTION
## Changes

- add a `job_logs.go` internal file for getting job logs Buildkite builds
- add a `_test.go` for the same file with comprehensive testing
- add the command to the root `commands` file

## Testing

Run `go test -run TestGetJobLogs ./... -v` for targeted test, or `go test ./... -v` for entire suite
