### PR TITLE
refactor: move the headers parser out to the command package

### DIFF
--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/buildkite/buildkite-mcp-server/internal/commands"
@@ -25,22 +24,6 @@ var (
 		Version     kong.VersionFlag
 	}
 )
-
-func parseHeaders(headerStrings []string, logger zerolog.Logger) map[string]string {
-	headers := make(map[string]string)
-	for _, h := range headerStrings {
-		parts := strings.SplitN(h, ":", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			headers[key] = value
-			logger.Debug().Str("key", key).Str("value", value).Msg("parsed header")
-		} else {
-			logger.Warn().Str("header", h).Msg("invalid header format, expected 'Key: Value'")
-		}
-	}
-	return headers
-}
 
 func main() {
 	ctx := context.Background()
@@ -70,7 +53,7 @@ func main() {
 	}()
 
 	// Parse additional headers into a map
-	headers := parseHeaders(cli.HTTPHeaders, logger)
+	headers := commands.ParseHeaders(cli.HTTPHeaders, logger)
 
 	client, err := buildkite.NewOpts(
 		buildkite.WithTokenAuth(cli.APIToken),

--- a/internal/commands/headers.go
+++ b/internal/commands/headers.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// ParseHeaders takes a slice of header strings in the format "Key: Value"
+// and returns a map of headers. This is used to parse additional HTTP headers
+// that can be sent with every request to the Buildkite API.
+func ParseHeaders(headerStrings []string, logger zerolog.Logger) map[string]string {
+	headers := make(map[string]string)
+	for _, h := range headerStrings {
+		parts := strings.SplitN(h, ":", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.TrimSpace(parts[1])
+			headers[key] = value
+			logger.Debug().Str("key", key).Str("value", value).Msg("parsed header")
+		} else {
+			logger.Warn().Str("header", h).Msg("invalid header format, expected 'Key: Value'")
+		}
+	}
+	return headers
+}

--- a/internal/commands/headers_test.go
+++ b/internal/commands/headers_test.go
@@ -1,14 +1,15 @@
-package main
+package commands
 
 import (
 	"testing"
+
 	"github.com/rs/zerolog"
 )
 
 func TestParseHeaders(t *testing.T) {
 	tests := []struct {
-		input    []string
-		want     map[string]string
+		input []string
+		want  map[string]string
 	}{
 		{[]string{"Authorization: Bearer token"}, map[string]string{"Authorization": "Bearer token"}},
 		{[]string{"Authorization: Bearer to.ke.n"}, map[string]string{"Authorization": "Bearer to.ke.n"}},
@@ -24,7 +25,7 @@ func TestParseHeaders(t *testing.T) {
 	logger := zerolog.Nop()
 
 	for _, tt := range tests {
-		got := parseHeaders(tt.input, logger)
+		got := ParseHeaders(tt.input, logger)
 		if len(got) != len(tt.want) {
 			t.Errorf("parseHeaders(%v) = %v, want %v", tt.input, got, tt.want)
 			continue


### PR DESCRIPTION
Just moving things around to keep the main package as lean as possible.
