### PR TITLE
fix: adjusted docker hub login in release script

### DIFF
--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -14,8 +14,8 @@ GORELEASER_KEY=$(buildkite-agent secret get goreleaser_key)
 if [[ -z "${DOCKERHUB_USER:-}" || -z "${DOCKERHUB_PASSWORD:-}" ]]; then
     echo "Skipping Docker login as DOCKERHUB_USER or DOCKERHUB_PASSWORD is not set"
 else
-    echo "--- :key: :docker: Login to Docker"
-    echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USER}" --password-stdin
+    echo "--- :key: :docker: Login to Docker hub using ko"
+    echo "${DOCKERHUB_PASSWORD}" | ko login index.docker.io --username "${DOCKERHUB_USER}" --password-stdin
     if [[ $? -ne 0 ]]; then
         echo "Docker login failed"
         exit 1


### PR DESCRIPTION
We are using ko to do releases so we don't need the docker socket or the docker CLI, just need to use ko correctly :joy:
