### PR TITLE
fix: downgrade go-buildkite as there is currently an issue in clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.5
 require (
 	github.com/alecthomas/kong v1.12.1
 	github.com/buildkite/buildkite-logs v0.6.1
-	github.com/buildkite/go-buildkite/v4 v4.6.0
+	github.com/buildkite/go-buildkite/v4 v4.5.1
 	github.com/buildkite/terminal-to-html/v3 v3.16.8
 	github.com/cenkalti/backoff/v5 v5.0.2
 	github.com/huantt/plaintext-extractor v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/buildkite/buildkite-logs v0.6.1 h1:5SlAsAFYKy1rl3j7GNldgeOzBMbuKYSgdFlvNnVINEs=
 github.com/buildkite/buildkite-logs v0.6.1/go.mod h1:ejxwp0IDk7Wd0yTH0Cvnw8GgRGnpboe6Up4k9SGmWTg=
-github.com/buildkite/go-buildkite/v4 v4.6.0 h1:9CSR/ENA5pc1rqp1fjlybKeG3VAKsLN8qCiNzvUAQW8=
-github.com/buildkite/go-buildkite/v4 v4.6.0/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
+github.com/buildkite/go-buildkite/v4 v4.5.1 h1:45Vgtua5PlZwaaHiI0i7Zz9icOS8PTHkW1YIetpf7Xs=
+github.com/buildkite/go-buildkite/v4 v4.5.1/go.mod h1:fMPu+/7hXzJ7Gy3HpGuVCLgeHqzDdrgHuwQvt8p370I=
 github.com/buildkite/terminal-to-html/v3 v3.16.8 h1:QN/daUob6cmK8GcdKnwn9+YTlPr1vNj+oeAIiJK6fPc=
 github.com/buildkite/terminal-to-html/v3 v3.16.8/go.mod h1:+k1KVKROZocrTLsEQ9PEf9A+8+X8uaVV5iO1ZIOwKYM=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
When I list clusters using v4.6.0 I get an error when unmarshalling.

> json: cannot unmarshal object into Go struct field Cluster.maintainers of type []buildkite.ClusterMaintainer

This was introduced in https://github.com/buildkite/go-buildkite/pull/240 so I am going to just downgrade while figuring out how to resolve it.
