### PR TITLE
docs: add Toolhive deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,25 @@ Local binary, with the [Job Log Token Threshold](#job-log-token-threshold) flag 
 </details>
 
 <details>
+<summary><a href="https://toolhive.dev">Toolhive</a></summary>
+
+The Buildkite MCP server is packaged and available in the Toolhive registry.
+
+Before running the server, store your API token as a secret:
+
+```bash
+cat ~/path/to/your/buildkite-api-token.txt | thv secret set buildkite-api-key
+```
+
+Run the server:
+
+```bash
+thv run --secret buildkite-api-key,target=BUILDKITE_API_TOKEN buildkite
+```
+
+</details>
+
+<details>
 <summary>Zed</summary>
 
 There is a Zed [editor extension](https://zed.dev) available in the [official extension gallery](https://zed.dev/extensions?query=buildkite). During installation it will ask for an API token which will be added to your settings.


### PR DESCRIPTION
This PR adds instructions for deploying the Buildkite MCP server using Toolhive.

## Changes
- Add Toolhive section to Configuration & Usage in README.md
- Include instructions for storing API token as secret using \`thv secret set\`
- Add command to run Buildkite MCP server via Toolhive registry using \`thv run\`
- Maintain consistent formatting with other client configurations

## Context
Toolhive simplifies MCP server deployment by running them in secure containers. The Buildkite MCP server is packaged and available in the Toolhive registry, making it easy for users to get started without dealing with Docker setup or manual binary installation.

The instructions follow the same concise format as other client configurations in the README.