### PR TITLE
feat: Rework get_job_logs to handle very large logfiles

### DIFF
--- a/internal/buildkite/jobs.go
+++ b/internal/buildkite/jobs.go
@@ -6,6 +6,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/buildkite/buildkite-mcp-server/internal/buildkite/joblogs"
 	"github.com/buildkite/buildkite-mcp-server/internal/tokens"
@@ -14,6 +20,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // withJobsPagination adds client-side pagination options to a tool with a max of 50 per page
@@ -145,7 +152,7 @@ func GetJobs(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler s
 
 func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_job_logs",
-			mcp.WithDescription("Get the log output and metadata for a specific job, including content, size, and header timestamps"),
+			mcp.WithDescription("Get the log output and metadata for a specific job, including content, size, and header timestamps. Automatically saves to file for large logs to avoid token limits."),
 			mcp.WithString("org",
 				mcp.Required(),
 				mcp.Description("The organization slug for the owner of the pipeline"),
@@ -162,9 +169,15 @@ func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, h
 				mcp.Required(),
 				mcp.Description("The UUID of the job"),
 			),
+			mcp.WithString("output_dir",
+				mcp.Description("Directory to save log file when using file mode (defaults to system temp directory)"),
+			),
+			mcp.WithString("filename_prefix",
+				mcp.Description("Prefix for log filename when using file mode (defaults to job UUID)"),
+			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
 				Title:        "Get Job Logs",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				ReadOnlyHint: mcp.ToBoolPtr(false),
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -191,13 +204,19 @@ func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, h
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 
+			outputDir := request.GetString("output_dir", "")
+			filenamePrefix := request.GetString("filename_prefix", jobUUID)
+
 			span.SetAttributes(
 				attribute.String("org", org),
 				attribute.String("pipeline_slug", pipelineSlug),
 				attribute.String("build_number", buildNumber),
 				attribute.String("job_uuid", jobUUID),
+				attribute.String("output_dir", outputDir),
+				attribute.String("filename_prefix", filenamePrefix),
 			)
 
+			// Get job logs from API
 			joblog, resp, err := client.Jobs.GetJobLog(ctx, org, pipelineSlug, buildNumber, jobUUID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
@@ -208,7 +227,7 @@ func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, h
 				if err != nil {
 					return nil, fmt.Errorf("failed to read response body: %w", err)
 				}
-				return mcp.NewToolResultError(fmt.Sprintf("failed to get issue: %s", string(body))), nil
+				return mcp.NewToolResultError(fmt.Sprintf("failed to get job logs: %s", string(body))), nil
 			}
 
 			// the default logs that come from the API can be pretty dense with ANSI codes or HTML
@@ -218,10 +237,194 @@ func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, h
 				return nil, fmt.Errorf("failed to process job log: %w", err)
 			}
 
-			tokens := tokens.EstimateTokens(processedLog)
+			// Estimate tokens to decide delivery mode
+			tokenCount := tokens.EstimateTokens(processedLog)
+			threshold := getTokenThreshold()
 
-			span.SetAttributes(attribute.Int("tokens", tokens))
+			span.SetAttributes(
+				attribute.Int("token_count", tokenCount),
+				attribute.Int("token_threshold", threshold),
+			)
 
-			return mcp.NewToolResultText(processedLog), nil
+			// Smart switching: use file mode for large logs
+			if tokenCount > threshold {
+				return handleLargeLogFile(ctx, span, processedLog, tokenCount, org, pipelineSlug, buildNumber, jobUUID, outputDir, filenamePrefix, threshold)
+			}
+
+			// Inline mode for small logs
+			span.SetAttributes(attribute.String("delivery_mode", "inline"))
+
+			response := JobLogsResponse{
+				DeliveryMode: "inline",
+				Content:      processedLog,
+				TokenCount:   tokenCount,
+				JobUUID:      jobUUID,
+				BuildNumber:  buildNumber,
+			}
+
+			r, err := json.Marshal(&response)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal response: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
 		}
+}
+
+// sanitizeFilename removes unsafe characters from filename components
+var unsafeChars = regexp.MustCompile(`[^\w\-_.]`)
+
+func sanitizeFilename(name string) string {
+	return unsafeChars.ReplaceAllString(name, "_")
+}
+
+// JobLogsResponse represents the unified response for job logs
+type JobLogsResponse struct {
+	DeliveryMode    string `json:"delivery_mode"`              // "inline" | "file"
+	Content         string `json:"content,omitempty"`          // Only for inline
+	FilePath        string `json:"file_path,omitempty"`        // Only for file
+	FileSizeBytes   int64  `json:"file_size_bytes,omitempty"`  // Only for file
+	TokenCount      int    `json:"token_count"`                // Always included
+	JobUUID         string `json:"job_uuid"`                   // Always included
+	BuildNumber     string `json:"build_number"`               // Always included
+	Reason          string `json:"reason,omitempty"`           // Why file mode was chosen
+}
+
+// getTokenThreshold returns the configurable token threshold for switching to file mode
+func getTokenThreshold() int {
+	if thresholdStr := os.Getenv("BUILDKITE_MCP_LOG_TOKEN_THRESHOLD"); thresholdStr != "" {
+		if threshold, err := strconv.Atoi(thresholdStr); err == nil && threshold > 0 {
+			return threshold
+		}
+	}
+	return 12000 // Default threshold
+}
+
+// handleLargeLogFile handles saving large logs to file
+func handleLargeLogFile(ctx context.Context, span oteltrace.Span, processedLog string, tokenCount int, org, pipelineSlug, buildNumber, jobUUID, outputDir, filenamePrefix string, threshold int) (*mcp.CallToolResult, error) {
+	span.SetAttributes(attribute.String("delivery_mode", "file"))
+
+	// Determine output directory
+	if outputDir == "" {
+		outputDir = os.TempDir()
+	} else {
+		// Clean and validate the path
+		outputDir = filepath.Clean(outputDir)
+		if strings.Contains(outputDir, "..") {
+			return mcp.NewToolResultError("invalid output directory: path traversal not allowed"), nil
+		}
+	}
+
+	// Verify directory exists and is writable, fallback to inline if file operations fail
+	if info, err := os.Stat(outputDir); err != nil {
+		// Fallback to inline mode on directory error
+		response := JobLogsResponse{
+			DeliveryMode: "inline",
+			Content:      processedLog,
+			TokenCount:   tokenCount,
+			JobUUID:      jobUUID,
+			BuildNumber:  buildNumber,
+			Reason:       fmt.Sprintf("Intended file mode due to %d tokens > %d threshold, but fell back to inline due to directory error: %s", tokenCount, threshold, err.Error()),
+		}
+		r, err := json.Marshal(&response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal fallback response: %w", err)
+		}
+		return mcp.NewToolResultText(string(r)), nil
+	} else if !info.IsDir() {
+		// Fallback to inline mode if path is not a directory
+		response := JobLogsResponse{
+			DeliveryMode: "inline",
+			Content:      processedLog,
+			TokenCount:   tokenCount,
+			JobUUID:      jobUUID,
+			BuildNumber:  buildNumber,
+			Reason:       fmt.Sprintf("Intended file mode due to %d tokens > %d threshold, but fell back to inline because output path is not a directory", tokenCount, threshold),
+		}
+		r, err := json.Marshal(&response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal fallback response: %w", err)
+		}
+		return mcp.NewToolResultText(string(r)), nil
+	}
+
+	// Generate safe filename
+	timestamp := time.Now().Unix()
+	sanitizedPrefix := sanitizeFilename(filenamePrefix)
+	sanitizedBuildNumber := sanitizeFilename(buildNumber)
+	filename := fmt.Sprintf("%s_%s_%s_%d.log", sanitizedPrefix, sanitizedBuildNumber, jobUUID, timestamp)
+	filePath := filepath.Join(outputDir, filename)
+
+	// Create and write file
+	file, err := os.Create(filePath)
+	if err != nil {
+		// Fallback to inline mode on file creation error
+		response := JobLogsResponse{
+			DeliveryMode: "inline",
+			Content:      processedLog,
+			TokenCount:   tokenCount,
+			JobUUID:      jobUUID,
+			BuildNumber:  buildNumber,
+			Reason:       fmt.Sprintf("Intended file mode due to %d tokens > %d threshold, but fell back to inline due to file creation error: %s", tokenCount, threshold, err.Error()),
+		}
+		r, err := json.Marshal(&response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal fallback response: %w", err)
+		}
+		return mcp.NewToolResultText(string(r)), nil
+	}
+	defer file.Close()
+
+	_, err = file.WriteString(processedLog)
+	if err != nil {
+		// Clean up partial file and fallback to inline
+		os.Remove(filePath)
+		response := JobLogsResponse{
+			DeliveryMode: "inline",
+			Content:      processedLog,
+			TokenCount:   tokenCount,
+			JobUUID:      jobUUID,
+			BuildNumber:  buildNumber,
+			Reason:       fmt.Sprintf("Intended file mode due to %d tokens > %d threshold, but fell back to inline due to file write error: %s", tokenCount, threshold, err.Error()),
+		}
+		r, err := json.Marshal(&response)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal fallback response: %w", err)
+		}
+		return mcp.NewToolResultText(string(r)), nil
+	}
+
+	// Get file info
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get file info: %s", err.Error())), nil
+	}
+
+	// Get absolute path for response
+	absPath, err := filepath.Abs(filePath)
+	if err != nil {
+		absPath = filePath // fallback to relative path
+	}
+
+	span.SetAttributes(
+		attribute.String("file_path", absPath),
+		attribute.Int64("file_size_bytes", fileInfo.Size()),
+	)
+
+	response := JobLogsResponse{
+		DeliveryMode:  "file",
+		FilePath:      absPath,
+		FileSizeBytes: fileInfo.Size(),
+		TokenCount:    tokenCount,
+		JobUUID:       jobUUID,
+		BuildNumber:   buildNumber,
+		Reason:        fmt.Sprintf("Log exceeded %d token threshold", threshold),
+	}
+
+	r, err := json.Marshal(&response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(r)), nil
 }


### PR DESCRIPTION
Our buildkite logfiles are routinely too large to handle directly by returning the log string to the LLM from tool invocation. This changeset reworks that tool to deal with that problem:

- [X] Save logfiles to a temp file if they're "too long" (using token estimate)
- [X] Add an env var to tune that threshold
- [X] Return a little bit of structured json instead of log text directly

I tested it out with a pretty ordinary "the linter in a CI job says I messed up, please find the relevant job from my pr and fix it" prompt with good results on a couple of PRs. The only unfortunate piece of the UX here is that when we persist to a tempfile, LLM tools will typically need to toss up a trust prompt for `/tmp/wherever-mktemp-came-up-with`.

Full disclosure, I don't know go super well, so I did lean on claude-code for some of the details here, so please do let me know if anything needs to change.

I believe this'd also close #26 

Commit 2 adds support for mapping paths through via docker mounts when running in docker, and commit 3 adds tests covering that path mapping behavior.