### PR TITLE
reduce default builds to 1

### DIFF
--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -36,7 +36,7 @@ func optionalPaginationParams(r mcp.CallToolRequest) (buildkite.ListOptions, err
 	if err != nil {
 		return buildkite.ListOptions{}, err
 	}
-	perPage, err := optionalIntParamWithDefault(r, "perPage", 30)
+	perPage, err := optionalIntParamWithDefault(r, "perPage", 1)
 	if err != nil {
 		return buildkite.ListOptions{}, err
 	}

--- a/internal/buildkite/buildkite_test.go
+++ b/internal/buildkite/buildkite_test.go
@@ -41,11 +41,11 @@ func Test_optionalPaginationParams(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "missing pagination parameters should use defaults",
+			name: "missing pagination parameters should use new defaults (1 per page)",
 			args: map[string]any{},
 			expected: buildkite.ListOptions{
 				Page:    1,
-				PerPage: 30,
+				PerPage: 1,
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION
## Why?

Currently, we set `30` builds as the default number that we look up when looking at a pipeline, however we could argue that unless specified, the most recent build is the only relevant one. If a user wants to more about their builds, they can ask something like _looking at the previous 5 builds..._.

The current default can mean that this MCP is reduced in value when we consider context length limits (tokens); 30 builds with just 8 steps each can easily blow out the context limits and cause a `400` response.

Given folks will be likely using this server in an IDE now that such a thing is supported, returning `400` responses during what is likely a debugging task is undesirable.
