### PR TITLE
Update otel semconv to v1.34.0

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -94,8 +94,8 @@ func NewHTTPClient() *http.Client {
 func NewHTTPClientWithHeaders(headers map[string]string) *http.Client {
 	return &http.Client{
 		Transport: &headerInjector{
-			headers:   headers,
-			wrapped:   otelhttp.NewTransport(http.DefaultTransport),
+			headers: headers,
+			wrapped: otelhttp.NewTransport(http.DefaultTransport),
 		},
 	}
 }


### PR DESCRIPTION
#77 bumped the otel package, but that caused it to start complaining about a mismatch in the semantic conventions schema.