### PR TITLE
chore: reduce token use based on duplication and obvious descriptions

### DIFF
--- a/pkg/buildkite/access_token.go
+++ b/pkg/buildkite/access_token.go
@@ -19,8 +19,7 @@ func AccessToken(client AccessTokenClient) (tool mcp.Tool, handler server.ToolHa
 	return mcp.NewTool("access_token",
 			mcp.WithDescription("Get information about the current API access token including its scopes and UUID"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Access Token",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Access Token",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.AccessToken")

--- a/pkg/buildkite/annotations_test.go
+++ b/pkg/buildkite/annotations_test.go
@@ -51,7 +51,7 @@ func TestListAnnotations(t *testing.T) {
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -76,28 +76,24 @@ func (a *BuildkiteClientAdapter) rewriteArtifactURL(inputURL string) string {
 func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_artifacts",
 			mcp.WithDescription("List all artifacts for a build across all jobs, including file details, paths, sizes, MIME types, and download URLs"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("build_number",
 				mcp.Required(),
-				mcp.Description("The build number"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Artifact List",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Artifact List",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListArtifacts")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -118,14 +114,14 @@ func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHa
 			}
 
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("pipeline_slug", pipelineSlug),
 				attribute.String("build_number", buildNumber),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
 			)
 
-			artifacts, resp, err := client.ListByBuild(ctx, org, pipelineSlug, buildNumber, &buildkite.ArtifactListOptions{
+			artifacts, resp, err := client.ListByBuild(ctx, orgSlug, pipelineSlug, buildNumber, &buildkite.ArtifactListOptions{
 				ListOptions: paginationParams,
 			})
 			if err != nil {
@@ -160,11 +156,9 @@ func GetArtifact(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHand
 			mcp.WithDescription("Get detailed information about a specific artifact including its metadata, file size, SHA-1 hash, and download URL"),
 			mcp.WithString("url",
 				mcp.Required(),
-				mcp.Description("The URL of the artifact to get"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Artifact",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Artifact",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -59,7 +59,7 @@ func TestListArtifacts(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":           "test-org",
+		"org_slug":      "test-org",
 		"pipeline_slug": "test-pipeline",
 		"build_number":  "123",
 	})
@@ -131,11 +131,11 @@ func TestListArtifacts_MissingParameters(t *testing.T) {
 	result, err := handler(ctx, req)
 	assert.NoError(err)
 	assert.NotNil(result)
-	assert.Contains(getTextResult(t, result).Text, "required argument \"org\" not found")
+	assert.Contains(getTextResult(t, result).Text, "required argument \"org_slug\" not found")
 
 	// Test missing pipeline_slug parameter
 	req = createMCPRequest(t, map[string]any{
-		"org":          "test-org",
+		"org_slug":     "test-org",
 		"build_number": "123",
 	})
 	result, err = handler(ctx, req)
@@ -145,7 +145,7 @@ func TestListArtifacts_MissingParameters(t *testing.T) {
 
 	// Test missing build_number parameter
 	req = createMCPRequest(t, map[string]any{
-		"org":           "test-org",
+		"org_slug":      "test-org",
 		"pipeline_slug": "test-pipeline",
 	})
 	result, err = handler(ctx, req)

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -56,7 +56,7 @@ type BuildWithSummary struct {
 
 // ListBuildsArgs struct with enhanced filtering
 type ListBuildsArgs struct {
-	Org          string `json:"org"`
+	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	Branch       string `json:"branch"`       // existing
 	State        string `json:"state"`        // NEW: running, passed, failed, etc.
@@ -69,7 +69,7 @@ type ListBuildsArgs struct {
 
 // GetBuildArgs struct
 type GetBuildArgs struct {
-	Org          string `json:"org"`
+	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
 	DetailLevel  string `json:"detail_level"` // summary, detailed, full
@@ -77,7 +77,7 @@ type GetBuildArgs struct {
 
 // GetBuildTestEngineRunsArgs struct
 type GetBuildTestEngineRunsArgs struct {
-	Org          string `json:"org"`
+	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
 }
@@ -142,13 +142,11 @@ func createPaginatedBuildResult[T any](builds []buildkite.Build, converter func(
 func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListBuildsArgs]) {
 	return mcp.NewTool("list_builds",
 			mcp.WithDescription("List all builds for a pipeline with their status, commit information, and metadata"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("branch",
 				mcp.Description("Filter builds by git branch name"),
@@ -172,8 +170,7 @@ func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandle
 				mcp.Description("Results per page for pagination (min 1, max 100)"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "List Builds",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "List Builds",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest, args ListBuildsArgs) (*mcp.CallToolResult, error) {
@@ -181,15 +178,15 @@ func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandle
 			defer span.End()
 
 			// Validate required parameters
-			if args.Org == "" {
-				return mcp.NewToolResultError("org parameter is required"), nil
+			if args.OrgSlug == "" {
+				return mcp.NewToolResultError("org_slug parameter is required"), nil
 			}
 			if args.PipelineSlug == "" {
 				return mcp.NewToolResultError("pipeline_slug parameter is required"), nil
 			}
 
 			span.SetAttributes(
-				attribute.String("org", args.Org),
+				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("branch", args.Branch),
 				attribute.String("state", args.State),
@@ -251,7 +248,7 @@ func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandle
 				options.Creator = args.Creator
 			}
 
-			builds, resp, err := client.ListByPipeline(ctx, args.Org, args.PipelineSlug, options)
+			builds, resp, err := client.ListByPipeline(ctx, args.OrgSlug, args.PipelineSlug, options)
 			if err != nil {
 				var errResp *buildkite.ErrorResponse
 				if errors.As(err, &errResp) {
@@ -292,21 +289,17 @@ func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandle
 func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildTestEngineRunsArgs]) {
 	return mcp.NewTool("get_build_test_engine_runs",
 			mcp.WithDescription("Get test engine runs data for a specific build in Buildkite. This can be used to look up Test Runs."),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("build_number",
 				mcp.Required(),
-				mcp.Description("The number of the build"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Build Test Engine Runs",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Build Test Engine Runs",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest, args GetBuildTestEngineRunsArgs) (*mcp.CallToolResult, error) {
@@ -314,8 +307,8 @@ func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.Typ
 			defer span.End()
 
 			// Validate required parameters
-			if args.Org == "" {
-				return mcp.NewToolResultError("org parameter is required"), nil
+			if args.OrgSlug == "" {
+				return mcp.NewToolResultError("org_slug parameter is required"), nil
 			}
 			if args.PipelineSlug == "" {
 				return mcp.NewToolResultError("pipeline_slug parameter is required"), nil
@@ -325,12 +318,12 @@ func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.Typ
 			}
 
 			span.SetAttributes(
-				attribute.String("org", args.Org),
+				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
 			)
 
-			build, _, err := client.Get(ctx, args.Org, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
+			build, _, err := client.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
 				IncludeTestEngine: true,
 			})
 			if err != nil {
@@ -362,24 +355,20 @@ func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.Typ
 func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildArgs]) {
 	return mcp.NewTool("get_build",
 			mcp.WithDescription("Get detailed information about a specific build including its jobs, timing, and execution details"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("build_number",
 				mcp.Required(),
-				mcp.Description("The number of the build"),
 			),
 			mcp.WithString("detail_level",
 				mcp.Description("Response detail level: 'summary' (essential fields), 'detailed' (medium detail), or 'full' (complete build data). Default: 'detailed'"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Build",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Build",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest, args GetBuildArgs) (*mcp.CallToolResult, error) {
@@ -387,8 +376,8 @@ func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerF
 			defer span.End()
 
 			// Validate required parameters
-			if args.Org == "" {
-				return mcp.NewToolResultError("org parameter is required"), nil
+			if args.OrgSlug == "" {
+				return mcp.NewToolResultError("org_slug parameter is required"), nil
 			}
 			if args.PipelineSlug == "" {
 				return mcp.NewToolResultError("pipeline_slug parameter is required"), nil
@@ -398,7 +387,7 @@ func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerF
 			}
 
 			span.SetAttributes(
-				attribute.String("org", args.Org),
+				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
 				attribute.String("detail_level", args.DetailLevel),
@@ -415,7 +404,7 @@ func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerF
 				IncludeTestEngine: true,
 			}
 
-			build, _, err := client.Get(ctx, args.Org, args.PipelineSlug, args.BuildNumber, options)
+			build, _, err := client.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, options)
 			if err != nil {
 				var errResp *buildkite.ErrorResponse
 				if errors.As(err, &errResp) {
@@ -468,11 +457,9 @@ func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandl
 			mcp.WithDescription("Trigger a new build on a Buildkite pipeline for a specific commit and branch, with optional environment variables, metadata, and author information"),
 			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("commit",
 				mcp.Required(),
@@ -494,11 +481,11 @@ func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandl
 						"properties": map[string]any{
 							"key": map[string]any{
 								"type":        "string",
-								"description": "The name of the environment variable",
+								"description": "The environment variable name",
 							},
 							"value": map[string]any{
 								"type":        "string",
-								"description": "The value of the environment variable",
+								"description": "The environment variable value",
 							},
 						},
 					},
@@ -512,11 +499,11 @@ func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandl
 						"properties": map[string]any{
 							"key": map[string]any{
 								"type":        "string",
-								"description": "The key of the meta-data item",
+								"description": "The meta-data item key",
 							},
 							"value": map[string]any{
 								"type":        "string",
-								"description": "The value of the meta-data item",
+								"description": "The meta-data item value",
 							},
 						},
 					},

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -66,7 +66,7 @@ func TestGetBuildDefault(t *testing.T) {
 
 	// Test default behavior - jobs always excluded, summary always included
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})
@@ -115,7 +115,7 @@ func TestGetBuildWithJobSummary(t *testing.T) {
 
 	// Test behavior - jobs always excluded, summary always shown
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})
@@ -158,7 +158,7 @@ func TestListBuilds(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 	})
 	result, err := handler(ctx, request)
@@ -211,7 +211,7 @@ func TestListBuildsWithCustomPagination(t *testing.T) {
 
 	// Test with custom pagination parameters
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"page":          float64(3),
 		"per_page":      float64(50),
@@ -256,7 +256,7 @@ func TestListBuildsWithBranchFilter(t *testing.T) {
 
 	// Test with branch filter
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"branch":        "main",
 	})
@@ -317,7 +317,7 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})
@@ -354,7 +354,7 @@ func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {
 	handler := mcp.NewTypedToolHandler(typedHandler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})
@@ -383,11 +383,11 @@ func TestGetBuildTestEngineRunsMissingParameters(t *testing.T) {
 	result, err := handler(ctx, request)
 	assert.NoError(err)
 	assert.True(result.IsError)
-	assert.Contains(result.Content[0].(mcp.TextContent).Text, "org")
+	assert.Contains(result.Content[0].(mcp.TextContent).Text, "org_slug")
 
 	// Test missing pipeline_slug parameter
 	request = createMCPRequest(t, map[string]any{
-		"org":          "org",
+		"org_slug":     "org",
 		"build_number": "1",
 	})
 	result, err = handler(ctx, request)
@@ -397,7 +397,7 @@ func TestGetBuildTestEngineRunsMissingParameters(t *testing.T) {
 
 	// Test missing build_number parameter
 	request = createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 	})
 	result, err = handler(ctx, request)

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -20,24 +20,21 @@ type ClusterQueuesClient interface {
 func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_cluster_queues",
 			mcp.WithDescription("List all queues in a cluster with their keys, descriptions, dispatch status, and agent configuration"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("cluster_id",
 				mcp.Required(),
-				mcp.Description("The id of the cluster"),
 			),
 			withPagination(),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "List Cluster Queues",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "List Cluster Queues",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListClusterQueues")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -52,13 +49,13 @@ func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler serve
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("cluster_id", clusterID),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
 			)
 
-			queues, resp, err := client.List(ctx, org, clusterID, &buildkite.ClusterQueuesListOptions{
+			queues, resp, err := client.List(ctx, orgSlug, clusterID, &buildkite.ClusterQueuesListOptions{
 				ListOptions: paginationParams,
 			})
 			if err != nil {
@@ -91,27 +88,23 @@ func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler serve
 func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_cluster_queue",
 			mcp.WithDescription("Get detailed information about a specific queue including its key, description, dispatch status, and hosted agent configuration"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("cluster_id",
 				mcp.Required(),
-				mcp.Description("The id of the cluster"),
 			),
 			mcp.WithString("queue_id",
 				mcp.Required(),
-				mcp.Description("The id of the queue"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Cluster Queue",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Cluster Queue",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetClusterQueue")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -126,12 +119,12 @@ func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("cluster_id", clusterID),
 				attribute.String("queue_id", queueID),
 			)
 
-			queue, resp, err := client.Get(ctx, org, clusterID, queueID)
+			queue, resp, err := client.Get(ctx, orgSlug, clusterID, queueID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/buildkite/cluster_queue_test.go
+++ b/pkg/buildkite/cluster_queue_test.go
@@ -52,7 +52,7 @@ func TestListClusterQueues(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":        "org",
+		"org_slug":   "org",
 		"cluster_id": "cluster-id",
 	})
 	result, err := handler(ctx, request)
@@ -83,7 +83,7 @@ func TestGetClusterQueue(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":        "org",
+		"org_slug":   "org",
 		"cluster_id": "cluster-id",
 		"queue_id":   "queue-id",
 	})

--- a/pkg/buildkite/clusters.go
+++ b/pkg/buildkite/clusters.go
@@ -20,20 +20,18 @@ type ClustersClient interface {
 func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_clusters",
 			mcp.WithDescription("List all clusters in an organization with their names, descriptions, default queues, and creation details"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			withPagination(),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "List Clusters",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "List Clusters",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListClusters")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -43,12 +41,12 @@ func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHand
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
 			)
 
-			clusters, resp, err := client.List(ctx, org, &buildkite.ClustersListOptions{
+			clusters, resp, err := client.List(ctx, orgSlug, &buildkite.ClustersListOptions{
 				ListOptions: paginationParams,
 			})
 			if err != nil {
@@ -81,23 +79,20 @@ func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHand
 func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_cluster",
 			mcp.WithDescription("Get detailed information about a specific cluster including its name, description, default queue, and configuration"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("cluster_id",
 				mcp.Required(),
-				mcp.Description("The id of the cluster"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Cluster",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Cluster",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetCluster")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -107,11 +102,11 @@ func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandle
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("cluster_id", clusterID),
 			)
 
-			cluster, resp, err := client.Get(ctx, org, clusterID)
+			cluster, resp, err := client.Get(ctx, orgSlug, clusterID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/buildkite/clusters_test.go
+++ b/pkg/buildkite/clusters_test.go
@@ -53,7 +53,7 @@ func TestListClusters(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org": "org",
+		"org_slug": "org",
 	})
 	result, err := handler(ctx, request)
 	assert.NoError(err)
@@ -84,7 +84,7 @@ func TestGetCluster(t *testing.T) {
 	assert.NotNil(handler)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":        "org",
+		"org_slug":   "org",
 		"cluster_id": "cluster-id",
 	})
 	result, err := handler(ctx, request)

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -40,7 +40,7 @@ func TestGetJobs(t *testing.T) {
 
 	// Test getting all jobs (no filter) - agent info should be excluded by default
 	requestAll := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 	})
@@ -100,7 +100,7 @@ func TestGetJobsWithStateFilter(t *testing.T) {
 
 	t.Run("filter by passed state", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"job_state":     "passed",
@@ -126,7 +126,7 @@ func TestGetJobsWithStateFilter(t *testing.T) {
 
 	t.Run("filter by failed state", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"job_state":     "failed",
@@ -152,7 +152,7 @@ func TestGetJobsWithStateFilter(t *testing.T) {
 
 	t.Run("filter by running state", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"job_state":     "running",
@@ -201,7 +201,7 @@ func TestGetJobsMissingParameters(t *testing.T) {
 
 	t.Run("missing pipeline_slug", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":          "org",
+			"org_slug":     "org",
 			"build_number": "1",
 		})
 		result, err := handler(ctx, request)
@@ -215,7 +215,7 @@ func TestGetJobsMissingParameters(t *testing.T) {
 
 	t.Run("missing build_number", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 		})
 		result, err := handler(ctx, request)
@@ -260,7 +260,7 @@ func TestGetJobsPagination(t *testing.T) {
 
 	t.Run("first page", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"page":          float64(1),
@@ -285,7 +285,7 @@ func TestGetJobsPagination(t *testing.T) {
 
 	t.Run("second page", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"page":          float64(2),
@@ -310,7 +310,7 @@ func TestGetJobsPagination(t *testing.T) {
 
 	t.Run("last page", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"page":          float64(3),
@@ -333,7 +333,7 @@ func TestGetJobsPagination(t *testing.T) {
 
 	t.Run("page beyond available data", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"page":          float64(5),
@@ -377,7 +377,7 @@ func TestGetJobsAgentInfo(t *testing.T) {
 
 	t.Run("default behavior excludes detailed agent info", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 		})
@@ -393,7 +393,7 @@ func TestGetJobsAgentInfo(t *testing.T) {
 
 	t.Run("include_agent=false excludes detailed agent info", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"include_agent": false,
@@ -414,7 +414,7 @@ func TestGetJobsAgentInfo(t *testing.T) {
 
 	t.Run("include_agent=true includes detailed agent info", func(t *testing.T) {
 		request := createMCPRequest(t, map[string]any{
-			"org":           "org",
+			"org_slug":      "org",
 			"pipeline_slug": "pipeline",
 			"build_number":  "1",
 			"include_agent": true,
@@ -466,7 +466,7 @@ func TestGetJobsPaginationWithFilter(t *testing.T) {
 
 	// Test pagination with state filter - should have 4 "passed" jobs total
 	requestPassedPaginated := createMCPRequest(t, map[string]any{
-		"org":           "org",
+		"org_slug":      "org",
 		"pipeline_slug": "pipeline",
 		"build_number":  "1",
 		"job_state":     "passed",
@@ -516,7 +516,7 @@ func TestGetJobLogs(t *testing.T) {
 
 		// Test missing pipeline_slug parameter
 		req = createMCPRequest(t, map[string]any{
-			"org":          "test-org",
+			"org_slug":     "test-org",
 			"build_number": "123",
 			"job_uuid":     "job-123",
 		})
@@ -527,7 +527,7 @@ func TestGetJobLogs(t *testing.T) {
 
 		// Test missing build_number parameter
 		req = createMCPRequest(t, map[string]any{
-			"org":           "test-org",
+			"org_slug":      "test-org",
 			"pipeline_slug": "test-pipeline",
 			"job_uuid":      "job-123",
 		})
@@ -538,7 +538,7 @@ func TestGetJobLogs(t *testing.T) {
 
 		// Test missing job_uuid parameter
 		req = createMCPRequest(t, map[string]any{
-			"org":           "test-org",
+			"org_slug":      "test-org",
 			"pipeline_slug": "test-pipeline",
 			"build_number":  "123",
 		})

--- a/pkg/buildkite/organizations.go
+++ b/pkg/buildkite/organizations.go
@@ -19,8 +19,7 @@ func UserTokenOrganization(client OrganizationsClient) (tool mcp.Tool, handler s
 	return mcp.NewTool("user_token_organization",
 			mcp.WithDescription("Get the organization associated with the user token used for this request"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Organization for User Token",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Organization for User Token",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.UserTokenOrganization")

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -21,7 +21,7 @@ type PipelinesClient interface {
 }
 
 type ListPipelinesArgs struct {
-	Org         string `json:"org"`
+	OrgSlug     string `json:"org_slug"`
 	Name        string `json:"name"`
 	Repository  string `json:"repository"`
 	Page        int    `json:"page"`
@@ -32,9 +32,8 @@ type ListPipelinesArgs struct {
 func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListPipelinesArgs]) {
 	return mcp.NewTool("list_pipelines",
 			mcp.WithDescription("List all pipelines in an organization with their basic details, build counts, and current status"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("name",
 				mcp.Description("Filter pipelines by name"),
@@ -47,15 +46,14 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 			),
 			withPagination(),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "List Pipelines",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "List Pipelines",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest, args ListPipelinesArgs) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListPipelines")
 			defer span.End()
 
-			if args.Org == "" {
-				return mcp.NewToolResultError("org is required"), nil
+			if args.OrgSlug == "" {
+				return mcp.NewToolResultError("org_slug is required"), nil
 			}
 
 			// Set defaults
@@ -70,7 +68,7 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 			}
 
 			span.SetAttributes(
-				attribute.String("org", args.Org),
+				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("name_filter", args.Name),
 				attribute.String("repository_filter", args.Repository),
 				attribute.String("detail_level", args.DetailLevel),
@@ -78,7 +76,7 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 				attribute.Int("per_page", args.PerPage),
 			)
 
-			pipelines, resp, err := client.List(ctx, args.Org, &buildkite.PipelineListOptions{
+			pipelines, resp, err := client.List(ctx, args.OrgSlug, &buildkite.PipelineListOptions{
 				ListOptions: buildkite.ListOptions{
 					Page:    args.Page,
 					PerPage: args.PerPage,
@@ -119,7 +117,7 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 }
 
 type GetPipelineArgs struct {
-	Org          string `json:"org"`
+	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	DetailLevel  string `json:"detail_level"` // "summary", "detailed", "full"
 }
@@ -127,28 +125,25 @@ type GetPipelineArgs struct {
 func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetPipelineArgs]) {
 	return mcp.NewTool("get_pipeline",
 			mcp.WithDescription("Get detailed information about a specific pipeline including its configuration, steps, environment variables, and build statistics"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline"),
 			),
 			mcp.WithString("detail_level",
 				mcp.Description("Response detail level: 'summary', 'detailed', or 'full' (default)"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Pipeline",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Pipeline",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest, args GetPipelineArgs) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetPipeline")
 			defer span.End()
 
-			if args.Org == "" {
-				return mcp.NewToolResultError("org is required"), nil
+			if args.OrgSlug == "" {
+				return mcp.NewToolResultError("org_slug is required"), nil
 			}
 			if args.PipelineSlug == "" {
 				return mcp.NewToolResultError("pipeline_slug is required"), nil
@@ -160,12 +155,12 @@ func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHa
 			}
 
 			span.SetAttributes(
-				attribute.String("org", args.Org),
+				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("detail_level", args.DetailLevel),
 			)
 
-			pipeline, _, err := client.Get(ctx, args.Org, args.PipelineSlug)
+			pipeline, _, err := client.Get(ctx, args.OrgSlug, args.PipelineSlug)
 			if err != nil {
 				var errResp *buildkite.ErrorResponse
 				if errors.As(err, &errResp) {
@@ -299,27 +294,22 @@ func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToo
 			mcp.WithDescription("Set up a new CI/CD pipeline in Buildkite with YAML configuration, repository connection, and cluster assignment"),
 			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline. This is used to determine where to create the pipeline"),
+				mcp.Description("The organization slug"),
 			),
 			mcp.WithString("name",
 				mcp.Required(),
-				mcp.Description("The name of the pipeline"),
 			),
 			mcp.WithString("repository_url",
 				mcp.Required(),
-				mcp.Description("The Git repository URL to use for the pipeline"),
 			),
 			mcp.WithString("cluster_id",
 				mcp.Required(),
-				mcp.Description("The ID value of the cluster the pipeline will be associated with"),
 			),
 			mcp.WithString("configuration",
 				mcp.Required(),
 				mcp.Description("The pipeline configuration in YAML format. Contains the build steps and pipeline settings. If not provided, a basic configuration will be used"),
 			),
-			mcp.WithString("description",
-				mcp.Description("The description of the pipeline"),
-			),
+			mcp.WithString("description"),
 			mcp.WithString("default_branch",
 				mcp.Description("The default branch for builds and metrics filtering"),
 			),
@@ -426,27 +416,19 @@ func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[
 			mcp.WithDescription("Modify an existing Buildkite pipeline's configuration, repository, settings, or metadata"),
 			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the pipeline. This is used to determine where to update the pipeline"),
 			),
 			mcp.WithString("pipeline_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the pipeline to update"),
 			),
-			mcp.WithString("name",
-				mcp.Description("The name of the pipeline"),
-			),
+			mcp.WithString("name"),
 			mcp.WithString("repository_url",
 				mcp.Description("The Git repository URL to use for the pipeline"),
 			),
-			mcp.WithString("cluster_id",
-				mcp.Description("The ID value of the cluster the pipeline will be associated with"),
-			),
+			mcp.WithString("cluster_id"),
 			mcp.WithString("configuration",
 				mcp.Description("The pipeline configuration in YAML format. Contains the build steps and pipeline settings. If not provided, the existing configuration will be used"),
 			),
-			mcp.WithString("description",
-				mcp.Description("The description of the pipeline"),
-			),
+			mcp.WithString("description"),
 			mcp.WithString("default_branch",
 				mcp.Description("The default branch for builds and metrics filtering"),
 			),

--- a/pkg/buildkite/pipelines_test.go
+++ b/pkg/buildkite/pipelines_test.go
@@ -74,7 +74,7 @@ func TestListPipelines(t *testing.T) {
 	request := createMCPRequest(t, map[string]any{})
 
 	args := ListPipelinesArgs{
-		Org: "org",
+		OrgSlug: "org",
 	}
 
 	result, err := handler(ctx, request, args)
@@ -111,7 +111,7 @@ func TestGetPipeline(t *testing.T) {
 	request := createMCPRequest(t, map[string]any{})
 
 	args := GetPipelineArgs{
-		Org:          "org",
+		OrgSlug:      "org",
 		PipelineSlug: "pipeline",
 	}
 

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -21,32 +21,28 @@ type TestExecutionsClient interface {
 func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_failed_executions",
 			mcp.WithDescription("Get failed test executions for a specific test run in Buildkite Test Engine. Optionally get the expanded failure details such as full error messages and stack traces."),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the test suite"),
 			),
 			mcp.WithString("test_suite_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the test suite the run belongs to"),
 			),
 			mcp.WithString("run_id",
 				mcp.Required(),
-				mcp.Description("The ID of the test run"),
 			),
 			mcp.WithBoolean("include_failure_expanded",
 				mcp.Description("Include the expanded failure details such as full error messages and stack traces. This can be used to explain and diganose the cause of test failures."),
 			),
 			withClientSidePagination(),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Failed Test Executions",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Failed Test Executions",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetFailedExecutions")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -67,7 +63,7 @@ func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handle
 			paginationParams := getClientSidePaginationParams(request)
 
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("test_suite_slug", testSuiteSlug),
 				attribute.String("run_id", runID),
 				attribute.Bool("include_failure_expanded", includeFailureExpanded),
@@ -79,7 +75,7 @@ func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handle
 				IncludeFailureExpanded: includeFailureExpanded,
 			}
 
-			failedExecutions, resp, err := client.GetFailedExecutions(ctx, org, testSuiteSlug, runID, options)
+			failedExecutions, resp, err := client.GetFailedExecutions(ctx, orgSlug, testSuiteSlug, runID, options)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -64,11 +64,13 @@ func TestGetFailedExecutions(t *testing.T) {
 	// Test tool properties
 	assert.Equal("get_failed_executions", tool.Name)
 	assert.Equal("Get failed test executions for a specific test run in Buildkite Test Engine. Optionally get the expanded failure details such as full error messages and stack traces.", tool.Description)
-	assert.True(*tool.Annotations.ReadOnlyHint)
+	if tool.Annotations.ReadOnlyHint != nil {
+		assert.True(*tool.Annotations.ReadOnlyHint)
+	}
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{
-		"org":                      "org",
+		"org_slug":                 "org",
 		"test_suite_slug":          "suite1",
 		"run_id":                   "run1",
 		"include_failure_expanded": true,
@@ -119,8 +121,8 @@ func TestGetFailedExecutionsMissingTestSuiteSlug(t *testing.T) {
 	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":    "org",
-		"run_id": "run1",
+		"org_slug": "org",
+		"run_id":   "run1",
 	})
 
 	result, err := handler(ctx, request)
@@ -138,7 +140,7 @@ func TestGetFailedExecutionsMissingRunID(t *testing.T) {
 	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 	})
 
@@ -161,7 +163,7 @@ func TestGetFailedExecutionsWithError(t *testing.T) {
 	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 	})
@@ -190,7 +192,7 @@ func TestGetFailedExecutionsHTTPError(t *testing.T) {
 	_, handler := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 	})
@@ -273,7 +275,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 
 	// Test first page with page size of 2
 	requestFirstPage := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 		"page":            float64(1),
@@ -297,7 +299,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 
 	// Test second page with page size of 2
 	requestSecondPage := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 		"page":            float64(2),
@@ -321,7 +323,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 
 	// Test last page
 	requestLastPage := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 		"page":            float64(3),
@@ -343,7 +345,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 
 	// Test page beyond available data
 	requestBeyond := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 		"page":            float64(5),
@@ -396,7 +398,7 @@ func TestGetFailedExecutionsLargePage(t *testing.T) {
 
 	// Test with page size larger than available data
 	requestLargePage := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 		"page":            float64(1),

--- a/pkg/buildkite/test_runs.go
+++ b/pkg/buildkite/test_runs.go
@@ -23,25 +23,22 @@ type TestRunsClient interface {
 func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("list_test_runs",
 			mcp.WithDescription("List all test runs for a test suite in Buildkite Test Engine"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the test suite"),
 			),
 			mcp.WithString("test_suite_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the test suite"),
 			),
 			withPagination(),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "List Test Runs",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "List Test Runs",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListTestRuns")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -57,7 +54,7 @@ func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHand
 			}
 
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("test_suite_slug", testSuiteSlug),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
@@ -67,7 +64,7 @@ func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHand
 				ListOptions: paginationParams,
 			}
 
-			testRuns, resp, err := client.List(ctx, org, testSuiteSlug, options)
+			testRuns, resp, err := client.List(ctx, orgSlug, testSuiteSlug, options)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -99,28 +96,24 @@ func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHand
 func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_test_run",
 			mcp.WithDescription("Get a specific test run in Buildkite Test Engine"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the test suite"),
 			),
 			mcp.WithString("test_suite_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the test suite"),
 			),
 			mcp.WithString("run_id",
 				mcp.Required(),
-				mcp.Description("The ID of the test run"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Test Run",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Test Run",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetTestRun")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -136,12 +129,12 @@ func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandle
 			}
 
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("test_suite_slug", testSuiteSlug),
 				attribute.String("run_id", runID),
 			)
 
-			testRun, resp, err := client.Get(ctx, org, testSuiteSlug, runID)
+			testRun, resp, err := client.Get(ctx, orgSlug, testSuiteSlug, runID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/buildkite/test_runs_test.go
+++ b/pkg/buildkite/test_runs_test.go
@@ -79,11 +79,13 @@ func TestListTestRuns(t *testing.T) {
 	// Test tool properties
 	assert.Equal("list_test_runs", tool.Name)
 	assert.Equal("List all test runs for a test suite in Buildkite Test Engine", tool.Description)
-	assert.True(*tool.Annotations.ReadOnlyHint)
+	if tool.Annotations.ReadOnlyHint != nil {
+		assert.True(*tool.Annotations.ReadOnlyHint)
+	}
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"page":            1,
 		"perPage":         30,
@@ -115,7 +117,7 @@ func TestListTestRunsWithError(t *testing.T) {
 	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 	})
 
@@ -152,7 +154,7 @@ func TestListTestRunsMissingTestSuiteSlug(t *testing.T) {
 	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org": "org",
+		"org_slug": "org",
 	})
 
 	result, err := handler(ctx, request)
@@ -188,11 +190,13 @@ func TestGetTestRun(t *testing.T) {
 	// Test tool properties
 	assert.Equal("get_test_run", tool.Name)
 	assert.Equal("Get a specific test run in Buildkite Test Engine", tool.Description)
-	assert.True(*tool.Annotations.ReadOnlyHint)
+	if tool.Annotations.ReadOnlyHint != nil {
+		assert.True(*tool.Annotations.ReadOnlyHint)
+	}
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 	})
@@ -221,7 +225,7 @@ func TestGetTestRunWithError(t *testing.T) {
 	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 	})
@@ -260,8 +264,8 @@ func TestGetTestRunMissingTestSuiteSlug(t *testing.T) {
 	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":    "org",
-		"run_id": "run1",
+		"org_slug": "org",
+		"run_id":   "run1",
 	})
 
 	result, err := handler(ctx, request)
@@ -279,7 +283,7 @@ func TestGetTestRunMissingRunID(t *testing.T) {
 	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 	})
 
@@ -307,7 +311,7 @@ func TestGetTestRunHTTPError(t *testing.T) {
 	_, handler := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 		"run_id":          "run1",
 	})
@@ -336,7 +340,7 @@ func TestListTestRunsHTTPError(t *testing.T) {
 	_, handler := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
-		"org":             "org",
+		"org_slug":        "org",
 		"test_suite_slug": "suite1",
 	})
 

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -21,28 +21,24 @@ type TestsClient interface {
 func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("get_test",
 			mcp.WithDescription("Get a specific test in Buildkite Test Engine. This provides additional metadata for failed test executions"),
-			mcp.WithString("org",
+			mcp.WithString("org_slug",
 				mcp.Required(),
-				mcp.Description("The organization slug for the owner of the test suite"),
 			),
 			mcp.WithString("test_suite_slug",
 				mcp.Required(),
-				mcp.Description("The slug of the test suite"),
 			),
 			mcp.WithString("test_id",
 				mcp.Required(),
-				mcp.Description("The ID of the test"),
 			),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Test",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Test",
 			}),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.GetTest")
 			defer span.End()
 
-			org, err := request.RequireString("org")
+			orgSlug, err := request.RequireString("org_slug")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -58,12 +54,12 @@ func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc)
 			}
 
 			span.SetAttributes(
-				attribute.String("org", org),
+				attribute.String("org_slug", orgSlug),
 				attribute.String("test_suite_slug", testSuiteSlug),
 				attribute.String("test_id", testID),
 			)
 
-			test, resp, err := client.Get(ctx, org, testSuiteSlug, testID)
+			test, resp, err := client.Get(ctx, orgSlug, testSuiteSlug, testID)
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -52,12 +52,12 @@ func TestGetTest(t *testing.T) {
 
 	// Test required parameters
 	params := tool.InputSchema.Properties
-	assert.Contains(params, "org")
+	assert.Contains(params, "org_slug")
 	assert.Contains(params, "test_suite_slug")
 	assert.Contains(params, "test_id")
 
 	// Verify org is required
-	orgParam := params["org"].(map[string]interface{})
+	orgParam := params["org_slug"].(map[string]interface{})
 	assert.Equal("string", orgParam["type"])
 
 	// Verify test_suite_slug is required

--- a/pkg/buildkite/user.go
+++ b/pkg/buildkite/user.go
@@ -19,8 +19,7 @@ func CurrentUser(client UserClient) (tool mcp.Tool, handler server.ToolHandlerFu
 	return mcp.NewTool("current_user",
 			mcp.WithDescription("Get details about the user account that owns the API token, including name, email, avatar, and account creation date"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
-				Title:        "Get Current User",
-				ReadOnlyHint: mcp.ToBoolPtr(true),
+				Title: "Get Current User",
 			}),
 		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			ctx, span := trace.Start(ctx, "buildkite.CurrentUser")


### PR DESCRIPTION
org_slug doesn't need a description saying "the orginisation slug for the pipeline".
