### PR TITLE
fix: add GHCR login during release to push images

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -41,6 +41,7 @@ steps:
             - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
+            GITHUB_USER: /pipelines/buildkite/buildkite-mcp-server-release/github-user
             GITHUB_TOKEN: /pipelines/buildkite/buildkite-mcp-server-release/github-token
             DOCKERHUB_PASSWORD: /pipelines/buildkite/buildkite-mcp-server-release/dockerhub-password
             DOCKERHUB_USER: /pipelines/buildkite/buildkite-mcp-server-release/dockerhub-user
@@ -54,6 +55,7 @@ steps:
             - --merge
           config: .buildkite/docker-compose.yaml
           env:
+            - GITHUB_USER
             - GITHUB_TOKEN
             - DOCKERHUB_USER
             - DOCKERHUB_PASSWORD

--- a/.buildkite/release.sh
+++ b/.buildkite/release.sh
@@ -22,6 +22,20 @@ else
     fi
 fi
 
+# check if GITHUB_USER is set
+if [[ -z "${GITHUB_USER:-}" ]]; then
+    echo "Skipping GHCR login as GITHUB_USER is not set"
+else
+    echo "--- :key: :github: Login to GHCR using ko"
+    echo "$GITHUB_TOKEN" | ko login ghcr.io --username "$GITHUB_USER" --password-stdin
+    if [[ $? -ne 0 ]]; then
+        echo "GitHub login failed"
+        exit 1
+    fi
+fi
+
+echo "--- :goreleaser: Building release with GoReleaser"
+
 if [[ $? -ne 0 ]]; then
     echo "Failed to retrieve GoReleaser Pro key"
     exit 1


### PR DESCRIPTION
The ko documentation refers to GITHUB_TOKEN being handled automatically in https://ko.build/get-started/#authenticate but doesn't seem to be so, others are logging in explicity so adding that. https://github.com/MizuchiLabs/mantrae/blob/65bb32e28c897fb68cce0f2d66a378be8f057c14/.woodpecker/build.yaml#L37 