### PR TITLE
chore: enable gosec for security checking and gocritic for go conventions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,13 @@
 version: "2"
 linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+    - gocritic
   exclusions:
     generated: lax
     presets:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For full functionality with all available tools, your API token needs these scop
 - **read_artifacts** - Access build artifacts and metadata
 - **read_suites** - Access Test Engine data (if using Test Engine)
 
-Create a buildkite API token with the required scopes at: [https://buildkite.com/user/api-access-tokens/new](https://buildkite.com/user/api-access-tokens/new?scopes[]=read_clusters&scopes[]=read_pipelines&scopes[]=read_builds&scopes[]=read_build_logs&scopes[]=read_user&scopes[]=read_organizations&scopes[]=read_artifacts&scopes[]=read_suites)
+Create a buildkite API token with [Full functionality](https://buildkite.com/user/api-access-tokens/new?scopes[]=read_clusters&scopes[]=read_pipelines&scopes[]=read_builds&scopes[]=read_build_logs&scopes[]=read_user&scopes[]=read_organizations&scopes[]=read_artifacts&scopes[]=read_suites)
 
 ### Minimum Recommended Scopes
 

--- a/cmd/update-docs/main.go
+++ b/cmd/update-docs/main.go
@@ -66,7 +66,7 @@ func updateReadme(toolsDocs string) {
 	newContent := re.ReplaceAllString(contentStr, toolsDocs+toolsSectionEnd)
 
 	// Write the updated README
-	err = os.WriteFile(readmePath, []byte(newContent), 0644)
+	err = os.WriteFile(readmePath, []byte(newContent), 0600)
 	if err != nil {
 		log.Fatalf("Error writing README: %v", err)
 	}

--- a/internal/buildkite/joblogs/process_test.go
+++ b/internal/buildkite/joblogs/process_test.go
@@ -23,7 +23,7 @@ func TestProcess(t *testing.T) {
 
 	// write out golden file if WRITE_JOB_LOG_GOLDEN_FILE is set
 	if os.Getenv("WRITE_JOB_LOG_GOLDEN_FILE") != "" {
-		err = os.WriteFile("testdata/processed.log", []byte(processedLog), 0644)
+		err = os.WriteFile("testdata/processed.log", []byte(processedLog), 0600)
 		if err != nil {
 			t.Fatalf("failed to write processed log golden file: %v", err)
 		}

--- a/internal/tokens/tokens.go
+++ b/internal/tokens/tokens.go
@@ -1,6 +1,8 @@
 package tokens
 
-import "strings"
+import (
+	"strings"
+)
 
 // EstimateTokens returns an estimate of the number of tokens in the given text.
 func EstimateTokens(text string) int {
@@ -10,11 +12,13 @@ func EstimateTokens(text string) int {
 	for _, word := range words {
 		// Simple heuristic: longer words typically split into more tokens
 		wordLen := len([]rune(word))
-		if wordLen <= 4 {
+		switch {
+		case wordLen <= 4:
 			tokenCount += 1
-		} else if wordLen <= 8 {
+		case wordLen <= 8:
 			tokenCount += 2
-		} else {
+		default:
+			// For longer words, assume 1 token per 4 characters, rounded up
 			tokenCount += (wordLen + 3) / 4
 		}
 	}

--- a/internal/tokens/tokens_test.go
+++ b/internal/tokens/tokens_test.go
@@ -1,0 +1,58 @@
+package tokens
+
+import (
+	"testing"
+)
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "single short word",
+			input:    "test",
+			expected: 1,
+		},
+		{
+			name:     "multiple short words",
+			input:    "this is a test",
+			expected: 4,
+		},
+		{
+			name:     "medium length words",
+			input:    "medium length",
+			expected: 4, // "medium" (6 chars) = 2, "length" (6 chars) = 2
+		},
+		{
+			name:     "long words",
+			input:    "internationalization standardization",
+			expected: 9, // "internationalization" (20 chars) = 5, "standardization" (14 chars) = 4
+		},
+		{
+			name:     "mixed length words",
+			input:    "this is a complicated test with internationalization",
+			expected: 13, // 1+1+1+3+1+1+5 = 13
+		},
+		{
+			name:     "multiple spaces",
+			input:    "this   is  a   test",
+			expected: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EstimateTokens(tt.input)
+			if result != tt.expected {
+				t.Errorf("EstimateTokens(%q) = %d, expected %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Just ensuring we have the standard linting in place for production.
