### PR TITLE
Add Support to specify the base URL and HTTP Headers in the MCP server

### DIFF
--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -17,6 +17,7 @@ var (
 	cli struct {
 		Stdio    commands.StdioCmd `cmd:"" help:"stdio mcp server."`
 		APIToken string            `help:"The Buildkite API token to use." env:"BUILDKITE_API_TOKEN"`
+		BaseURL  string            `help:"The base URL of the Buildkite API to use." env:"BUILDKITE_BASE_URL"`
 		Debug    bool              `help:"Enable debug mode."`
 		Version  kong.VersionFlag
 	}
@@ -53,6 +54,7 @@ func main() {
 		buildkite.WithTokenAuth(cli.APIToken),
 		buildkite.WithUserAgent(commands.UserAgent(version)),
 		buildkite.WithHTTPClient(trace.NewHTTPClient()),
+		buildkite.WithBaseURL(cli.BaseURL),
 	)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to create buildkite client")


### PR DESCRIPTION
At present the base url is fixed to api.buildkite.com , adding the option to specify different base URL along side with additional HTTP Headers ( useful cases like the api access is behind a proxy ) . 

**Test Plan :** Tested with a local build of the mcp server 