### PR TITLE
refactor: revisit builds and reduce token use for common tasks

### DIFF
--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -67,9 +67,15 @@ func BuildkiteTools(client *gobuildkite.Client, buildkiteLogsClient *buildkitelo
 	)
 
 	// Build tools
-	tools = addTool(buildkite.ListBuilds(client.Builds))
-	tools = addTool(buildkite.GetBuild(client.Builds))
-	tools = addTool(buildkite.GetBuildTestEngineRuns(client.Builds))
+	tools = addTool(
+		fromTypeTool(buildkite.ListBuilds(client.Builds)),
+	)
+	tools = addTool(
+		fromTypeTool(buildkite.GetBuild(client.Builds)),
+	)
+	tools = addTool(
+		fromTypeTool(buildkite.GetBuildTestEngineRuns(client.Builds)),
+	)
 	tools = addTool(
 		fromTypeTool(buildkite.CreateBuild(client.Builds)),
 	)


### PR DESCRIPTION
* BuildSummary - Essential fields only (~85% token reduction)
* BuildDetail - Medium detail with job summary (~60% token reduction)
* BuildWithSummary - Maintained for backward compatibility

Also adds:
* Typed Args Structs for build related tools.
* Improved filtering for ListBuilds, with support for state, commit, creator and detail_level.
