### PR TITLE
Dockerize MCP server

### DIFF
--- a/.buildkite/Dockerfile.build
+++ b/.buildkite/Dockerfile.build
@@ -1,3 +1,11 @@
 FROM public.ecr.aws/docker/library/golang:1.24.2@sha256:1ecc479bc712a6bdb56df3e346e33edcc141f469f82840bab9f4bc2bc41bf91d
 
 COPY --from=goreleaser/goreleaser-pro:v2.8.2@sha256:62bff5f26c37e1615265ae9c1106fbabc427882fd442c67a89db4c513d31b326 /usr/bin/goreleaser /usr/local/bin/goreleaser
+
+# Install Docker CLI for GoReleaser
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli

--- a/.buildkite/docker-compose.yaml
+++ b/.buildkite/docker-compose.yaml
@@ -26,3 +26,4 @@ services:
       - ~/gocache:/gocache
       - ~/gomodcache:/gomodcache      
       - ${BUILDKITE_AGENT_JOB_API_SOCKET}:${BUILDKITE_AGENT_JOB_API_SOCKET}
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,9 +37,6 @@ dockers:
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     - "--label=org.opencontainers.image.version={{.Version}}"
     use: buildx
-    platforms:
-    - linux/amd64
-    - linux/arm64
 
 archives:
   - formats: ["tar.gz"]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,22 @@ builds:
       - windows
       - darwin
 
+dockers:
+  - image_templates:
+    - "buildkite/buildkite-mcp-server:{{ .Version }}"
+    - "buildkite/buildkite-mcp-server:latest"
+    dockerfile: Dockerfile
+    build_flag_templates:
+    - "--pull"
+    - "--label=org.opencontainers.image.created={{.Date}}"
+    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    - "--label=org.opencontainers.image.version={{.Version}}"
+    use: buildx
+    platforms:
+    - linux/amd64
+    - linux/arm64
+
 archives:
   - formats: ["tar.gz"]
     # this name template makes the OS and Arch compatible with the results of `uname`.

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - darwin
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -38,7 +38,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 changelog:
   sort: asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.21
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+# Copy the binary built by GoReleaser
+COPY buildkite-mcp-server /app/
+
+# Set the entrypoint to run the server in stdio mode
+ENTRYPOINT ["/app/buildkite-mcp-server", "stdio"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ WORKDIR /app
 # Copy the binary built by GoReleaser
 COPY buildkite-mcp-server /app/
 
-# Set the entrypoint to run the server in stdio mode
-ENTRYPOINT ["/app/buildkite-mcp-server", "stdio"]
+# Set the entrypoint to run the server 
+ENTRYPOINT ["/app/buildkite-mcp-server"] 
+CMD ["stdio"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,28 @@
+# Build stage
+FROM public.ecr.aws/docker/library/golang:1.24.2 AS builder
+
+WORKDIR /app
+
+# Copy go.mod and go.sum first to leverage Docker cache
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the binary
+RUN CGO_ENABLED=0 go build -o buildkite-mcp-server ./cmd/buildkite-mcp-server/main.go
+
+# Final stage
+FROM alpine:3.21
+
+# Install ca-certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /app
+
+# Copy the binary from the builder stage
+COPY --from=builder /app/buildkite-mcp-server /app/buildkite-mcp-server
+
+# Set the entrypoint to run the server in stdio mode
+ENTRYPOINT ["/app/buildkite-mcp-server", "stdio"]

--- a/README.md
+++ b/README.md
@@ -22,17 +22,51 @@ Example of the `get_pipeline` tool in action.
 
 # building
 
-Build the binary.
+## Local Build
 
-```
+Build the binary locally.
+
+```bash
 make build
 ```
 
 Copy it to your path.
 
+## Docker
+
+### Local Development
+
+Build the Docker image using the local development Dockerfile:
+
+```bash
+docker build -t buildkite/buildkite-mcp-server:dev -f Dockerfile.local .
+```
+
+Run the container:
+
+```bash
+docker run -i --rm -e BUILDKITE_API_TOKEN="your-token" buildkite/buildkite-mcp-server:dev
+```
+
+### Production
+
+Pull the pre-built image (once published):
+
+```bash
+docker pull buildkite/buildkite-mcp-server
+```
+
+Or build it yourself using GoReleaser:
+
+```bash
+goreleaser build --snapshot --clean
+```
+
 # configuration
 
 Create a buildkite api token with read access to pipelines.
+
+## Local Installation
 
 ```json
 {
@@ -50,6 +84,35 @@ Create a buildkite api token with read access to pipelines.
 }
 ```
 
+## Docker Configuration
+
+Use this configuration if you want to run the server using Docker:
+
+```json
+{
+    "mcpServers": {
+        "buildkite": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "BUILDKITE_API_TOKEN",
+                "buildkite/buildkite-mcp-server"
+            ],
+            "env": {
+                "BUILDKITE_API_TOKEN": "bkua_xxxxxxxx"
+            }
+        }
+    }
+}
+```
+
+## Goose Configuration
+
+YAML configuration for [Goose](https://block.github.io/goose/):
+
 ```yaml
 extensions:
   fetch:
@@ -62,7 +125,19 @@ extensions:
     timeout: 300
 ```
 
-YAML configuration is required by [Goose](https://block.github.io/goose/).
+For Docker with Goose:
+
+```yaml
+extensions:
+  fetch:
+    name: Buildkite
+    cmd: docker
+    args: ["run", "-i", "--rm", "-e", "BUILDKITE_API_TOKEN", "buildkite/buildkite-mcp-server"]
+    enabled: true
+    envs: { "BUILDKITE_API_TOKEN": "bkua_xxxxxxxx" }
+    type: stdio
+    timeout: 300
+```
 
 
 ## Disclaimer


### PR DESCRIPTION
## Changes

- allows user to run server via docker
    - no longer need to  build to use
- updated README
- added `dockers` to `.goreleaser.yaml`
- included a `.local` Dockerfile for testing

## Testing

```sh
docker build -t buildkite/buildkite-mcp-server:dev -f Dockerfile.local .
```

Set your config:

```json
{
  "mcpServers": {
    "buildkite": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "-e",
        "BUILDKITE_API_TOKEN",
        "buildkite/buildkite-mcp-server:dev"
      ],
      "env": {
        "BUILDKITE_API_TOKEN": "bkua_xxxxxxxxxxxxx"
      }
    }
  }
}
```

Re-launch Claude Desktop and you'll see that the `buildkite` MCP server is still available
