### PR TITLE
Ignore zed config and zed debugger binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 .envrc*
+.zed
 .vscode
 vendor/
 *.zip
@@ -7,3 +8,6 @@ vendor/
 /buildkite-mcp-server
 coverage.out
 /specs
+
+# debugger binaries
+__debug_bin*


### PR DESCRIPTION
A tiny one to avoid accidentally checking in debugger things from zed. I've also added it to my global gitignore, but it can be useful for others!