### PR TITLE
Fix malformed json schema for `create_build` tool's input schema

### DIFF
--- a/internal/buildkite/builds.go
+++ b/internal/buildkite/builds.go
@@ -321,17 +321,16 @@ func CreateBuild(ctx context.Context, client BuildsClient) (tool mcp.Tool, handl
 			mcp.WithArray("environment",
 				mcp.Items(
 					map[string]any{
-						"type": "object",
+						"type":     "object",
+						"required": []string{"key", "value"},
 						"properties": map[string]any{
 							"key": map[string]any{
 								"type":        "string",
 								"description": "The name of the environment variable",
-								"required":    true,
 							},
 							"value": map[string]any{
 								"type":        "string",
 								"description": "The value of the environment variable",
-								"required":    true,
 							},
 						},
 					},
@@ -340,17 +339,16 @@ func CreateBuild(ctx context.Context, client BuildsClient) (tool mcp.Tool, handl
 			mcp.WithArray("metadata",
 				mcp.Items(
 					map[string]any{
-						"type": "object",
+						"type":     "object",
+						"required": []string{"key", "value"},
 						"properties": map[string]any{
 							"key": map[string]any{
 								"type":        "string",
 								"description": "The name of the environment variable",
-								"required":    true,
 							},
 							"value": map[string]any{
 								"type":        "string",
 								"description": "The value of the environment variable",
-								"required":    true,
 							},
 						},
 					},


### PR DESCRIPTION
The `required` properties are at the wrong level on the env/metadata fields.