### PR TITLE
add simple test to ensure that creation of trace provider is valid

### DIFF
--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -1,0 +1,17 @@
+package trace
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewProvider(t *testing.T) {
+	provider, err := NewProvider(context.Background(), "test", "1.2.3")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if provider == nil {
+		t.Fatal("expected non-nil TracerProvider")
+	}
+}


### PR DESCRIPTION
#77 accidentally broke the otel trace provider because of a mismatch on semconv schema
#81 fixed it, but I forgot to push up my test, so here it is!