### PR TITLE
feat: add the link header to list results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/buildkite/buildkite-mcp-server
 go 1.24.2
 
 require (
-	github.com/alecthomas/kong v1.10.0
+	github.com/alecthomas/kong v1.11.0
 	github.com/buildkite/go-buildkite/v4 v4.1.0
 	github.com/buildkite/terminal-to-html/v3 v3.16.8
 	github.com/huantt/plaintext-extractor v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.10.0 h1:8K4rGDpT7Iu+jEXCIJUeKqvpwZHbsFRoebLbnzlmrpw=
-github.com/alecthomas/kong v1.10.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
+github.com/alecthomas/kong v1.11.0 h1:y++1gI7jf8O7G7l4LZo5ASFhrhJvzc+WgF/arranEmM=
+github.com/alecthomas/kong v1.11.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/buildkite/go-buildkite/v4 v4.1.0 h1:n1f3EAe8/64ju9QjSWJYMjD8++mn1pOLK/tZscD5DKo=

--- a/internal/buildkite/artifacts.go
+++ b/internal/buildkite/artifacts.go
@@ -107,7 +107,14 @@ func ListArtifacts(ctx context.Context, client ArtifactsClient) (tool mcp.Tool, 
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get issue: %s", string(body))), nil
 			}
 
-			r, err := json.Marshal(artifacts)
+			result := PaginatedResult[buildkite.Artifact]{
+				Items: artifacts,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			r, err := json.Marshal(result)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal artifacts: %w", err)
 			}

--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -5,6 +5,11 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+type PaginatedResult[T any] struct {
+	Headers map[string]string `json:"headers"`
+	Items   []T               `json:"items"`
+}
+
 func optionalPaginationParams(r mcp.CallToolRequest) (buildkite.ListOptions, error) {
 	page := r.GetInt("page", 1)
 	perPage := r.GetInt("perPage", 1)

--- a/internal/buildkite/builds.go
+++ b/internal/buildkite/builds.go
@@ -77,7 +77,14 @@ func ListBuilds(ctx context.Context, client BuildsClient) (tool mcp.Tool, handle
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get issue: %s", string(body))), nil
 			}
 
-			r, err := json.Marshal(&builds)
+			result := PaginatedResult[buildkite.Build]{
+				Items: builds,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			r, err := json.Marshal(&result)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal builds: %w", err)
 			}

--- a/internal/buildkite/builds_test.go
+++ b/internal/buildkite/builds_test.go
@@ -102,8 +102,8 @@ func TestListBuilds(t *testing.T) {
 
 	textContent := getTextResult(t, result)
 
-	assert.Equal(`[{"id":"123","number":1,"state":"running","author":{},"created_at":"0001-01-01T00:00:00Z","creator":{"avatar_url":"","created_at":null,"email":"","id":"","name":""}}]`, textContent.Text)
-	
+	assert.Equal(`{"headers":{"Link":""},"items":[{"id":"123","number":1,"state":"running","author":{},"created_at":"0001-01-01T00:00:00Z","creator":{"avatar_url":"","created_at":null,"email":"","id":"","name":""}}]}`, textContent.Text)
+
 	// Verify default pagination parameters - ensure they are set to 1 per page
 	assert.NotNil(capturedOptions)
 	assert.Equal(1, capturedOptions.Page)

--- a/internal/buildkite/cluster_queue.go
+++ b/internal/buildkite/cluster_queue.go
@@ -72,7 +72,14 @@ func ListClusterQueues(ctx context.Context, client ClusterQueuesClient) (tool mc
 				return mcp.NewToolResultText("No clusters found"), nil
 			}
 
-			r, err := json.Marshal(queues)
+			result := PaginatedResult[buildkite.ClusterQueue]{
+				Items: queues,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			r, err := json.Marshal(&result)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal cluster queues response: %w", err)
 			}

--- a/internal/buildkite/cluster_queue_test.go
+++ b/internal/buildkite/cluster_queue_test.go
@@ -59,7 +59,7 @@ func TestListClusterQueues(t *testing.T) {
 	assert.NoError(err)
 
 	textContent := getTextResult(t, result)
-	assert.Equal("[{\"id\":\"queue-id\",\"created_by\":{}}]", textContent.Text)
+	assert.Equal(`{"headers":{"Link":""},"items":[{"id":"queue-id","created_by":{}}]}`, textContent.Text)
 }
 
 func TestGetClusterQueue(t *testing.T) {

--- a/internal/buildkite/clusters.go
+++ b/internal/buildkite/clusters.go
@@ -62,7 +62,14 @@ func ListClusters(ctx context.Context, client ClustersClient) (tool mcp.Tool, ha
 				return mcp.NewToolResultText("No clusters found"), nil
 			}
 
-			r, err := json.Marshal(clusters)
+			result := PaginatedResult[buildkite.Cluster]{
+				Items: clusters,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			r, err := json.Marshal(&result)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal clusters response: %w", err)
 			}

--- a/internal/buildkite/clusters_test.go
+++ b/internal/buildkite/clusters_test.go
@@ -59,7 +59,7 @@ func TestListClusters(t *testing.T) {
 	assert.NoError(err)
 
 	textContent := getTextResult(t, result)
-	assert.Equal("[{\"id\":\"cluster-id\",\"name\":\"cluster-name\",\"created_by\":{}}]", textContent.Text)
+	assert.Equal(`{"headers":{"Link":""},"items":[{"id":"cluster-id","name":"cluster-name","created_by":{}}]}`, textContent.Text)
 }
 
 func TestGetCluster(t *testing.T) {

--- a/internal/buildkite/pipelines.go
+++ b/internal/buildkite/pipelines.go
@@ -66,7 +66,14 @@ func ListPipelines(ctx context.Context, client PipelinesClient) (tool mcp.Tool, 
 				return mcp.NewToolResultError(fmt.Sprintf("failed to get issue: %s", string(body))), nil
 			}
 
-			r, err := json.Marshal(&pipelines)
+			result := PaginatedResult[buildkite.Pipeline]{
+				Items: pipelines,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			r, err := json.Marshal(&result)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal pipelines: %w", err)
 			}

--- a/internal/buildkite/pipelines_test.go
+++ b/internal/buildkite/pipelines_test.go
@@ -63,7 +63,7 @@ func TestListPipelines(t *testing.T) {
 
 	textContent := getTextResult(t, result)
 
-	assert.Equal(`[{"id":"123","name":"Test Pipeline","slug":"test-pipeline","created_at":"0001-01-01T00:00:00Z","provider":{"id":"","webhook_url":"","settings":null}}]`, textContent.Text)
+	assert.Equal(`{"headers":{"Link":""},"items":[{"id":"123","name":"Test Pipeline","slug":"test-pipeline","created_at":"0001-01-01T00:00:00Z","provider":{"id":"","webhook_url":"","settings":null}}]}`, textContent.Text)
 }
 
 func TestGetPipeline(t *testing.T) {


### PR DESCRIPTION
I noticed that when i queried claude desktop about the state of my pipelines it would only list one, then summarise the results. 

To overcome this I added the `Link` header to all list results which contains the next, last page URLs and now it correctly collects all pipelines and summarises them.

There is scope to add other headers where needed in the future as well.

Also bumped the flags package. 