### PR TITLE
fix: remove unused context passed in at tool creation

### DIFF
--- a/cmd/update-docs/main.go
+++ b/cmd/update-docs/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -21,13 +20,11 @@ const (
 )
 
 func main() {
-	ctx := context.Background()
-
 	// Create a dummy client to initialize tools
 	client := &gobuildkite.Client{}
 
 	// Collect all tools
-	tools := commands.BuildkiteTools(ctx, client)
+	tools := commands.BuildkiteTools(client)
 
 	// Generate markdown documentation for the tools
 	toolsDocs := generateToolsDocs(tools)

--- a/internal/buildkite/access_token.go
+++ b/internal/buildkite/access_token.go
@@ -15,7 +15,7 @@ type AccessTokenClient interface {
 	Get(ctx context.Context) (buildkite.AccessToken, *buildkite.Response, error)
 }
 
-func AccessToken(ctx context.Context, client AccessTokenClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func AccessToken(client AccessTokenClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("access_token",
 			mcp.WithDescription("Get information about the current API access token including its scopes and UUID"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{

--- a/internal/buildkite/access_token_test.go
+++ b/internal/buildkite/access_token_test.go
@@ -41,7 +41,7 @@ func TestAccessToken(t *testing.T) {
 		},
 	}
 
-	tool, handler := AccessToken(ctx, client)
+	tool, handler := AccessToken(client)
 	assert.NotNil(t, tool)
 	assert.NotNil(t, handler)
 

--- a/internal/buildkite/annotations.go
+++ b/internal/buildkite/annotations.go
@@ -20,7 +20,7 @@ type AnnotationsClient interface {
 }
 
 // ListAnnotations returns an MCP tool + handler pair that lists annotations for a build.
-func ListAnnotations(ctx context.Context, client AnnotationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListAnnotations(client AnnotationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_annotations",
 			mcp.WithDescription("List all annotations for a build, including their context, style (success/info/warning/error), rendered HTML content, and creation timestamps"),
 			mcp.WithString("org",

--- a/internal/buildkite/annotations_test.go
+++ b/internal/buildkite/annotations_test.go
@@ -47,7 +47,7 @@ func TestListAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListAnnotations(ctx, client)
+	tool, handler := ListAnnotations(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 	request := createMCPRequest(t, map[string]any{

--- a/internal/buildkite/artifacts.go
+++ b/internal/buildkite/artifacts.go
@@ -73,7 +73,7 @@ func (a *BuildkiteClientAdapter) rewriteArtifactURL(inputURL string) string {
 	return parsedURL.String()
 }
 
-func ListArtifacts(ctx context.Context, client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_artifacts",
 			mcp.WithDescription("List all artifacts for a build across all jobs, including file details, paths, sizes, MIME types, and download URLs"),
 			mcp.WithString("org",
@@ -159,7 +159,7 @@ func ListArtifacts(ctx context.Context, client ArtifactsClient) (tool mcp.Tool, 
 		}
 }
 
-func GetArtifact(ctx context.Context, client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetArtifact(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_artifact",
 			mcp.WithDescription("Get detailed information about a specific artifact including its metadata, file size, SHA-1 hash, and download URL"),
 			mcp.WithString("url",

--- a/internal/buildkite/artifacts_test.go
+++ b/internal/buildkite/artifacts_test.go
@@ -54,7 +54,7 @@ func TestListArtifacts(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListArtifacts(ctx, mockArtifactsClient)
+	tool, handler := ListArtifacts(mockArtifactsClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -94,7 +94,7 @@ func TestGetArtifact(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetArtifact(ctx, client)
+	tool, handler := GetArtifact(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -121,7 +121,7 @@ func TestListArtifacts_MissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockArtifactsClient{}
 
-	_, handler := ListArtifacts(ctx, client)
+	_, handler := ListArtifacts(client)
 
 	// Test missing org parameter
 	req := createMCPRequest(t, map[string]any{
@@ -160,7 +160,7 @@ func TestGetArtifact_MissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockArtifactsClient{}
 
-	_, handler := GetArtifact(ctx, client)
+	_, handler := GetArtifact(client)
 
 	// Test missing url parameter
 	req := createMCPRequest(t, map[string]any{})
@@ -186,7 +186,7 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 		},
 	}
 
-	_, handler := GetArtifact(ctx, client)
+	_, handler := GetArtifact(client)
 
 	req := createMCPRequest(t, map[string]any{
 		"url": "https://example.com/nonexistent-artifact",

--- a/internal/buildkite/builds.go
+++ b/internal/buildkite/builds.go
@@ -31,7 +31,7 @@ type BuildWithSummary struct {
 	JobSummary *JobSummary `json:"job_summary"`
 }
 
-func ListBuilds(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListBuilds(client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_builds",
 			mcp.WithDescription("List all builds for a pipeline with their status, commit information, and metadata"),
 			mcp.WithString("org",
@@ -117,7 +117,7 @@ func ListBuilds(ctx context.Context, client BuildsClient) (tool mcp.Tool, handle
 		}
 }
 
-func GetBuildTestEngineRuns(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_build_test_engine_runs",
 			mcp.WithDescription("Get test engine runs data for a specific build in Buildkite. This can be used to look up Test Runs."),
 			mcp.WithString("org",
@@ -191,7 +191,7 @@ func GetBuildTestEngineRuns(ctx context.Context, client BuildsClient) (tool mcp.
 		}
 }
 
-func GetBuild(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetBuild(client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_build",
 			mcp.WithDescription("Get detailed information about a specific build including its jobs, timing, and execution details"),
 			mcp.WithString("org",
@@ -295,7 +295,7 @@ type CreateBuildArgs struct {
 	MetaData     []Entry `json:"metadata"`
 }
 
-func CreateBuild(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreateBuildArgs]) {
+func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreateBuildArgs]) {
 	return mcp.NewTool("create_build",
 			mcp.WithDescription("Trigger a new build on a Buildkite pipeline for a specific commit and branch, with optional environment variables, metadata, and author information"),
 			mcp.WithString("org_slug",

--- a/internal/buildkite/builds_test.go
+++ b/internal/buildkite/builds_test.go
@@ -59,7 +59,7 @@ func TestGetBuildDefault(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetBuild(ctx, client)
+	tool, handler := GetBuild(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -102,7 +102,7 @@ func TestGetBuildWithJobSummary(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetBuild(ctx, client)
+	tool, handler := GetBuild(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -145,7 +145,7 @@ func TestListBuilds(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListBuilds(ctx, client)
+	tool, handler := ListBuilds(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -190,7 +190,7 @@ func TestListBuildsWithCustomPagination(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListBuilds(ctx, client)
+	tool, handler := ListBuilds(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -234,7 +234,7 @@ func TestListBuildsWithBranchFilter(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListBuilds(ctx, client)
+	tool, handler := ListBuilds(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -290,7 +290,7 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetBuildTestEngineRuns(ctx, client)
+	tool, handler := GetBuildTestEngineRuns(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -333,7 +333,7 @@ func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {
 		},
 	}
 
-	_, handler := GetBuildTestEngineRuns(ctx, client)
+	_, handler := GetBuildTestEngineRuns(client)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":           "org",
@@ -354,7 +354,7 @@ func TestGetBuildTestEngineRunsMissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockBuildsClient{}
 
-	_, handler := GetBuildTestEngineRuns(ctx, client)
+	_, handler := GetBuildTestEngineRuns(client)
 
 	// Test missing org parameter
 	request := createMCPRequest(t, map[string]any{
@@ -420,7 +420,7 @@ func TestCreateBuild(t *testing.T) {
 		},
 	}
 
-	tool, handler := CreateBuild(ctx, client)
+	tool, handler := CreateBuild(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/cluster_queue.go
+++ b/internal/buildkite/cluster_queue.go
@@ -17,7 +17,7 @@ type ClusterQueuesClient interface {
 	Get(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error)
 }
 
-func ListClusterQueues(ctx context.Context, client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_cluster_queues",
 			mcp.WithDescription("List all queues in a cluster with their keys, descriptions, dispatch status, and agent configuration"),
 			mcp.WithString("org",
@@ -88,7 +88,7 @@ func ListClusterQueues(ctx context.Context, client ClusterQueuesClient) (tool mc
 		}
 }
 
-func GetClusterQueue(ctx context.Context, client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_cluster_queue",
 			mcp.WithDescription("Get detailed information about a specific queue including its key, description, dispatch status, and hosted agent configuration"),
 			mcp.WithString("org",

--- a/internal/buildkite/cluster_queue_test.go
+++ b/internal/buildkite/cluster_queue_test.go
@@ -47,7 +47,7 @@ func TestListClusterQueues(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListClusterQueues(ctx, client)
+	tool, handler := ListClusterQueues(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -78,7 +78,7 @@ func TestGetClusterQueue(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetClusterQueue(ctx, client)
+	tool, handler := GetClusterQueue(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/clusters.go
+++ b/internal/buildkite/clusters.go
@@ -17,7 +17,7 @@ type ClustersClient interface {
 	Get(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error)
 }
 
-func ListClusters(ctx context.Context, client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_clusters",
 			mcp.WithDescription("List all clusters in an organization with their names, descriptions, default queues, and creation details"),
 			mcp.WithString("org",
@@ -78,7 +78,7 @@ func ListClusters(ctx context.Context, client ClustersClient) (tool mcp.Tool, ha
 		}
 }
 
-func GetCluster(ctx context.Context, client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_cluster",
 			mcp.WithDescription("Get detailed information about a specific cluster including its name, description, default queue, and configuration"),
 			mcp.WithString("org",

--- a/internal/buildkite/clusters_test.go
+++ b/internal/buildkite/clusters_test.go
@@ -48,7 +48,7 @@ func TestListClusters(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListClusters(ctx, client)
+	tool, handler := ListClusters(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -79,7 +79,7 @@ func TestGetCluster(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetCluster(ctx, client)
+	tool, handler := GetCluster(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/jobs.go
+++ b/internal/buildkite/jobs.go
@@ -39,7 +39,7 @@ func withJobsPagination() mcp.ToolOption {
 	}
 }
 
-func GetJobs(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetJobs(client BuildsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_jobs",
 			mcp.WithDescription("Get all jobs for a specific build including their state, timing, commands, and execution details"),
 			mcp.WithString("org",
@@ -150,7 +150,7 @@ func GetJobs(ctx context.Context, client BuildsClient) (tool mcp.Tool, handler s
 		}
 }
 
-func GetJobLogs(ctx context.Context, client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetJobLogs(client *buildkite.Client) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_job_logs",
 			mcp.WithDescription("Get the log output and metadata for a specific job, including content, size, and header timestamps. Automatically saves to file for large logs to avoid token limits."),
 			mcp.WithString("org",

--- a/internal/buildkite/jobs_test.go
+++ b/internal/buildkite/jobs_test.go
@@ -34,7 +34,7 @@ func TestGetJobs(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -94,7 +94,7 @@ func TestGetJobsWithStateFilter(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -181,7 +181,7 @@ func TestGetJobsMissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockBuildsClient{}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -254,7 +254,7 @@ func TestGetJobsPagination(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -371,7 +371,7 @@ func TestGetJobsAgentInfo(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -460,7 +460,7 @@ func TestGetJobsPaginationWithFilter(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(ctx, client)
+	tool, handler := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -493,7 +493,7 @@ func TestGetJobsPaginationWithFilter(t *testing.T) {
 func TestGetJobLogs(t *testing.T) {
 	// Test the tool definition
 	t.Run("ToolDefinition", func(t *testing.T) {
-		tool, _ := GetJobLogs(context.Background(), nil)
+		tool, _ := GetJobLogs(nil)
 
 		assert.Equal(t, "get_job_logs", tool.Name)
 		assert.Contains(t, tool.Description, "Get the log output and metadata for a specific job, including content, size, and header timestamps")
@@ -501,7 +501,7 @@ func TestGetJobLogs(t *testing.T) {
 
 	t.Run("MissingParameters", func(t *testing.T) {
 		assert := require.New(t)
-		_, handler := GetJobLogs(context.Background(), &buildkite.Client{})
+		_, handler := GetJobLogs(&buildkite.Client{})
 
 		// Test missing org parameter
 		req := createMCPRequest(t, map[string]any{

--- a/internal/buildkite/organizations.go
+++ b/internal/buildkite/organizations.go
@@ -15,7 +15,7 @@ type OrganizationsClient interface {
 	List(ctx context.Context, options *buildkite.OrganizationListOptions) ([]buildkite.Organization, *buildkite.Response, error)
 }
 
-func UserTokenOrganization(ctx context.Context, client OrganizationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func UserTokenOrganization(client OrganizationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("user_token_organization",
 			mcp.WithDescription("Get the organization associated with the user token used for this request"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{

--- a/internal/buildkite/organizations_test.go
+++ b/internal/buildkite/organizations_test.go
@@ -39,7 +39,7 @@ func TestUserTokenOrganization(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(ctx, client)
+	tool, handler := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -66,7 +66,7 @@ func TestUserTokenOrganizationError(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(ctx, client)
+	tool, handler := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -93,7 +93,7 @@ func TestUserTokenOrganizationErrorNoOrganization(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(ctx, client)
+	tool, handler := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/pipelines.go
+++ b/internal/buildkite/pipelines.go
@@ -21,7 +21,7 @@ type PipelinesClient interface {
 	Update(ctx context.Context, org, pipelineSlug string, p buildkite.UpdatePipeline) (buildkite.Pipeline, *buildkite.Response, error)
 }
 
-func ListPipelines(ctx context.Context, client PipelinesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_pipelines",
 			mcp.WithDescription("List all pipelines in an organization with their basic details, build counts, and current status"),
 			mcp.WithString("org",
@@ -83,7 +83,7 @@ func ListPipelines(ctx context.Context, client PipelinesClient) (tool mcp.Tool, 
 		}
 }
 
-func GetPipeline(ctx context.Context, client PipelinesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_pipeline",
 			mcp.WithDescription("Get detailed information about a specific pipeline including its configuration, steps, environment variables, and build statistics"),
 			mcp.WithString("org",
@@ -152,7 +152,7 @@ type CreatePipelineArgs struct {
 	Tags                      []string `json:"tags"`
 }
 
-func CreatePipeline(ctx context.Context, client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreatePipelineArgs]) {
+func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreatePipelineArgs]) {
 	return mcp.NewTool("create_pipeline",
 			mcp.WithDescription("Set up a new CI/CD pipeline in Buildkite with YAML configuration, repository connection, and cluster assignment"),
 			mcp.WithString("org_slug",
@@ -279,7 +279,7 @@ type UpdatePipelineArgs struct {
 	Tags                      []string `json:"tags"` // Optional, labels to apply to the pipeline
 }
 
-func UpdatePipeline(ctx context.Context, client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[UpdatePipelineArgs]) {
+func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[UpdatePipelineArgs]) {
 	return mcp.NewTool("update_pipeline",
 			mcp.WithDescription("Modify an existing Buildkite pipeline's configuration, repository, settings, or metadata"),
 			mcp.WithString("org_slug",

--- a/internal/buildkite/pipelines_test.go
+++ b/internal/buildkite/pipelines_test.go
@@ -67,7 +67,7 @@ func TestListPipelines(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListPipelines(ctx, client)
+	tool, handler := ListPipelines(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -101,7 +101,7 @@ func TestGetPipeline(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetPipeline(ctx, client)
+	tool, handler := GetPipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -158,7 +158,7 @@ steps:
 		},
 	}
 
-	tool, handler := CreatePipeline(ctx, client)
+	tool, handler := CreatePipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -217,7 +217,7 @@ steps:
 		},
 	}
 
-	tool, handler := UpdatePipeline(ctx, client)
+	tool, handler := UpdatePipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/test_executions.go
+++ b/internal/buildkite/test_executions.go
@@ -18,7 +18,7 @@ type TestExecutionsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
 }
 
-func GetFailedTestExecutions(ctx context.Context, client TestExecutionsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_failed_executions",
 			mcp.WithDescription("Get failed test executions for a specific test run in Buildkite Test Engine. Optionally get the expanded failure details such as full error messages and stack traces."),
 			mcp.WithString("org",

--- a/internal/buildkite/test_executions_test.go
+++ b/internal/buildkite/test_executions_test.go
@@ -59,7 +59,7 @@ func TestGetFailedExecutions(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(ctx, mockClient)
+	tool, handler := GetFailedTestExecutions(mockClient)
 
 	// Test tool properties
 	assert.Equal("get_failed_executions", tool.Name)
@@ -97,7 +97,7 @@ func TestGetFailedExecutionsMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(ctx, mockClient)
+	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -116,7 +116,7 @@ func TestGetFailedExecutionsMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(ctx, mockClient)
+	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":    "org",
@@ -135,7 +135,7 @@ func TestGetFailedExecutionsMissingRunID(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(ctx, mockClient)
+	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -158,7 +158,7 @@ func TestGetFailedExecutionsWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetFailedTestExecutions(ctx, mockClient)
+	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -187,7 +187,7 @@ func TestGetFailedExecutionsHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetFailedTestExecutions(ctx, mockClient)
+	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -267,7 +267,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(ctx, mockClient)
+	tool, handler := GetFailedTestExecutions(mockClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -390,7 +390,7 @@ func TestGetFailedExecutionsLargePage(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(ctx, mockClient)
+	tool, handler := GetFailedTestExecutions(mockClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/test_runs.go
+++ b/internal/buildkite/test_runs.go
@@ -20,7 +20,7 @@ type TestRunsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
 }
 
-func ListTestRuns(ctx context.Context, client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_test_runs",
 			mcp.WithDescription("List all test runs for a test suite in Buildkite Test Engine"),
 			mcp.WithString("org",
@@ -96,7 +96,7 @@ func ListTestRuns(ctx context.Context, client TestRunsClient) (tool mcp.Tool, ha
 		}
 }
 
-func GetTestRun(ctx context.Context, client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_test_run",
 			mcp.WithDescription("Get a specific test run in Buildkite Test Engine"),
 			mcp.WithString("org",

--- a/internal/buildkite/test_runs_test.go
+++ b/internal/buildkite/test_runs_test.go
@@ -74,7 +74,7 @@ func TestListTestRuns(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListTestRuns(ctx, mockClient)
+	tool, handler := ListTestRuns(mockClient)
 
 	// Test tool properties
 	assert.Equal("list_test_runs", tool.Name)
@@ -112,7 +112,7 @@ func TestListTestRunsWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := ListTestRuns(ctx, mockClient)
+	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -131,7 +131,7 @@ func TestListTestRunsMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := ListTestRuns(ctx, mockClient)
+	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -149,7 +149,7 @@ func TestListTestRunsMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := ListTestRuns(ctx, mockClient)
+	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org": "org",
@@ -183,7 +183,7 @@ func TestGetTestRun(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetTestRun(ctx, mockClient)
+	tool, handler := GetTestRun(mockClient)
 
 	// Test tool properties
 	assert.Equal("get_test_run", tool.Name)
@@ -218,7 +218,7 @@ func TestGetTestRunWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetTestRun(ctx, mockClient)
+	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -238,7 +238,7 @@ func TestGetTestRunMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(ctx, mockClient)
+	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -257,7 +257,7 @@ func TestGetTestRunMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(ctx, mockClient)
+	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":    "org",
@@ -276,7 +276,7 @@ func TestGetTestRunMissingRunID(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(ctx, mockClient)
+	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -304,7 +304,7 @@ func TestGetTestRunHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetTestRun(ctx, mockClient)
+	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -333,7 +333,7 @@ func TestListTestRunsHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := ListTestRuns(ctx, mockClient)
+	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org":             "org",
@@ -345,4 +345,3 @@ func TestListTestRunsHTTPError(t *testing.T) {
 	assert.True(result.IsError)
 	assert.Contains(result.Content[0].(mcp.TextContent).Text, "Access denied")
 }
-

--- a/internal/buildkite/tests.go
+++ b/internal/buildkite/tests.go
@@ -18,7 +18,7 @@ type TestsClient interface {
 	Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
 }
 
-func GetTest(ctx context.Context, client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_test",
 			mcp.WithDescription("Get a specific test in Buildkite Test Engine. This provides additional metadata for failed test executions"),
 			mcp.WithString("org",

--- a/internal/buildkite/tests_test.go
+++ b/internal/buildkite/tests_test.go
@@ -27,24 +27,22 @@ var _ TestsClient = (*MockTestsClient)(nil)
 func TestGetTest(t *testing.T) {
 	assert := require.New(t)
 
-	ctx := context.Background()
-
 	client := &MockTestsClient{
 		GetFunc: func(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error) {
 			return buildkite.Test{
-				ID:       "test-123",
-				Name:     "Example Test",
-				Location: "spec/example_test.rb",
-			}, &buildkite.Response{
-				Response: &http.Response{
-					StatusCode: 200,
-					Body:       io.NopCloser(strings.NewReader(`{"id": "test-123"}`)),
-				},
-			}, nil
+					ID:       "test-123",
+					Name:     "Example Test",
+					Location: "spec/example_test.rb",
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+						Body:       io.NopCloser(strings.NewReader(`{"id": "test-123"}`)),
+					},
+				}, nil
 		},
 	}
 
-	tool, handler := GetTest(ctx, client)
+	tool, handler := GetTest(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/buildkite/user.go
+++ b/internal/buildkite/user.go
@@ -15,7 +15,7 @@ type UserClient interface {
 	CurrentUser(ctx context.Context) (buildkite.User, *buildkite.Response, error)
 }
 
-func CurrentUser(ctx context.Context, client UserClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func CurrentUser(client UserClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("current_user",
 			mcp.WithDescription("Get details about the user account that owns the API token, including name, email, avatar, and account creation date"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{

--- a/internal/buildkite/user_test.go
+++ b/internal/buildkite/user_test.go
@@ -39,7 +39,7 @@ func TestCurrentUser(t *testing.T) {
 		},
 	}
 
-	tool, handler := CurrentUser(ctx, client)
+	tool, handler := CurrentUser(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -13,7 +13,7 @@ type HTTPCmd struct {
 
 func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 
-	mcpServer := NewMCPServer(ctx, globals)
+	mcpServer := NewMCPServer(globals)
 
 	httpServer := server.NewSSEServer(mcpServer)
 

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -9,8 +9,20 @@ import (
 type StdioCmd struct{}
 
 func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
+	s := NewMCPServer(globals)
 
-	s := NewMCPServer(ctx, globals)
+	return server.ServeStdio(s,
+		server.WithStdioContextFunc(
+			setupContext(globals),
+		),
+	)
+}
 
-	return server.ServeStdio(s)
+// NewMCPServer creates a new MCP server instance with the provided globals.
+func setupContext(globals *Globals) server.StdioContextFunc {
+	return func(ctx context.Context) context.Context {
+
+		// add the logger to the context
+		return globals.Logger.WithContext(ctx)
+	}
 }

--- a/internal/commands/tools.go
+++ b/internal/commands/tools.go
@@ -16,7 +16,7 @@ func (c *ToolsCmd) Run(ctx context.Context, globals *Globals) error {
 	client := &gobuildkite.Client{}
 
 	// Collect all tools
-	tools := BuildkiteTools(ctx, client)
+	tools := BuildkiteTools(client)
 
 	for _, tool := range tools {
 


### PR DESCRIPTION
This change cleans up an extra context passed in at tool creation, which shadows the handler context. In practice each handler runs with a context which is scoped to the stdio server.

To remove all this confusion I am removing this context, and to resolve log propegation via the handlers context I have introduced an option to set it up correctly, which fixes the logger. :facepalm:
