### PR TITLE
Fix accidental heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ docker mcp server enable buildkite
 ```
 
 View on [Docker MCP Hub](https://hub.docker.com/mcp/server/buildkite)
+
 ---
 
 ## ⚙️ Configuration & Usage


### PR DESCRIPTION
<img width="1960" height="576" alt="CleanShot 2025-07-22 at 14 34 28@2x" src="https://github.com/user-attachments/assets/60f4ff1a-b6d2-43b2-99be-baf2fa54f46d" />

I accidentally put the View on Docker Hub link on the line before the `---` horizontal rule, and I'd forgotten that markdown turns that into a heading 😅 