### PR TITLE
feat: add read only access to clusters and cluster queues

### DIFF
--- a/internal/buildkite/cluster_queue.go
+++ b/internal/buildkite/cluster_queue.go
@@ -1,0 +1,143 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/buildkite-mcp-server/internal/trace"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type ClusterQueuesClient interface {
+	List(ctx context.Context, org, clusterID string, opts *buildkite.ClusterQueuesListOptions) ([]buildkite.ClusterQueue, *buildkite.Response, error)
+	Get(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error)
+}
+
+func ListClusterQueues(ctx context.Context, client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("list_cluster_queues",
+			mcp.WithDescription("List all buildkite queues in a cluster"),
+			mcp.WithString("org",
+				mcp.Required(),
+				mcp.Description("The organization slug for the owner of the pipeline"),
+			),
+			mcp.WithString("cluster_id",
+				mcp.Required(),
+				mcp.Description("The id of the cluster"),
+			),
+			withPagination(),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        "List Cluster Queues",
+				ReadOnlyHint: mcp.ToBoolPtr(true),
+			}),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListClusterQueues")
+			defer span.End()
+
+			org, err := request.RequireString("org")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			clusterID, err := request.RequireString("cluster_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			paginationParams, err := optionalPaginationParams(request)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			span.SetAttributes(
+				attribute.String("org", org),
+				attribute.String("cluster_id", clusterID),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+			)
+
+			queues, resp, err := client.List(ctx, org, clusterID, &buildkite.ClusterQueuesListOptions{
+				ListOptions: paginationParams,
+			})
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if resp.StatusCode != 200 {
+				return mcp.NewToolResultError("Failed to list clusters"), nil
+			}
+			if len(queues) == 0 {
+				return mcp.NewToolResultText("No clusters found"), nil
+			}
+
+			r, err := json.Marshal(queues)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal cluster queues response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
+func GetClusterQueue(ctx context.Context, client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_cluster_queue",
+			mcp.WithDescription("Get details of a buildkite cluster queue in an organization"),
+			mcp.WithString("org",
+				mcp.Required(),
+				mcp.Description("The organization slug for the owner of the pipeline"),
+			),
+			mcp.WithString("cluster_id",
+				mcp.Required(),
+				mcp.Description("The id of the cluster"),
+			),
+			mcp.WithString("queue_id",
+				mcp.Required(),
+				mcp.Description("The id of the queue"),
+			),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        "Get Cluster Queue",
+				ReadOnlyHint: mcp.ToBoolPtr(true),
+			}),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetClusterQueue")
+			defer span.End()
+
+			org, err := request.RequireString("org")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			clusterID, err := request.RequireString("cluster_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			queueID, err := request.RequireString("queue_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			span.SetAttributes(
+				attribute.String("org", org),
+				attribute.String("cluster_id", clusterID),
+				attribute.String("queue_id", queueID),
+			)
+
+			queue, resp, err := client.Get(ctx, org, clusterID, queueID)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if resp.StatusCode != 200 {
+				return mcp.NewToolResultError("Failed to list clusters"), nil
+			}
+
+			r, err := json.Marshal(queue)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal cluster queue response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/internal/buildkite/cluster_queue_test.go
+++ b/internal/buildkite/cluster_queue_test.go
@@ -1,0 +1,95 @@
+package buildkite
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClusterQueuesClient struct {
+	ListFunc func(ctx context.Context, org, clusterID string, opts *buildkite.ClusterQueuesListOptions) ([]buildkite.ClusterQueue, *buildkite.Response, error)
+	GetFunc  func(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error)
+}
+
+func (m *mockClusterQueuesClient) List(ctx context.Context, org, clusterID string, opts *buildkite.ClusterQueuesListOptions) ([]buildkite.ClusterQueue, *buildkite.Response, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx, org, clusterID, opts)
+	}
+	return nil, nil, nil
+}
+func (m *mockClusterQueuesClient) Get(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, org, clusterID, queueID)
+	}
+	return buildkite.ClusterQueue{}, nil, nil
+}
+
+var _ ClusterQueuesClient = (*mockClusterQueuesClient)(nil)
+
+func TestListClusterQueues(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := context.Background()
+	client := &mockClusterQueuesClient{
+		ListFunc: func(ctx context.Context, org, clusterID string, opts *buildkite.ClusterQueuesListOptions) ([]buildkite.ClusterQueue, *buildkite.Response, error) {
+			return []buildkite.ClusterQueue{
+					{
+						ID: "queue-id",
+					},
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+					},
+				}, nil
+		},
+	}
+
+	tool, handler := ListClusterQueues(ctx, client)
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+
+	request := createMCPRequest(t, map[string]any{
+		"org":        "org",
+		"cluster_id": "cluster-id",
+	})
+	result, err := handler(ctx, request)
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.Equal("[{\"id\":\"queue-id\",\"created_by\":{}}]", textContent.Text)
+}
+
+func TestGetClusterQueue(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := context.Background()
+	client := &mockClusterQueuesClient{
+		GetFunc: func(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error) {
+			return buildkite.ClusterQueue{
+					ID: "queue-id",
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+					},
+				}, nil
+		},
+	}
+
+	tool, handler := GetClusterQueue(ctx, client)
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+
+	request := createMCPRequest(t, map[string]any{
+		"org":        "org",
+		"cluster_id": "cluster-id",
+		"queue_id":   "queue-id",
+	})
+	result, err := handler(ctx, request)
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.Equal("{\"id\":\"queue-id\",\"created_by\":{}}", textContent.Text)
+}

--- a/internal/buildkite/clusters.go
+++ b/internal/buildkite/clusters.go
@@ -1,0 +1,122 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/buildkite/buildkite-mcp-server/internal/trace"
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type ClustersClient interface {
+	List(ctx context.Context, org string, opts *buildkite.ClustersListOptions) ([]buildkite.Cluster, *buildkite.Response, error)
+	Get(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error)
+}
+
+func ListClusters(ctx context.Context, client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("list_clusters",
+			mcp.WithDescription("List all buildkite clusters in an organization"),
+			mcp.WithString("org",
+				mcp.Required(),
+				mcp.Description("The organization slug for the owner of the pipeline"),
+			),
+			withPagination(),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        "List Clusters",
+				ReadOnlyHint: mcp.ToBoolPtr(true),
+			}),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListClusters")
+			defer span.End()
+
+			org, err := request.RequireString("org")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			paginationParams, err := optionalPaginationParams(request)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			span.SetAttributes(
+				attribute.String("org", org),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+			)
+
+			clusters, resp, err := client.List(ctx, org, &buildkite.ClustersListOptions{
+				ListOptions: paginationParams,
+			})
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if resp.StatusCode != 200 {
+				return mcp.NewToolResultError("Failed to list clusters"), nil
+			}
+			if len(clusters) == 0 {
+				return mcp.NewToolResultText("No clusters found"), nil
+			}
+
+			r, err := json.Marshal(clusters)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal clusters response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
+func GetCluster(ctx context.Context, client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool("get_cluster",
+			mcp.WithDescription("Get details of a buildkite cluster in an organization"),
+			mcp.WithString("org",
+				mcp.Required(),
+				mcp.Description("The organization slug for the owner of the pipeline"),
+			),
+			mcp.WithString("cluster_id",
+				mcp.Required(),
+				mcp.Description("The id of the cluster"),
+			),
+			mcp.WithToolAnnotation(mcp.ToolAnnotation{
+				Title:        "Get Cluster",
+				ReadOnlyHint: mcp.ToBoolPtr(true),
+			}),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetCluster")
+			defer span.End()
+
+			org, err := request.RequireString("org")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			clusterID, err := request.RequireString("cluster_id")
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			span.SetAttributes(
+				attribute.String("org", org),
+				attribute.String("cluster_id", clusterID),
+			)
+
+			cluster, resp, err := client.Get(ctx, org, clusterID)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+
+			if resp.StatusCode != 200 {
+				return mcp.NewToolResultError("Failed to get cluster"), nil
+			}
+
+			r, err := json.Marshal(cluster)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal cluster response: %w", err)
+			}
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/internal/buildkite/clusters_test.go
+++ b/internal/buildkite/clusters_test.go
@@ -1,0 +1,95 @@
+package buildkite
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v4"
+	"github.com/stretchr/testify/require"
+)
+
+var _ ClustersClient = (*mockClustersClient)(nil)
+
+type mockClustersClient struct {
+	ListFunc func(ctx context.Context, org string, opts *buildkite.ClustersListOptions) ([]buildkite.Cluster, *buildkite.Response, error)
+	GetFunc  func(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error)
+}
+
+func (m *mockClustersClient) List(ctx context.Context, org string, opts *buildkite.ClustersListOptions) ([]buildkite.Cluster, *buildkite.Response, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx, org, opts)
+	}
+	return nil, nil, nil
+}
+func (m *mockClustersClient) Get(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, org, id)
+	}
+	return buildkite.Cluster{}, nil, nil
+}
+
+func TestListClusters(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := context.Background()
+	client := &mockClustersClient{
+		ListFunc: func(ctx context.Context, org string, opts *buildkite.ClustersListOptions) ([]buildkite.Cluster, *buildkite.Response, error) {
+			return []buildkite.Cluster{
+					{
+						ID:   "cluster-id",
+						Name: "cluster-name",
+					},
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+					},
+				}, nil
+		},
+	}
+
+	tool, handler := ListClusters(ctx, client)
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+
+	request := createMCPRequest(t, map[string]any{
+		"org": "org",
+	})
+	result, err := handler(ctx, request)
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.Equal("[{\"id\":\"cluster-id\",\"name\":\"cluster-name\",\"created_by\":{}}]", textContent.Text)
+}
+
+func TestGetCluster(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := context.Background()
+	client := &mockClustersClient{
+		GetFunc: func(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error) {
+			return buildkite.Cluster{
+					ID:   "cluster-id",
+					Name: "cluster-name",
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+					},
+				}, nil
+		},
+	}
+
+	tool, handler := GetCluster(ctx, client)
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+
+	request := createMCPRequest(t, map[string]any{
+		"org":        "org",
+		"cluster_id": "cluster-id",
+	})
+	result, err := handler(ctx, request)
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.Equal("{\"id\":\"cluster-id\",\"name\":\"cluster-name\",\"created_by\":{}}", textContent.Text)
+}

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -27,6 +27,12 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 
 	log.Ctx(ctx).Info().Str("version", globals.Version).Msg("Starting Buildkite MCP server")
 
+	s.AddTool(buildkite.GetCluster(ctx, globals.Client.Clusters))
+	s.AddTool(buildkite.ListClusters(ctx, globals.Client.Clusters))
+
+	s.AddTool(buildkite.GetClusterQueue(ctx, globals.Client.ClusterQueues))
+	s.AddTool(buildkite.ListClusterQueues(ctx, globals.Client.ClusterQueues))
+
 	s.AddTool(buildkite.GetPipeline(ctx, globals.Client.Pipelines))
 	s.AddTool(buildkite.ListPipelines(ctx, globals.Client.Pipelines))
 


### PR DESCRIPTION
As per #34 we need to list clusters so we can associate a queue to the pipeline at creation.