### PR TITLE
Remove broken Cursor button and add proper configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Local binary, with the [Job Log Token Threshold](#job-log-token-threshold) flag 
 <details>
 <summary>Cursor</summary>
 
-**Install directly:** [cursor://anysphere.cursor-deeplink/mcp/install?name=buildkite&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC1lIEJVSUxES0lURV9BUElfVE9LRU4gZ2hjci5pby9idWlsZGtpdGUvYnVpbGRraXRlLW1jcC1zZXJ2ZXIgc3RkaW8ifQ%3D%3D](cursor://anysphere.cursor-deeplink/mcp/install?name=buildkite&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC1lIEJVSUxES0lURV9BUElfVE9LRU4gZ2hjci5pby9idWlsZGtpdGUvYnVpbGRraXRlLW1jcC1zZXJ2ZXIgc3RkaW8ifQ%3D%3D)
+[Add Buildkite MCP Server to Cursor](cursor://anysphere.cursor-deeplink/mcp/install?name=buildkite&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biAtaSAtLXJtIC1lIEJVSUxES0lURV9BUElfVE9LRU4gZ2hjci5pby9idWlsZGtpdGUvYnVpbGRraXRlLW1jcC1zZXJ2ZXIgc3RkaW8ifQ%3D%3D)
 
 Docker (recommended):
 


### PR DESCRIPTION
My previous change to fix the "Add to Cursor" button with a working deep link makes the button direct to the image URL, instead of triggering the install because GitHub seems to sanitize deep links in README's. TIL.

I think we should just remove the top-level Cursor button in favor of a working deeplink for one-click install in the Cursor section. Moving it to the config section might be where users expect to find setup instructions anyway