### PR TITLE
feat: add token tracking to otel and some cleanup of http errors

### DIFF
--- a/pkg/buildkite/joblogs.go
+++ b/pkg/buildkite/joblogs.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	buildkitelogs "github.com/buildkite/buildkite-logs"
+	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/mark3labs/mcp-go/mcp"
 	"go.opentelemetry.io/otel/attribute"
@@ -262,6 +263,11 @@ func SearchLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToo
 				return nil, fmt.Errorf("failed to marshal search results: %w", err)
 			}
 
+			span.SetAttributes(
+				attribute.Int("item_count", len(results)),
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
+
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }
@@ -358,6 +364,11 @@ func TailLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolH
 				return nil, fmt.Errorf("failed to marshal tail results: %w", err)
 			}
 
+			span.SetAttributes(
+				attribute.Int("item_count", len(entries)),
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
+
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }
@@ -436,6 +447,10 @@ func GetLogsInfo(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedTo
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal file info: %w", err)
 			}
+
+			span.SetAttributes(
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
 
 			return mcp.NewToolResultText(string(r)), nil
 		}
@@ -536,6 +551,11 @@ func ReadLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolH
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal read results: %w", err)
 			}
+
+			span.SetAttributes(
+				attribute.Int("item_count", len(entries)),
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
 
 			return mcp.NewToolResultText(string(r)), nil
 		}

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -113,6 +114,11 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 				return nil, fmt.Errorf("failed to marshal pipelines: %w", err)
 			}
 
+			span.SetAttributes(
+				attribute.Int("item_count", len(pipelines)),
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
+
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }
@@ -188,6 +194,10 @@ func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHa
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal pipeline: %w", err)
 			}
+
+			span.SetAttributes(
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
 
 			return mcp.NewToolResultText(string(r)), nil
 		}
@@ -395,6 +405,10 @@ func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToo
 				return nil, fmt.Errorf("failed to marshal issue: %w", err)
 			}
 
+			span.SetAttributes(
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
+
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }
@@ -510,6 +524,11 @@ func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal pipeline: %w", err)
 			}
+
+			span.SetAttributes(
+				attribute.Int("estimated_tokens", tokens.EstimateTokens(string(r))),
+			)
+
 			return mcp.NewToolResultText(string(r)), nil
 		}
 }

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -180,12 +180,18 @@ func TestGetFailedExecutionsHTTPError(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{
 		GetFailedExecutionsFunc: func(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			return []buildkite.FailedExecution{}, &buildkite.Response{
-				Response: &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader("Failed executions not found")),
+			resp := &http.Response{
+				Request: &http.Request{
+					Method: "GET",
+					URL:    nil,
 				},
-			}, nil
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(strings.NewReader("Failed executions not found")),
+			}
+
+			return []buildkite.FailedExecution{}, &buildkite.Response{
+				Response: resp,
+			}, &buildkite.ErrorResponse{Response: resp, Message: "Failed executions not found"}
 		},
 	}
 

--- a/pkg/buildkite/test_runs_test.go
+++ b/pkg/buildkite/test_runs_test.go
@@ -328,12 +328,14 @@ func TestListTestRunsHTTPError(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{
 		ListFunc: func(ctx context.Context, org, slug string, opt *buildkite.TestRunsListOptions) ([]buildkite.TestRun, *buildkite.Response, error) {
+			resp := &http.Response{
+				Request:    &http.Request{Method: "GET"},
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("Access denied")),
+			}
 			return []buildkite.TestRun{}, &buildkite.Response{
-				Response: &http.Response{
-					StatusCode: http.StatusForbidden,
-					Body:       io.NopCloser(strings.NewReader("Access denied")),
-				},
-			}, nil
+				Response: resp,
+			}, &buildkite.ErrorResponse{Response: resp, Message: "Access denied"}
 		},
 	}
 


### PR DESCRIPTION
This enables tracking of token use across tools using OTEL.

I have also gone through and removed some duplicate status checking, the underlying go-buildkite library already does this and returns an error structure for it, I also updated the tests verifying this behaviour. 