### PR TITLE
Add Homebrew cask configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,9 +41,9 @@ kos:
     build: buildkite-mcp-server
     main: ./cmd/buildkite-mcp-server/
     creation_time: "{{.CommitTimestamp}}"
-    base_image: 'cgr.dev/chainguard/static:latest'
+    base_image: "cgr.dev/chainguard/static:latest"
     tags:
-      - '{{.Version}}'
+      - "{{.Version}}"
       - latest
     labels:
       org.opencontainers.image.authors: Buildkite Inc. https://buildkite.com
@@ -55,7 +55,7 @@ kos:
     bare: true
     preserve_import_paths: false
     # FIXME: We use GOOS and -split in our pipeline which is causing issues with the ko integration
-    # so we disable it here when the GOOS is set to something other than linux. This avoids 
+    # so we disable it here when the GOOS is set to something other than linux. This avoids
     # the ko build to fail when running on macos or windows.
     disable: '{{ and (isEnvSet "GOOS") (ne .Env.GOOS "linux") }}'
     platforms:
@@ -82,6 +82,27 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+# Publish new releases to our homebrew tap:
+# https://github.com/buildkite/homebrew-buildkite
+homebrew_casks:
+  - name: buildkite-mcp-server
+    repository:
+      owner: buildkite
+      name: homebrew-buildkite
+      branch: master
+    homepage: https://github.com/buildkite/buildkite-mcp-server
+    description: "Model Context Protocol server for Buildkite"
+    # We don't notarize our binaries so they fail to run when quarantined, which
+    # homebrew does by default. `brew install --no-quarantine ...` is possible,
+    # but nobody does it, and the error is opaque. So just self-release from
+    # quarantine.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/buildkite-mcp-server"]
+          end
 
 release:
   footer: >-


### PR DESCRIPTION
I'd like to `brew install buildkite/buildkite/buildkite-mcp-server`. Goreleaser [supports homebrew casks](https://goreleaser.com/customization/homebrew_casks/), and we have [a homebrew tap](https://github.com/buildkite/homebrew-buildkite), so let's switch it on!

On this branch, I ran:

```console
$ goreleaser release --snapshot
```

This generates casks like:

```ruby
# This file was generated by GoReleaser. DO NOT EDIT.
cask "buildkite-mcp-server" do
  desc "Model Context Protocol server for Buildkite"
  homepage "https://github.com/buildkite/buildkite-mcp-server"
  version "0.5.5-SNAPSHOT-51c2883"

  livecheck do
    skip "Auto-generated on release."
  end

  binary "buildkite-mcp-server"

  on_macos do
    on_intel do
      url "https://github.com/buildkite/buildkite-mcp-server/releases/download/v0.5.5/buildkite-mcp-server_Darwin_x86_64.tar.gz"
      sha256 "d380dcda54d4217be8a4004bd2fa0777ea772d0235e72580a3f5c7dea7f167df"
    end
    on_arm do
      url "https://github.com/buildkite/buildkite-mcp-server/releases/download/v0.5.5/buildkite-mcp-server_Darwin_arm64.tar.gz"
      sha256 "5ef3a3a38d11d85ae76ad0d896c6436605248503c5c2842b3abdd0740ddbd0ee"
    end
  end

  on_linux do
    on_intel do
      url "https://github.com/buildkite/buildkite-mcp-server/releases/download/v0.5.5/buildkite-mcp-server_Linux_x86_64.tar.gz"
      sha256 "1905a1c1accb1c508b25ad3da815ed03e5b2ce353d00dfc98c9a3cf288a52ce0"
    end
    on_arm do
      url "https://github.com/buildkite/buildkite-mcp-server/releases/download/v0.5.5/buildkite-mcp-server_Linux_arm64.tar.gz"
      sha256 "e7c43a14957501a136720066462d3224cdfa6089c0bb929915148307047d8f26"
    end
  end

  postflight do
    if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
      system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/buildkite-mcp-server"]
    end
  end

  # No zap stanza required
end
```

I copy pasted this into my local clone of the tap, adjusted it to [the latest official v0.5.5 artifacts](https://github.com/buildkite/buildkite-mcp-server/releases/tag/v0.5.5), and it works a treat:

```console
$ brew install buildkite/buildkite/buildkite-mcp-server
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Downloading https://github.com/buildkite/buildkite-mcp-server/releases/download/v0.5.5/buildkite-mcp-server_Darwin_arm64.tar.gz
Already downloaded: /Users/sj26/Library/Caches/Homebrew/downloads/e4ea39ee1b140052feff876f6ae31313b6296b54301e6ee57f615cf850469731--buildkite-mcp-server_Darwin_arm64.tar.gz
==> Installing Cask buildkite-mcp-server
==> Linking Binary 'buildkite-mcp-server' to '/opt/homebrew/bin/buildkite-mcp-server'
🍺  buildkite-mcp-server was successfully installed!
```
```console
$ buildkite-mcp-server --version
0.5.5
```

I'll go update our tap to support formulae and casks, and add an initial cask based on the already released version.

I suspect we'll need to give our release pipeline permission to cut a new cask. I presume it already has some form of GitHub credential. We might need to adjust this to open a PR, I don't think it'll be able to push straight to main.

How do you test this release process nicely? Can we do a snapshot release or something?