### PR TITLE
feat: this adds toolsets with optional dynamic tools as well

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,12 @@ formatters:
       sections:
         - standard
         - default
+    gofmt:
+      rewrite-rules:
+        - pattern: "interface{}"
+          replacement: "any"
+        - pattern: "a[b:len(a)]"
+          replacement: "a[b:]"
   exclusions:
     generated: lax
     paths:

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/buildkite/buildkite-mcp-server/internal/toolsets"
 	"github.com/buildkite/buildkite-mcp-server/pkg/config"
 	"github.com/buildkite/buildkite-mcp-server/pkg/server"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -15,13 +16,21 @@ import (
 )
 
 type HTTPCmd struct {
-	Listen        string `help:"The address to listen on." default:"localhost:3000" env:"HTTP_LISTEN_ADDR"`
-	UseSSE        bool   `help:"Use deprecated SSS transport instead of Streamable HTTP." default:"false"`
-	config.Config        // embed configuration options for http server
+	Listen          string   `help:"The address to listen on." default:"localhost:3000" env:"HTTP_LISTEN_ADDR"`
+	UseSSE          bool     `help:"Use deprecated SSS transport instead of Streamable HTTP." default:"false"`
+	EnabledToolsets []string `help:"Comma-separated list of toolsets to enable (e.g., 'pipelines,builds,clusters'). Use 'all' to enable all toolsets." default:"all" env:"BUILDKITE_TOOLSETS"`
+	ReadOnly        bool     `help:"Enable read-only mode, which filters out write operations from all toolsets." default:"false" env:"BUILDKITE_READ_ONLY"`
+	config.Config            // embed configuration options for http server
 }
 
 func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
-	mcpServer := server.NewMCPServerWithConfig(globals.Version, globals.Client, globals.BuildkiteLogsClient, &c.Config)
+	// Validate the enabled toolsets
+	if err := toolsets.ValidateToolsets(c.EnabledToolsets); err != nil {
+		return err
+	}
+
+	mcpServer := server.NewMCPServer(globals.Version, globals.Client, globals.BuildkiteLogsClient,
+		server.WithReadOnly(c.ReadOnly), server.WithToolsets(c.EnabledToolsets...))
 
 	listener, err := net.Listen("tcp", c.Listen)
 	if err != nil {

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/buildkite/buildkite-mcp-server/pkg/config"
 	"github.com/buildkite/buildkite-mcp-server/pkg/server"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog/log"
@@ -14,12 +15,13 @@ import (
 )
 
 type HTTPCmd struct {
-	Listen string `help:"The address to listen on." default:"localhost:3000" env:"HTTP_LISTEN_ADDR"`
-	UseSSE bool   `help:"Use deprecated SSS transport instead of Streamable HTTP." default:"false"`
+	Listen        string `help:"The address to listen on." default:"localhost:3000" env:"HTTP_LISTEN_ADDR"`
+	UseSSE        bool   `help:"Use deprecated SSS transport instead of Streamable HTTP." default:"false"`
+	config.Config        // embed configuration options for http server
 }
 
 func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
-	mcpServer := server.NewMCPServer(globals.Version, globals.Client, globals.BuildkiteLogsClient)
+	mcpServer := server.NewMCPServerWithConfig(globals.Version, globals.Client, globals.BuildkiteLogsClient, &c.Config)
 
 	listener, err := net.Listen("tcp", c.Listen)
 	if err != nil {

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -13,7 +13,12 @@ type StdioCmd struct {
 }
 
 func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
-	s := server.NewMCPServer(globals.Version, globals.Client, globals.BuildkiteLogsClient)
+	// Parse toolsets from string if provided via CLI
+	if len(c.EnabledToolsets) == 1 && c.EnabledToolsets[0] != "all" {
+		c.ParseToolsets(c.EnabledToolsets[0])
+	}
+
+	s := server.NewMCPServerWithConfig(globals.Version, globals.Client, globals.BuildkiteLogsClient, &c.Config)
 
 	return mcpserver.ServeStdio(s,
 		mcpserver.WithStdioContextFunc(

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -3,22 +3,26 @@ package commands
 import (
 	"context"
 
+	"github.com/buildkite/buildkite-mcp-server/internal/toolsets"
 	"github.com/buildkite/buildkite-mcp-server/pkg/config"
 	"github.com/buildkite/buildkite-mcp-server/pkg/server"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 )
 
 type StdioCmd struct {
-	config.Config // embed configuration options for stdio server
+	EnabledToolsets []string `help:"Comma-separated list of toolsets to enable (e.g., 'pipelines,builds,clusters'). Use 'all' to enable all toolsets." default:"all" env:"BUILDKITE_TOOLSETS"`
+	ReadOnly        bool     `help:"Enable read-only mode, which filters out write operations from all toolsets." default:"false" env:"BUILDKITE_READ_ONLY"`
+	config.Config            // embed configuration options for stdio server
 }
 
 func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
-	// Parse toolsets from string if provided via CLI
-	if len(c.EnabledToolsets) == 1 && c.EnabledToolsets[0] != "all" {
-		c.ParseToolsets(c.EnabledToolsets[0])
+	// Validate the enabled toolsets
+	if err := toolsets.ValidateToolsets(c.EnabledToolsets); err != nil {
+		return err
 	}
 
-	s := server.NewMCPServerWithConfig(globals.Version, globals.Client, globals.BuildkiteLogsClient, &c.Config)
+	s := server.NewMCPServer(globals.Version, globals.Client, globals.BuildkiteLogsClient,
+		server.WithReadOnly(c.ReadOnly), server.WithToolsets(c.EnabledToolsets...))
 
 	return mcpserver.ServeStdio(s,
 		mcpserver.WithStdioContextFunc(

--- a/internal/commands/tools.go
+++ b/internal/commands/tools.go
@@ -17,7 +17,7 @@ func (c *ToolsCmd) Run(ctx context.Context, globals *Globals) error {
 	client := &gobuildkite.Client{}
 
 	// Collect all tools (pass nil for ParquetClient since this is just for listing)
-	tools := server.BuildkiteTools(client, nil)
+	tools := server.BuildkiteTools(client, nil, server.WithToolsets("all"))
 
 	for _, tool := range tools {
 

--- a/internal/tools/toolsets.go
+++ b/internal/tools/toolsets.go
@@ -1,0 +1,498 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+
+	buildkitelogs "github.com/buildkite/buildkite-logs"
+	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	gobuildkite "github.com/buildkite/go-buildkite/v4"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// ToolDefinition wraps an MCP tool with additional metadata
+type ToolDefinition struct {
+	Tool           mcp.Tool
+	Handler        server.ToolHandlerFunc
+	RequiredScopes []string // Buildkite API token scopes required for this tool
+}
+
+// IsReadOnly returns true if the tool is read-only
+func (td ToolDefinition) IsReadOnly() bool {
+	if td.Tool.Annotations.ReadOnlyHint == nil {
+		return false
+	}
+	return *td.Tool.Annotations.ReadOnlyHint
+}
+
+// Toolset represents a logical grouping of related tools
+type Toolset struct {
+	Name        string
+	Description string
+	Tools       []ToolDefinition
+}
+
+// GetReadOnlyTools returns only the read-only tools from this toolset
+func (ts Toolset) GetReadOnlyTools() []ToolDefinition {
+	var readOnlyTools []ToolDefinition
+	for _, tool := range ts.Tools {
+		if tool.IsReadOnly() {
+			readOnlyTools = append(readOnlyTools, tool)
+		}
+	}
+	return readOnlyTools
+}
+
+// GetAllTools returns all tools from this toolset
+func (ts Toolset) GetAllTools() []ToolDefinition {
+	return ts.Tools
+}
+
+// GetRequiredScopes returns all unique scopes required by tools in this toolset
+func (ts Toolset) GetRequiredScopes() []string {
+	scopeMap := make(map[string]bool)
+	for _, tool := range ts.Tools {
+		for _, scope := range tool.RequiredScopes {
+			scopeMap[scope] = true
+		}
+	}
+
+	scopes := make([]string, 0, len(scopeMap))
+	for scope := range scopeMap {
+		scopes = append(scopes, scope)
+	}
+	slices.Sort(scopes)
+	return scopes
+}
+
+// ToolsetRegistry manages the registration and discovery of toolsets
+type ToolsetRegistry struct {
+	toolsets map[string]Toolset
+}
+
+// NewToolsetRegistry creates a new toolset registry
+func NewToolsetRegistry() *ToolsetRegistry {
+	return &ToolsetRegistry{
+		toolsets: make(map[string]Toolset),
+	}
+}
+
+// Register adds a toolset to the registry
+func (tr *ToolsetRegistry) Register(name string, toolset Toolset) {
+	tr.toolsets[name] = toolset
+}
+
+// Get retrieves a toolset by name
+func (tr *ToolsetRegistry) Get(name string) (Toolset, bool) {
+	toolset, exists := tr.toolsets[name]
+	return toolset, exists
+}
+
+// List returns all registered toolset names
+func (tr *ToolsetRegistry) List() []string {
+	names := make([]string, 0, len(tr.toolsets))
+	for name := range tr.toolsets {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// GetEnabledTools returns tools from enabled toolsets, optionally filtering for read-only
+func (tr *ToolsetRegistry) GetEnabledTools(enabledToolsets []string, readOnlyMode bool) []ToolDefinition {
+	var tools []ToolDefinition
+
+	// If "all" is specified, enable all toolsets
+	if slices.Contains(enabledToolsets, "all") {
+		enabledToolsets = tr.List()
+	}
+
+	for _, toolsetName := range enabledToolsets {
+		if toolset, exists := tr.toolsets[toolsetName]; exists {
+			if readOnlyMode {
+				tools = append(tools, toolset.GetReadOnlyTools()...)
+			} else {
+				tools = append(tools, toolset.GetAllTools()...)
+			}
+		}
+	}
+
+	return tools
+}
+
+// ToolsetMetadata provides information about a toolset for introspection
+type ToolsetMetadata struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	ToolCount     int    `json:"tool_count"`
+	ReadOnlyCount int    `json:"read_only_count"`
+}
+
+// GetMetadata returns metadata for all registered toolsets
+func (tr *ToolsetRegistry) GetMetadata() []ToolsetMetadata {
+	metadata := make([]ToolsetMetadata, 0, len(tr.toolsets))
+
+	for name, toolset := range tr.toolsets {
+		readOnlyCount := len(toolset.GetReadOnlyTools())
+		metadata = append(metadata, ToolsetMetadata{
+			Name:          name,
+			Description:   toolset.Description,
+			ToolCount:     len(toolset.Tools),
+			ReadOnlyCount: readOnlyCount,
+		})
+	}
+
+	// Sort by name for consistency
+	slices.SortFunc(metadata, func(a, b ToolsetMetadata) int {
+		if a.Name < b.Name {
+			return -1
+		} else if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+
+	return metadata
+}
+
+// GetRequiredScopes returns all unique scopes required by enabled toolsets
+func (tr *ToolsetRegistry) GetRequiredScopes(enabledToolsets []string, readOnlyMode bool) []string {
+	scopeMap := make(map[string]bool)
+
+	// If "all" is specified, enable all toolsets
+	if slices.Contains(enabledToolsets, "all") {
+		enabledToolsets = tr.List()
+	}
+
+	for _, toolsetName := range enabledToolsets {
+		if toolset, exists := tr.toolsets[toolsetName]; exists {
+			var tools []ToolDefinition
+			if readOnlyMode {
+				tools = toolset.GetReadOnlyTools()
+			} else {
+				tools = toolset.GetAllTools()
+			}
+
+			for _, tool := range tools {
+				for _, scope := range tool.RequiredScopes {
+					scopeMap[scope] = true
+				}
+			}
+		}
+	}
+
+	scopes := make([]string, 0, len(scopeMap))
+	for scope := range scopeMap {
+		scopes = append(scopes, scope)
+	}
+	slices.Sort(scopes)
+	return scopes
+}
+
+// NewTool creates a new tool definition with annotations based on access level
+func NewTool(tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) ToolDefinition {
+	return ToolDefinition{
+		Tool:           tool,
+		Handler:        handler,
+		RequiredScopes: scopes,
+	}
+}
+
+// CreateBuiltinToolsets creates the default toolsets with all available tools
+func CreateBuiltinToolsets(client *gobuildkite.Client, buildkiteLogsClient *buildkitelogs.Client) map[string]Toolset {
+	// Create a client adapter for artifact tools
+	clientAdapter := &buildkite.BuildkiteClientAdapter{Client: client}
+
+	return map[string]Toolset{
+		"clusters": {
+			Name:        "Cluster Management",
+			Description: "Tools for managing Buildkite clusters and cluster queues",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.GetCluster(client.Clusters) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.ListClusters(client.Clusters) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					return buildkite.GetClusterQueue(client.ClusterQueues)
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					return buildkite.ListClusterQueues(client.ClusterQueues)
+				}),
+			},
+		},
+		"pipelines": {
+			Name:        "Pipeline Management",
+			Description: "Tools for managing Buildkite pipelines",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.GetPipeline(client.Pipelines)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.ListPipelines(client.Pipelines)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.CreatePipeline(client.Pipelines)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.UpdatePipeline(client.Pipelines)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+			},
+		},
+		"builds": {
+			Name:        "Build Operations",
+			Description: "Tools for managing builds and jobs",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.ListBuilds(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.GetBuild(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.GetBuildTestEngineRuns(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.CreateBuild(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.WaitForBuild(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.GetJobs(client.Builds)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.UnblockJob(client.Jobs)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+			},
+		},
+		"artifacts": {
+			Name:        "Artifact Management",
+			Description: "Tools for managing build artifacts",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.ListArtifacts(clientAdapter) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.GetArtifact(clientAdapter) }),
+			},
+		},
+		"tests": {
+			Name:        "Test Engine",
+			Description: "Tools for managing test runs and test results",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.ListTestRuns(client.TestRuns) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.GetTestRun(client.TestRuns) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					return buildkite.GetFailedTestExecutions(client.TestRuns)
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.GetTest(client.Tests) }),
+			},
+		},
+		"logs": {
+			Name:        "Log Management",
+			Description: "Tools for searching, reading, and analyzing job logs",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.SearchLogs(buildkiteLogsClient)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.TailLogs(buildkiteLogsClient)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.GetLogsInfo(buildkiteLogsClient)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					tool, handler, scopes := buildkite.ReadLogs(buildkiteLogsClient)
+					return tool, mcp.NewTypedToolHandler(handler), scopes
+				}),
+			},
+		},
+		"annotations": {
+			Name:        "Annotation Management",
+			Description: "Tools for managing build annotations",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					return buildkite.ListAnnotations(client.Annotations)
+				}),
+			},
+		},
+		"user": {
+			Name:        "User & Organization",
+			Description: "Tools for user and organization information",
+			Tools: []ToolDefinition{
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.CurrentUser(client.User) }),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
+					return buildkite.UserTokenOrganization(client.Organizations)
+				}),
+				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) { return buildkite.AccessToken(client.AccessTokens) }),
+			},
+		},
+	}
+}
+
+// newToolFromFunc creates a new ToolDefinition from a function that returns (tool, handler, scopes)
+func newToolFromFunc(toolFunc func() (mcp.Tool, server.ToolHandlerFunc, []string)) ToolDefinition {
+	tool, handler, scopes := toolFunc()
+	return NewTool(tool, handler, scopes)
+}
+
+// CreateIntrospectionTools creates tools for toolset discovery and introspection
+func CreateIntrospectionTools(registry *ToolsetRegistry) []ToolDefinition {
+	return []ToolDefinition{
+		NewTool(
+			mcp.NewTool("list_toolsets",
+				mcp.WithDescription("List all available toolsets with their descriptions and tool counts"),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:        "List Toolsets",
+					ReadOnlyHint: mcp.ToBoolPtr(true),
+				}),
+			),
+			func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				metadata := registry.GetMetadata()
+
+				result := map[string]any{
+					"toolsets":       metadata,
+					"total_toolsets": len(metadata),
+				}
+
+				jsonBytes, err := json.Marshal(result)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
+				}
+
+				return mcp.NewToolResultText(string(jsonBytes)), nil
+			},
+			[]string{},
+		),
+		NewTool(
+			mcp.NewTool("get_toolset_info",
+				mcp.WithDescription("Get detailed information about a specific toolset including its tools"),
+				mcp.WithString("toolset_name", mcp.Required()),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:        "Get Toolset Information",
+					ReadOnlyHint: mcp.ToBoolPtr(true),
+				}),
+			),
+			func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				toolsetName, err := request.RequireString("toolset_name")
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
+				}
+
+				toolset, exists := registry.Get(toolsetName)
+				if !exists {
+					return mcp.NewToolResultError("toolset not found: " + toolsetName), nil
+				}
+
+				// Convert tools to a serializable format
+				tools := make([]map[string]any, len(toolset.Tools))
+				readOnlyCount := 0
+				allScopes := make(map[string]bool)
+				for i, tool := range toolset.Tools {
+					isReadOnly := tool.IsReadOnly()
+					if isReadOnly {
+						readOnlyCount++
+					}
+					// Collect all unique scopes for this toolset
+					for _, scope := range tool.RequiredScopes {
+						allScopes[scope] = true
+					}
+					tools[i] = map[string]any{
+						"name":        tool.Tool.Name,
+						"description": tool.Tool.Description,
+						"read_only":   isReadOnly,
+						"scopes":      tool.RequiredScopes,
+					}
+				}
+
+				// Convert scope map to sorted slice
+				toolsetScopes := make([]string, 0, len(allScopes))
+				for scope := range allScopes {
+					toolsetScopes = append(toolsetScopes, scope)
+				}
+				slices.Sort(toolsetScopes)
+
+				result := map[string]any{
+					"name":            toolset.Name,
+					"description":     toolset.Description,
+					"tool_count":      len(toolset.Tools),
+					"read_only_count": readOnlyCount,
+					"required_scopes": toolsetScopes,
+					"tools":           tools,
+				}
+
+				jsonBytes, err := json.Marshal(result)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
+				}
+
+				return mcp.NewToolResultText(string(jsonBytes)), nil
+			},
+			[]string{},
+		),
+		NewTool(
+			mcp.NewTool("get_required_scopes",
+				mcp.WithDescription("Get the minimum Buildkite API token scopes required for a given toolset configuration"),
+				mcp.WithString("toolsets"),
+				mcp.WithString("read_only"),
+				mcp.WithToolAnnotation(mcp.ToolAnnotation{
+					Title:        "Get Required Scopes",
+					ReadOnlyHint: mcp.ToBoolPtr(true),
+				}),
+			),
+			func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				toolsetsStr, err := request.RequireString("toolsets")
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
+				}
+
+				readOnlyStr, _ := request.RequireString("read_only")
+				if readOnlyStr == "" {
+					readOnlyStr = "false" // default to false
+				}
+				readOnly := readOnlyStr == "true"
+
+				// Parse toolsets string
+				var enabledToolsets []string
+				if toolsetsStr == "all" {
+					enabledToolsets = []string{"all"}
+				} else {
+					enabledToolsets = strings.Split(toolsetsStr, ",")
+					for i, toolset := range enabledToolsets {
+						enabledToolsets[i] = strings.TrimSpace(toolset)
+					}
+				}
+
+				// Get required scopes
+				requiredScopes := registry.GetRequiredScopes(enabledToolsets, readOnly)
+
+				result := map[string]any{
+					"toolsets":        enabledToolsets,
+					"read_only_mode":  readOnly,
+					"required_scopes": requiredScopes,
+					"scope_count":     len(requiredScopes),
+				}
+
+				jsonBytes, err := json.Marshal(result)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), nil
+				}
+
+				return mcp.NewToolResultText(string(jsonBytes)), nil
+			},
+			[]string{},
+		),
+	}
+}

--- a/pkg/buildkite/access_token.go
+++ b/pkg/buildkite/access_token.go
@@ -13,7 +13,7 @@ type AccessTokenClient interface {
 	Get(ctx context.Context) (buildkite.AccessToken, *buildkite.Response, error)
 }
 
-func AccessToken(client AccessTokenClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func AccessToken(client AccessTokenClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("access_token",
 			mcp.WithDescription("Get information about the current API access token including its scopes and UUID"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
@@ -30,5 +30,5 @@ func AccessToken(client AccessTokenClient) (tool mcp.Tool, handler server.ToolHa
 			}
 
 			return mcpTextResult(span, &token)
-		}
+		}, []string{"read_user"}
 }

--- a/pkg/buildkite/access_token_test.go
+++ b/pkg/buildkite/access_token_test.go
@@ -53,7 +53,7 @@ func TestAccessToken(t *testing.T) {
 		},
 	}
 
-	tool, handler := AccessToken(client)
+	tool, handler, _ := AccessToken(client)
 	assert.NotNil(t, tool)
 	assert.NotNil(t, handler)
 

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -16,7 +16,7 @@ type AnnotationsClient interface {
 }
 
 // ListAnnotations returns an MCP tool + handler pair that lists annotations for a build.
-func ListAnnotations(client AnnotationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListAnnotations(client AnnotationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("list_annotations",
 			mcp.WithDescription("List all annotations for a build, including their context, style (success/info/warning/error), rendered HTML content, and creation timestamps"),
 			mcp.WithString("org_slug",
@@ -84,5 +84,5 @@ func ListAnnotations(client AnnotationsClient) (tool mcp.Tool, handler server.To
 			)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_builds"}
 }

--- a/pkg/buildkite/annotations_test.go
+++ b/pkg/buildkite/annotations_test.go
@@ -47,7 +47,7 @@ func TestListAnnotations(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListAnnotations(client)
+	tool, handler, _ := ListAnnotations(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 	request := createMCPRequest(t, map[string]any{

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -73,7 +73,7 @@ func (a *BuildkiteClientAdapter) rewriteArtifactURL(inputURL string) string {
 	return parsedURL.String()
 }
 
-func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("list_artifacts",
 			mcp.WithDescription("List all artifacts for a build across all jobs, including file details, paths, sizes, MIME types, and download URLs"),
 			mcp.WithString("org_slug",
@@ -147,10 +147,10 @@ func ListArtifacts(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHa
 			)
 
 			return mcp.NewToolResultText(string(r)), nil
-		}
+		}, []string{"read_artifacts"}
 }
 
-func GetArtifact(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetArtifact(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_artifact",
 			mcp.WithDescription("Get detailed information about a specific artifact including its metadata, file size, SHA-1 hash, and download URL"),
 			mcp.WithString("url",
@@ -193,5 +193,5 @@ func GetArtifact(client ArtifactsClient) (tool mcp.Tool, handler server.ToolHand
 			}
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_artifacts"}
 }

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -54,7 +54,7 @@ func TestListArtifacts(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListArtifacts(mockArtifactsClient)
+	tool, handler, _ := ListArtifacts(mockArtifactsClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -94,7 +94,7 @@ func TestGetArtifact(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetArtifact(client)
+	tool, handler, _ := GetArtifact(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -121,7 +121,7 @@ func TestListArtifacts_MissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockArtifactsClient{}
 
-	_, handler := ListArtifacts(client)
+	_, handler, _ := ListArtifacts(client)
 
 	// Test missing org parameter
 	req := createMCPRequest(t, map[string]any{
@@ -160,7 +160,7 @@ func TestGetArtifact_MissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockArtifactsClient{}
 
-	_, handler := GetArtifact(client)
+	_, handler, _ := GetArtifact(client)
 
 	// Test missing url parameter
 	req := createMCPRequest(t, map[string]any{})
@@ -188,7 +188,7 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 		},
 	}
 
-	_, handler := GetArtifact(client)
+	_, handler, _ := GetArtifact(client)
 
 	req := createMCPRequest(t, map[string]any{
 		"url": "https://example.com/nonexistent-artifact",

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -143,7 +143,7 @@ func createPaginatedBuildResult[T any](builds []buildkite.Build, converter func(
 	}
 }
 
-func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListBuildsArgs]) {
+func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListBuildsArgs], scopes []string) {
 	return mcp.NewTool("list_builds",
 			mcp.WithDescription("List all builds for a pipeline with their status, commit information, and metadata"),
 			mcp.WithString("org_slug",
@@ -288,10 +288,10 @@ func ListBuilds(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandle
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
-		}
+		}, []string{"read_builds"}
 }
 
-func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildTestEngineRunsArgs]) {
+func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildTestEngineRunsArgs], scopes []string) {
 	return mcp.NewTool("get_build_test_engine_runs",
 			mcp.WithDescription("Get test engine runs data for a specific build in Buildkite. This can be used to look up Test Runs."),
 			mcp.WithString("org_slug",
@@ -350,10 +350,10 @@ func GetBuildTestEngineRuns(client BuildsClient) (tool mcp.Tool, handler mcp.Typ
 			}
 
 			return mcpTextResult(span, &testEngineRuns)
-		}
+		}, []string{"read_builds"}
 }
 
-func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildArgs]) {
+func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetBuildArgs], scopes []string) {
 	return mcp.NewTool("get_build",
 			mcp.WithDescription("Get detailed information about a specific build including its jobs, timing, and execution details"),
 			mcp.WithString("org_slug",
@@ -431,7 +431,7 @@ func GetBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerF
 			}
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_builds"}
 }
 
 type Entry struct {
@@ -449,7 +449,7 @@ type CreateBuildArgs struct {
 	MetaData     []Entry `json:"metadata"`
 }
 
-func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreateBuildArgs]) {
+func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreateBuildArgs], scopes []string) {
 	return mcp.NewTool("create_build",
 			mcp.WithDescription("Trigger a new build on a Buildkite pipeline for a specific commit and branch, with optional environment variables, metadata, and author information"),
 			mcp.WithString("org_slug",
@@ -541,7 +541,7 @@ func CreateBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandl
 			}
 
 			return mcpTextResult(span, &build)
-		}
+		}, []string{"write_builds"}
 }
 
 type WaitForBuildArgs struct {
@@ -551,7 +551,7 @@ type WaitForBuildArgs struct {
 	WaitTimeout  int    `json:"wait_timeout"`
 }
 
-func WaitForBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[WaitForBuildArgs]) {
+func WaitForBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[WaitForBuildArgs], scopes []string) {
 	return mcp.NewTool("wait_for_build",
 			mcp.WithDescription("Wait for a specific build to complete"),
 			mcp.WithString("org_slug",
@@ -681,7 +681,7 @@ func WaitForBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHand
 			result := detailBuild(build)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_builds"}
 }
 
 func convertEntries(entries []Entry) map[string]string {

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -69,7 +69,7 @@ func TestWaitForBuildCompletes(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := WaitForBuild(client)
+	tool, typedHandler, _ := WaitForBuild(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -123,7 +123,7 @@ func TestWaitForBuildTimeout(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := WaitForBuild(client)
+	tool, typedHandler, _ := WaitForBuild(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -159,7 +159,7 @@ func TestWaitForBuildMissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockBuildsClient{}
 
-	tool, typedHandler := WaitForBuild(client)
+	tool, typedHandler, _ := WaitForBuild(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -215,7 +215,7 @@ func TestGetBuildDefault(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := GetBuild(client)
+	tool, typedHandler, _ := GetBuild(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -264,7 +264,7 @@ func TestGetBuildWithJobSummary(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := GetBuild(client)
+	tool, typedHandler, _ := GetBuild(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -308,7 +308,7 @@ func TestListBuilds(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := ListBuilds(client)
+	tool, typedHandler, _ := ListBuilds(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -360,7 +360,7 @@ func TestListBuildsWithCustomPagination(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := ListBuilds(client)
+	tool, typedHandler, _ := ListBuilds(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -405,7 +405,7 @@ func TestListBuildsWithBranchFilter(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := ListBuilds(client)
+	tool, typedHandler, _ := ListBuilds(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -462,7 +462,7 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 		},
 	}
 
-	tool, typedHandler := GetBuildTestEngineRuns(client)
+	tool, typedHandler, _ := GetBuildTestEngineRuns(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
@@ -506,7 +506,7 @@ func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {
 		},
 	}
 
-	_, typedHandler := GetBuildTestEngineRuns(client)
+	_, typedHandler, _ := GetBuildTestEngineRuns(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 
 	request := createMCPRequest(t, map[string]any{
@@ -528,7 +528,7 @@ func TestGetBuildTestEngineRunsMissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockBuildsClient{}
 
-	_, typedHandler := GetBuildTestEngineRuns(client)
+	_, typedHandler, _ := GetBuildTestEngineRuns(client)
 	handler := mcp.NewTypedToolHandler(typedHandler)
 
 	// Test missing org parameter
@@ -595,7 +595,7 @@ func TestCreateBuild(t *testing.T) {
 		},
 	}
 
-	tool, handler := CreateBuild(client)
+	tool, handler, _ := CreateBuild(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -15,7 +15,7 @@ type ClusterQueuesClient interface {
 	Get(ctx context.Context, org, clusterID, queueID string) (buildkite.ClusterQueue, *buildkite.Response, error)
 }
 
-func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("list_cluster_queues",
 			mcp.WithDescription("List all queues in a cluster with their keys, descriptions, dispatch status, and agent configuration"),
 			mcp.WithString("org_slug",
@@ -77,10 +77,10 @@ func ListClusterQueues(client ClusterQueuesClient) (tool mcp.Tool, handler serve
 			)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_clusters"}
 }
 
-func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_cluster_queue",
 			mcp.WithDescription("Get detailed information about a specific queue including its key, description, dispatch status, and hosted agent configuration"),
 			mcp.WithString("org_slug",
@@ -126,5 +126,5 @@ func GetClusterQueue(client ClusterQueuesClient) (tool mcp.Tool, handler server.
 			}
 
 			return mcpTextResult(span, &queue)
-		}
+		}, []string{"read_clusters"}
 }

--- a/pkg/buildkite/cluster_queue_test.go
+++ b/pkg/buildkite/cluster_queue_test.go
@@ -47,7 +47,7 @@ func TestListClusterQueues(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListClusterQueues(client)
+	tool, handler, _ := ListClusterQueues(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -78,7 +78,7 @@ func TestGetClusterQueue(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetClusterQueue(client)
+	tool, handler, _ := GetClusterQueue(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/clusters.go
+++ b/pkg/buildkite/clusters.go
@@ -15,7 +15,7 @@ type ClustersClient interface {
 	Get(ctx context.Context, org, id string) (buildkite.Cluster, *buildkite.Response, error)
 }
 
-func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("list_clusters",
 			mcp.WithDescription("List all clusters in an organization with their names, descriptions, default queues, and creation details"),
 			mcp.WithString("org_slug",
@@ -68,10 +68,10 @@ func ListClusters(client ClustersClient) (tool mcp.Tool, handler server.ToolHand
 			)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_clusters"}
 }
 
-func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_cluster",
 			mcp.WithDescription("Get detailed information about a specific cluster including its name, description, default queue, and configuration"),
 			mcp.WithString("org_slug",
@@ -108,5 +108,5 @@ func GetCluster(client ClustersClient) (tool mcp.Tool, handler server.ToolHandle
 			}
 
 			return mcpTextResult(span, &cluster)
-		}
+		}, []string{"read_clusters"}
 }

--- a/pkg/buildkite/clusters_test.go
+++ b/pkg/buildkite/clusters_test.go
@@ -48,7 +48,7 @@ func TestListClusters(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListClusters(client)
+	tool, handler, _ := ListClusters(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -79,7 +79,7 @@ func TestGetCluster(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetCluster(client)
+	tool, handler, _ := GetCluster(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/joblogs.go
+++ b/pkg/buildkite/joblogs.go
@@ -131,7 +131,7 @@ func formatLogEntries(entries []buildkitelogs.ParquetLogEntry) any {
 }
 
 // SearchLogs implements the search_logs MCP tool
-func SearchLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[SearchLogsParams]) {
+func SearchLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[SearchLogsParams], scopes []string) {
 	return mcp.NewTool("search_logs",
 			mcp.WithDescription("Search log entries using regex patterns with optional context lines. 💡 For recent failures, try 'tail_logs' first, then use search_logs with patterns like 'error|failed|exception' and limit: 10-20. The json format: {ts: timestamp_ms, c: content, rn: row_number}."),
 			mcp.WithString("org_slug",
@@ -261,11 +261,12 @@ func SearchLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToo
 			)
 
 			return mcpTextResult(span, &response)
-		}
+		},
+		[]string{"read_build_logs"}
 }
 
 // TailLogs implements the tail_logs MCP tool
-func TailLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[TailLogsParams]) {
+func TailLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[TailLogsParams], scopes []string) {
 	return mcp.NewTool("tail_logs",
 			mcp.WithDescription("Show the last N entries from the log file. 🔥 RECOMMENDED for failure diagnosis - most build failures appear in the final log entries. More token-efficient than read_logs for recent issues. The json format: {ts: timestamp_ms, c: content, rn: row_number}."),
 			mcp.WithString("org_slug",
@@ -356,11 +357,12 @@ func TailLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolH
 			)
 
 			return mcpTextResult(span, &response)
-		}
+		},
+		[]string{"read_build_logs"}
 }
 
 // GetLogsInfo implements the get_logs_info MCP tool
-func GetLogsInfo(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[JobLogsBaseParams]) {
+func GetLogsInfo(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[JobLogsBaseParams], scopes []string) {
 	return mcp.NewTool("get_logs_info",
 			mcp.WithDescription("Get metadata and statistics about the Parquet log file. 📊 RECOMMENDED as first step - check file size before reading large logs to plan your approach efficiently."),
 			mcp.WithString("org_slug",
@@ -430,11 +432,12 @@ func GetLogsInfo(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedTo
 			}
 
 			return mcpTextResult(span, &response)
-		}
+		},
+		[]string{"read_build_logs"}
 }
 
 // ReadLogs implements the read_logs MCP tool
-func ReadLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ReadLogsParams]) {
+func ReadLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ReadLogsParams], scopes []string) {
 	return mcp.NewTool("read_logs",
 			mcp.WithDescription("Read log entries from the file, optionally starting from a specific row number. ⚠️ ALWAYS use 'limit' parameter to avoid excessive tokens. For recent failures, use 'tail_logs' instead. Recommended limits: investigation (100-500), exploration (use seek + small limits). The json format: {ts: timestamp_ms, c: content, rn: row_number}."),
 			mcp.WithString("org_slug",
@@ -529,5 +532,6 @@ func ReadLogs(client BuildkiteLogsClient) (tool mcp.Tool, handler mcp.TypedToolH
 			)
 
 			return mcpTextResult(span, &response)
-		}
+		},
+		[]string{"read_build_logs"}
 }

--- a/pkg/buildkite/joblogs_test.go
+++ b/pkg/buildkite/joblogs_test.go
@@ -114,7 +114,7 @@ func TestSearchLogsHandler(t *testing.T) {
 		},
 	}
 
-	_, handler := SearchLogs(mockClient)
+	_, handler, _ := SearchLogs(mockClient)
 
 	t.Run("invalid regex pattern", func(t *testing.T) {
 		params := SearchLogsParams{
@@ -141,7 +141,7 @@ func TestSearchLogsHandler(t *testing.T) {
 			},
 		}
 
-		_, errorHandler := SearchLogs(errorClient)
+		_, errorHandler, _ := SearchLogs(errorClient)
 
 		params := SearchLogsParams{
 			JobLogsBaseParams: JobLogsBaseParams{
@@ -171,7 +171,7 @@ func TestTailLogsHandler(t *testing.T) {
 		},
 	}
 
-	_, handler := TailLogs(mockClient)
+	_, handler, _ := TailLogs(mockClient)
 
 	t.Run("default tail value", func(t *testing.T) {
 		params := TailLogsParams{
@@ -203,7 +203,7 @@ func TestGetLogsInfoHandler(t *testing.T) {
 		},
 	}
 
-	_, handler := GetLogsInfo(mockClient)
+	_, handler, _ := GetLogsInfo(mockClient)
 
 	params := JobLogsBaseParams{
 		OrgSlug:      "test-org",
@@ -230,7 +230,7 @@ func TestReadLogsHandler(t *testing.T) {
 		},
 	}
 
-	_, handler := ReadLogs(mockClient)
+	_, handler, _ := ReadLogs(mockClient)
 
 	params := ReadLogsParams{
 		JobLogsBaseParams: JobLogsBaseParams{

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -53,7 +53,7 @@ type UnblockJobArgs struct {
 	Fields       map[string]string `json:"fields,omitempty"`
 }
 
-func GetJobs(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetJobsArgs]) {
+func GetJobs(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetJobsArgs], scopes []string) {
 	return mcp.NewTool("get_jobs",
 			mcp.WithDescription("Get all jobs for a specific build including their state, timing, commands, and execution details"),
 			mcp.WithString("org_slug",
@@ -171,7 +171,7 @@ func GetJobs(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFu
 			}
 
 			return mcp.NewToolResultText(string(r)), nil
-		}
+		}, []string{"read_builds"}
 }
 
 func GetJobLogs(client *buildkite.Client) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetJobLogsArgs]) {
@@ -354,7 +354,7 @@ func handleLargeLogFile(ctx context.Context, processedLog string, response JobLo
 	return mcp.NewToolResultText(string(r)), nil
 }
 
-func UnblockJob(client JobsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[UnblockJobArgs]) {
+func UnblockJob(client JobsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[UnblockJobArgs], scopes []string) {
 	return mcp.NewTool("unblock_job",
 			mcp.WithDescription("Unblock a blocked job in a Buildkite build to allow it to continue execution"),
 			mcp.WithString("org_slug",
@@ -422,5 +422,5 @@ func UnblockJob(client JobsClient) (tool mcp.Tool, handler mcp.TypedToolHandlerF
 			}
 
 			return mcpTextResult(span, &job)
-		}
+		}, []string{"write_builds"}
 }

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -35,7 +35,7 @@ func TestGetJobs(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -96,7 +96,7 @@ func TestGetJobsWithStateFilter(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -186,7 +186,7 @@ func TestGetJobsMissingParameters(t *testing.T) {
 	ctx := context.Background()
 	client := &MockBuildsClient{}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -262,7 +262,7 @@ func TestGetJobsPagination(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -383,7 +383,7 @@ func TestGetJobsAgentInfo(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -475,7 +475,7 @@ func TestGetJobsPaginationWithFilter(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetJobs(client)
+	tool, handler, _ := GetJobs(client)
 	require.NotNil(t, tool)
 	require.NotNil(t, handler)
 
@@ -594,7 +594,7 @@ func TestUnblockJob(t *testing.T) {
 
 	// Test tool definition
 	t.Run("ToolDefinition", func(t *testing.T) {
-		tool, _ := UnblockJob(&MockJobsClient{})
+		tool, _, _ := UnblockJob(&MockJobsClient{})
 		assert.Equal(t, "unblock_job", tool.Name)
 		assert.Contains(t, tool.Description, "Unblock a blocked job")
 	})
@@ -619,7 +619,7 @@ func TestUnblockJob(t *testing.T) {
 			},
 		}
 
-		_, handler := UnblockJob(mockJobs)
+		_, handler, _ := UnblockJob(mockJobs)
 
 		req := createMCPRequest(t, map[string]any{})
 		args := UnblockJobArgs{
@@ -656,7 +656,7 @@ func TestUnblockJob(t *testing.T) {
 			},
 		}
 
-		_, handler := UnblockJob(mockJobs)
+		_, handler, _ := UnblockJob(mockJobs)
 
 		req := createMCPRequest(t, map[string]any{})
 		args := UnblockJobArgs{
@@ -680,7 +680,7 @@ func TestUnblockJob(t *testing.T) {
 			},
 		}
 
-		_, handler := UnblockJob(mockJobs)
+		_, handler, _ := UnblockJob(mockJobs)
 
 		req := createMCPRequest(t, map[string]any{})
 		args := UnblockJobArgs{
@@ -697,7 +697,7 @@ func TestUnblockJob(t *testing.T) {
 
 	// Test missing parameters
 	t.Run("MissingParameters", func(t *testing.T) {
-		_, handler := UnblockJob(&MockJobsClient{})
+		_, handler, _ := UnblockJob(&MockJobsClient{})
 
 		// Test missing org parameter
 		req := createMCPRequest(t, map[string]any{})

--- a/pkg/buildkite/organizations.go
+++ b/pkg/buildkite/organizations.go
@@ -13,7 +13,7 @@ type OrganizationsClient interface {
 	List(ctx context.Context, options *buildkite.OrganizationListOptions) ([]buildkite.Organization, *buildkite.Response, error)
 }
 
-func UserTokenOrganization(client OrganizationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func UserTokenOrganization(client OrganizationsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("user_token_organization",
 			mcp.WithDescription("Get the organization associated with the user token used for this request"),
 			mcp.WithToolAnnotation(mcp.ToolAnnotation{
@@ -34,7 +34,7 @@ func UserTokenOrganization(client OrganizationsClient) (tool mcp.Tool, handler s
 			}
 
 			return mcpTextResult(span, &orgs[0])
-		}
+		}, []string{"read_organizations"}
 }
 
 func HandleUserTokenOrganizationPrompt(

--- a/pkg/buildkite/organizations_test.go
+++ b/pkg/buildkite/organizations_test.go
@@ -39,7 +39,7 @@ func TestUserTokenOrganization(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(client)
+	tool, handler, _ := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -68,7 +68,7 @@ func TestUserTokenOrganizationError(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(client)
+	tool, handler, _ := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -92,7 +92,7 @@ func TestUserTokenOrganizationErrorNoOrganization(t *testing.T) {
 		},
 	}
 
-	tool, handler := UserTokenOrganization(client)
+	tool, handler, _ := UserTokenOrganization(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -28,7 +28,7 @@ type ListPipelinesArgs struct {
 	DetailLevel string `json:"detail_level"` // "summary", "detailed", "full"
 }
 
-func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListPipelinesArgs]) {
+func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[ListPipelinesArgs], scopes []string) {
 	return mcp.NewTool("list_pipelines",
 			mcp.WithDescription("List all pipelines in an organization with their basic details, build counts, and current status"),
 			mcp.WithString("org_slug",
@@ -112,7 +112,7 @@ func ListPipelines(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedTool
 			)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_pipelines"}
 }
 
 type GetPipelineArgs struct {
@@ -121,7 +121,7 @@ type GetPipelineArgs struct {
 	DetailLevel  string `json:"detail_level"` // "summary", "detailed", "full"
 }
 
-func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetPipelineArgs]) {
+func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[GetPipelineArgs], scopes []string) {
 	return mcp.NewTool("get_pipeline",
 			mcp.WithDescription("Get detailed information about a specific pipeline including its configuration, steps, environment variables, and build statistics"),
 			mcp.WithString("org_slug",
@@ -183,7 +183,7 @@ func GetPipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHa
 			}
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_pipelines"}
 }
 
 // PipelineSummary contains essential pipeline fields for token-efficient responses
@@ -284,7 +284,7 @@ type CreatePipelineArgs struct {
 	Tags                      []string `json:"tags"`
 }
 
-func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreatePipelineArgs]) {
+func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToolHandlerFunc[CreatePipelineArgs], scopes []string) {
 	return mcp.NewTool("create_pipeline",
 			mcp.WithDescription("Set up a new CI/CD pipeline in Buildkite with YAML configuration, repository connection, and cluster assignment"),
 			mcp.WithString("org_slug",
@@ -384,7 +384,7 @@ func CreatePipeline(client PipelinesClient) (tool mcp.Tool, handler mcp.TypedToo
 			}
 
 			return mcpTextResult(span, &pipeline)
-		}
+		}, []string{"write_pipelines"}
 }
 
 type UpdatePipelineArgs struct {
@@ -401,7 +401,7 @@ type UpdatePipelineArgs struct {
 	Tags                      []string `json:"tags"` // Optional, labels to apply to the pipeline
 }
 
-func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[UpdatePipelineArgs]) {
+func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[UpdatePipelineArgs], []string) {
 	return mcp.NewTool("update_pipeline",
 			mcp.WithDescription("Modify an existing Buildkite pipeline's configuration, repository, settings, or metadata"),
 			mcp.WithString("org_slug",
@@ -495,5 +495,5 @@ func UpdatePipeline(client PipelinesClient) (mcp.Tool, mcp.TypedToolHandlerFunc[
 			}
 
 			return mcpTextResult(span, &pipeline)
-		}
+		}, []string{"write_pipelines"}
 }

--- a/pkg/buildkite/pipelines_test.go
+++ b/pkg/buildkite/pipelines_test.go
@@ -67,7 +67,7 @@ func TestListPipelines(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListPipelines(client)
+	tool, handler, _ := ListPipelines(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -104,7 +104,7 @@ func TestGetPipeline(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetPipeline(client)
+	tool, handler, _ := GetPipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -164,7 +164,7 @@ steps:
 		},
 	}
 
-	tool, handler := CreatePipeline(client)
+	tool, handler, _ := CreatePipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -223,7 +223,7 @@ steps:
 		},
 	}
 
-	tool, handler := UpdatePipeline(client)
+	tool, handler, _ := UpdatePipeline(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -14,7 +14,7 @@ type TestExecutionsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
 }
 
-func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_failed_executions",
 			mcp.WithDescription("Get failed test executions for a specific test run in Buildkite Test Engine. Optionally get the expanded failure details such as full error messages and stack traces."),
 			mcp.WithString("org_slug",
@@ -85,5 +85,5 @@ func GetFailedTestExecutions(client TestExecutionsClient) (tool mcp.Tool, handle
 			)
 
 			return mcpTextResult(span, &result)
-		}
+		}, []string{"read_suites"}
 }

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -59,7 +59,7 @@ func TestGetFailedExecutions(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(mockClient)
+	tool, handler, _ := GetFailedTestExecutions(mockClient)
 
 	// Test tool properties
 	assert.Equal("get_failed_executions", tool.Name)
@@ -99,7 +99,7 @@ func TestGetFailedExecutionsMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(mockClient)
+	_, handler, _ := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -118,7 +118,7 @@ func TestGetFailedExecutionsMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(mockClient)
+	_, handler, _ := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug": "org",
@@ -137,7 +137,7 @@ func TestGetFailedExecutionsMissingRunID(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestExecutionsClient{}
 
-	_, handler := GetFailedTestExecutions(mockClient)
+	_, handler, _ := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -160,7 +160,7 @@ func TestGetFailedExecutionsWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetFailedTestExecutions(mockClient)
+	_, handler, _ := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -195,7 +195,7 @@ func TestGetFailedExecutionsHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetFailedTestExecutions(mockClient)
+	_, handler, _ := GetFailedTestExecutions(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -275,7 +275,7 @@ func TestGetFailedExecutionsPagination(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(mockClient)
+	tool, handler, _ := GetFailedTestExecutions(mockClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -398,7 +398,7 @@ func TestGetFailedExecutionsLargePage(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetFailedTestExecutions(mockClient)
+	tool, handler, _ := GetFailedTestExecutions(mockClient)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/buildkite/test_runs.go
+++ b/pkg/buildkite/test_runs.go
@@ -21,7 +21,7 @@ type TestRunsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
 }
 
-func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("list_test_runs",
 			mcp.WithDescription("List all test runs for a test suite in Buildkite Test Engine"),
 			mcp.WithString("org_slug",
@@ -89,10 +89,10 @@ func ListTestRuns(client TestRunsClient) (tool mcp.Tool, handler server.ToolHand
 			)
 
 			return mcp.NewToolResultText(string(r)), nil
-		}
+		}, []string{"read_suites"}
 }
 
-func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_test_run",
 			mcp.WithDescription("Get a specific test run in Buildkite Test Engine"),
 			mcp.WithString("org_slug",
@@ -148,5 +148,5 @@ func GetTestRun(client TestRunsClient) (tool mcp.Tool, handler server.ToolHandle
 			}
 
 			return mcpTextResult(span, &testRun)
-		}
+		}, []string{"read_suites"}
 }

--- a/pkg/buildkite/test_runs_test.go
+++ b/pkg/buildkite/test_runs_test.go
@@ -74,7 +74,7 @@ func TestListTestRuns(t *testing.T) {
 		},
 	}
 
-	tool, handler := ListTestRuns(mockClient)
+	tool, handler, _ := ListTestRuns(mockClient)
 
 	// Test tool properties
 	assert.Equal("list_test_runs", tool.Name)
@@ -114,7 +114,7 @@ func TestListTestRunsWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := ListTestRuns(mockClient)
+	_, handler, _ := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -133,7 +133,7 @@ func TestListTestRunsMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := ListTestRuns(mockClient)
+	_, handler, _ := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -151,7 +151,7 @@ func TestListTestRunsMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := ListTestRuns(mockClient)
+	_, handler, _ := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug": "org",
@@ -185,7 +185,7 @@ func TestGetTestRun(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetTestRun(mockClient)
+	tool, handler, _ := GetTestRun(mockClient)
 
 	// Test tool properties
 	assert.Equal("get_test_run", tool.Name)
@@ -222,7 +222,7 @@ func TestGetTestRunWithError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetTestRun(mockClient)
+	_, handler, _ := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -242,7 +242,7 @@ func TestGetTestRunMissingOrg(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(mockClient)
+	_, handler, _ := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"test_suite_slug": "suite1",
@@ -261,7 +261,7 @@ func TestGetTestRunMissingTestSuiteSlug(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(mockClient)
+	_, handler, _ := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug": "org",
@@ -280,7 +280,7 @@ func TestGetTestRunMissingRunID(t *testing.T) {
 	ctx := context.Background()
 	mockClient := &MockTestRunsClient{}
 
-	_, handler := GetTestRun(mockClient)
+	_, handler, _ := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -308,7 +308,7 @@ func TestGetTestRunHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := GetTestRun(mockClient)
+	_, handler, _ := GetTestRun(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",
@@ -339,7 +339,7 @@ func TestListTestRunsHTTPError(t *testing.T) {
 		},
 	}
 
-	_, handler := ListTestRuns(mockClient)
+	_, handler, _ := ListTestRuns(mockClient)
 
 	request := createMCPRequest(t, map[string]any{
 		"org_slug":        "org",

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -14,7 +14,7 @@ type TestsClient interface {
 	Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
 }
 
-func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc, scopes []string) {
 	return mcp.NewTool("get_test",
 			mcp.WithDescription("Get a specific test in Buildkite Test Engine. This provides additional metadata for failed test executions"),
 			mcp.WithString("org_slug",
@@ -62,5 +62,5 @@ func GetTest(client TestsClient) (tool mcp.Tool, handler server.ToolHandlerFunc)
 			}
 
 			return mcpTextResult(span, &test)
-		}
+		}, []string{"read_suites"}
 }

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -42,7 +42,7 @@ func TestGetTest(t *testing.T) {
 		},
 	}
 
-	tool, handler := GetTest(client)
+	tool, handler, _ := GetTest(client)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
@@ -57,14 +57,14 @@ func TestGetTest(t *testing.T) {
 	assert.Contains(params, "test_id")
 
 	// Verify org is required
-	orgParam := params["org_slug"].(map[string]interface{})
+	orgParam := params["org_slug"].(map[string]any)
 	assert.Equal("string", orgParam["type"])
 
 	// Verify test_suite_slug is required
-	testSuiteParam := params["test_suite_slug"].(map[string]interface{})
+	testSuiteParam := params["test_suite_slug"].(map[string]any)
 	assert.Equal("string", testSuiteParam["type"])
 
 	// Verify test_id is required
-	testIDParam := params["test_id"].(map[string]interface{})
+	testIDParam := params["test_id"].(map[string]any)
 	assert.Equal("string", testIDParam["type"])
 }

--- a/pkg/buildkite/user_test.go
+++ b/pkg/buildkite/user_test.go
@@ -39,7 +39,8 @@ func TestCurrentUser(t *testing.T) {
 		},
 	}
 
-	tool, handler := CurrentUser(client)
+	tool, handler, scopes := CurrentUser(client)
+	assert.Equal([]string{"read_user"}, scopes)
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,37 +2,10 @@ package config
 
 import (
 	"context"
-	"slices"
-	"strings"
 )
 
 type Config struct {
-	JobLogTokenThreshold int      `help:"The threshold for logging tokens. Default is 0, which means no tokens are logged." default:"0" env:"JOB_LOG_TOKEN_THRESHOLD"`
-	EnabledToolsets      []string `help:"Comma-separated list of toolsets to enable (e.g., 'pipelines,builds,clusters'). Use 'all' to enable all toolsets." default:"all" env:"BUILDKITE_TOOLSETS"`
-	ReadOnly             bool     `help:"Enable read-only mode, which filters out write operations from all toolsets." default:"false" env:"BUILDKITE_READ_ONLY"`
-	DynamicToolsets      bool     `help:"Enable dynamic toolset discovery for optimized AI agent interactions." default:"false" env:"BUILDKITE_DYNAMIC_TOOLSETS"`
-}
-
-// IsToolsetEnabled checks if a toolset is enabled based on the configuration
-func (c *Config) IsToolsetEnabled(name string) bool {
-	if slices.Contains(c.EnabledToolsets, "all") {
-		return true
-	}
-	return slices.Contains(c.EnabledToolsets, name)
-}
-
-// ParseToolsets parses a comma-separated string of toolset names
-func (c *Config) ParseToolsets(toolsetsStr string) {
-	if toolsetsStr == "" {
-		c.EnabledToolsets = []string{"all"}
-		return
-	}
-
-	toolsets := strings.Split(toolsetsStr, ",")
-	for i, toolset := range toolsets {
-		toolsets[i] = strings.TrimSpace(toolset)
-	}
-	c.EnabledToolsets = toolsets
+	JobLogTokenThreshold int `help:"The threshold for logging tokens. Default is 0, which means no tokens are logged." default:"0" env:"JOB_LOG_TOKEN_THRESHOLD"`
 }
 
 // configContextKey is used as a key for storing Config in context
@@ -44,9 +17,6 @@ func FromContext(ctx context.Context) *Config {
 	}
 	return &Config{
 		JobLogTokenThreshold: 0, // Default value
-		EnabledToolsets:      []string{"all"},
-		ReadOnly:             false,
-		DynamicToolsets:      false,
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,20 +1,55 @@
 package config
 
-import "context"
+import (
+	"context"
+	"slices"
+	"strings"
+)
 
 type Config struct {
-	JobLogTokenThreshold int `help:"The threshold for logging tokens. Default is 0, which means no tokens are logged." default:"0" env:"JOB_LOG_TOKEN_THRESHOLD"`
+	JobLogTokenThreshold int      `help:"The threshold for logging tokens. Default is 0, which means no tokens are logged." default:"0" env:"JOB_LOG_TOKEN_THRESHOLD"`
+	EnabledToolsets      []string `help:"Comma-separated list of toolsets to enable (e.g., 'pipelines,builds,clusters'). Use 'all' to enable all toolsets." default:"all" env:"BUILDKITE_TOOLSETS"`
+	ReadOnly             bool     `help:"Enable read-only mode, which filters out write operations from all toolsets." default:"false" env:"BUILDKITE_READ_ONLY"`
+	DynamicToolsets      bool     `help:"Enable dynamic toolset discovery for optimized AI agent interactions." default:"false" env:"BUILDKITE_DYNAMIC_TOOLSETS"`
 }
 
+// IsToolsetEnabled checks if a toolset is enabled based on the configuration
+func (c *Config) IsToolsetEnabled(name string) bool {
+	if slices.Contains(c.EnabledToolsets, "all") {
+		return true
+	}
+	return slices.Contains(c.EnabledToolsets, name)
+}
+
+// ParseToolsets parses a comma-separated string of toolset names
+func (c *Config) ParseToolsets(toolsetsStr string) {
+	if toolsetsStr == "" {
+		c.EnabledToolsets = []string{"all"}
+		return
+	}
+
+	toolsets := strings.Split(toolsetsStr, ",")
+	for i, toolset := range toolsets {
+		toolsets[i] = strings.TrimSpace(toolset)
+	}
+	c.EnabledToolsets = toolsets
+}
+
+// configContextKey is used as a key for storing Config in context
+type configContextKey struct{}
+
 func FromContext(ctx context.Context) *Config {
-	if config, ok := ctx.Value(Config{}).(*Config); ok {
+	if config, ok := ctx.Value(configContextKey{}).(*Config); ok {
 		return config
 	}
 	return &Config{
 		JobLogTokenThreshold: 0, // Default value
+		EnabledToolsets:      []string{"all"},
+		ReadOnly:             false,
+		DynamicToolsets:      false,
 	}
 }
 
 func WithConfig(ctx context.Context, config *Config) context.Context {
-	return context.WithValue(ctx, Config{}, config)
+	return context.WithValue(ctx, configContextKey{}, config)
 }

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	buildkitelogs "github.com/buildkite/buildkite-logs"
+	"github.com/buildkite/buildkite-mcp-server/internal/tools"
 	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	"github.com/buildkite/buildkite-mcp-server/pkg/config"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	gobuildkite "github.com/buildkite/go-buildkite/v4"
 	"github.com/mark3labs/mcp-go/mcp"
@@ -10,11 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func fromTypeTool[T any](tool mcp.Tool, handler mcp.TypedToolHandlerFunc[T]) (mcp.Tool, server.ToolHandlerFunc) {
-	return tool, mcp.NewTypedToolHandler(handler)
-}
-
-func NewMCPServer(version string, client *gobuildkite.Client, buildkiteLogsClient *buildkitelogs.Client) *server.MCPServer {
+func NewMCPServerWithConfig(version string, client *gobuildkite.Client, buildkiteLogsClient *buildkitelogs.Client, cfg *config.Config) *server.MCPServer {
 	s := server.NewMCPServer(
 		"buildkite-mcp-server",
 		version,
@@ -26,7 +24,13 @@ func NewMCPServer(version string, client *gobuildkite.Client, buildkiteLogsClien
 
 	log.Info().Str("version", version).Msg("Starting Buildkite MCP server")
 
-	s.AddTools(BuildkiteTools(client, buildkiteLogsClient)...)
+	// Use toolset system with configuration
+	if cfg != nil {
+		s.AddTools(BuildkiteTools(client, buildkiteLogsClient, WithConfig(cfg))...)
+	} else {
+		// Use default toolset configuration when no config provided
+		s.AddTools(BuildkiteTools(client, buildkiteLogsClient)...)
+	}
 
 	s.AddPrompt(mcp.NewPrompt("user_token_organization_prompt",
 		mcp.WithPromptDescription("When asked for detail of a users pipelines start by looking up the user's token organization"),
@@ -41,100 +45,92 @@ func NewMCPServer(version string, client *gobuildkite.Client, buildkiteLogsClien
 	return s
 }
 
-func BuildkiteTools(client *gobuildkite.Client, buildkiteLogsClient *buildkitelogs.Client) []server.ServerTool {
-	// Create a client adapter so that we can use a mock or true client
-	clientAdapter := &buildkite.BuildkiteClientAdapter{Client: client}
+// ToolsetOption configures toolset behavior
+type ToolsetOption func(*ToolsetConfig)
 
-	var tools []server.ServerTool
+// ToolsetConfig holds configuration for toolset selection and behavior
+type ToolsetConfig struct {
+	EnabledToolsets []string
+	ReadOnly        bool
+	DynamicToolsets bool
+}
 
-	addTool := func(tool mcp.Tool, handler server.ToolHandlerFunc) []server.ServerTool {
-		return append(tools, server.ServerTool{Tool: tool, Handler: handler})
+// WithToolsets enables specific toolsets
+func WithToolsets(toolsets ...string) ToolsetOption {
+	return func(cfg *ToolsetConfig) {
+		cfg.EnabledToolsets = toolsets
+	}
+}
+
+// WithReadOnly enables read-only mode which filters out write operations
+func WithReadOnly(readOnly bool) ToolsetOption {
+	return func(cfg *ToolsetConfig) {
+		cfg.ReadOnly = readOnly
+	}
+}
+
+// WithDynamicToolsets enables dynamic toolset discovery tools
+func WithDynamicToolsets(dynamic bool) ToolsetOption {
+	return func(cfg *ToolsetConfig) {
+		cfg.DynamicToolsets = dynamic
+	}
+}
+
+// WithConfig applies settings from a config.Config struct
+func WithConfig(cfg *config.Config) ToolsetOption {
+	return func(toolsetCfg *ToolsetConfig) {
+		toolsetCfg.EnabledToolsets = cfg.EnabledToolsets
+		toolsetCfg.ReadOnly = cfg.ReadOnly
+		toolsetCfg.DynamicToolsets = cfg.DynamicToolsets
+	}
+}
+
+// BuildkiteTools creates tools using the toolset system with functional options
+func BuildkiteTools(client *gobuildkite.Client, buildkiteLogsClient *buildkitelogs.Client, opts ...ToolsetOption) []server.ServerTool {
+	// Default configuration
+	cfg := &ToolsetConfig{
+		EnabledToolsets: []string{"all"},
+		ReadOnly:        false,
+		DynamicToolsets: false,
 	}
 
-	// Cluster tools
-	tools = addTool(buildkite.GetCluster(client.Clusters))
-	tools = addTool(buildkite.ListClusters(client.Clusters))
+	// Apply options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	// Create builtin toolsets
+	builtinToolsets := tools.CreateBuiltinToolsets(client, buildkiteLogsClient)
 
-	// Queue tools
-	tools = addTool(buildkite.GetClusterQueue(client.ClusterQueues))
-	tools = addTool(buildkite.ListClusterQueues(client.ClusterQueues))
+	// Create registry and register toolsets
+	registry := tools.NewToolsetRegistry()
+	for name, toolset := range builtinToolsets {
+		registry.Register(name, toolset)
+	}
 
-	// Pipeline tools
-	tools = addTool(
-		fromTypeTool(buildkite.GetPipeline(client.Pipelines)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.ListPipelines(client.Pipelines)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.CreatePipeline(client.Pipelines)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.UpdatePipeline(client.Pipelines)),
-	)
+	// Get enabled tools with read-only filtering
+	enabledTools := registry.GetEnabledTools(cfg.EnabledToolsets, cfg.ReadOnly)
 
-	// Build tools
-	tools = addTool(
-		fromTypeTool(buildkite.ListBuilds(client.Builds)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.GetBuild(client.Builds)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.GetBuildTestEngineRuns(client.Builds)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.CreateBuild(client.Builds)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.WaitForBuild(client.Builds)),
-	)
+	// Add introspection tools if dynamic toolsets is enabled
+	if cfg.DynamicToolsets {
+		introspectionTools := tools.CreateIntrospectionTools(registry)
+		enabledTools = append(enabledTools, introspectionTools...)
+	}
 
-	// User tools
-	tools = addTool(buildkite.CurrentUser(client.User))
-	tools = addTool(buildkite.UserTokenOrganization(client.Organizations))
+	// Convert to ServerTool format
+	var serverTools []server.ServerTool
+	for _, toolDef := range enabledTools {
+		serverTools = append(serverTools, server.ServerTool{
+			Tool:    toolDef.Tool,
+			Handler: toolDef.Handler,
+		})
+	}
 
-	// Job tools
-	tools = addTool(
-		fromTypeTool(buildkite.GetJobs(client.Builds)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.UnblockJob(client.Jobs)),
-	)
+	log.Info().
+		Strs("enabled_toolsets", cfg.EnabledToolsets).
+		Bool("read_only", cfg.ReadOnly).
+		Bool("dynamic_toolsets", cfg.DynamicToolsets).
+		Int("tool_count", len(serverTools)).
+		Msg("Registered tools from toolsets")
 
-	// Artifacts tools
-	tools = addTool(buildkite.ListArtifacts(clientAdapter))
-	tools = addTool(buildkite.GetArtifact(clientAdapter))
-
-	// Annotation tools
-	tools = addTool(buildkite.ListAnnotations(client.Annotations))
-
-	// Test Run tools
-	tools = addTool(buildkite.ListTestRuns(client.TestRuns))
-	tools = addTool(buildkite.GetTestRun(client.TestRuns))
-
-	// Test Execution tools
-	tools = addTool(buildkite.GetFailedTestExecutions(client.TestRuns))
-
-	// Test tools
-	tools = addTool(buildkite.GetTest(client.Tests))
-
-	// Job Log tools (Parquet-based)
-	tools = addTool(
-		fromTypeTool(buildkite.SearchLogs(buildkiteLogsClient)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.TailLogs(buildkiteLogsClient)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.GetLogsInfo(buildkiteLogsClient)),
-	)
-	tools = addTool(
-		fromTypeTool(buildkite.ReadLogs(buildkiteLogsClient)),
-	)
-
-	// Other tools
-	tools = addTool(buildkite.AccessToken(client.AccessTokens))
-
-	return tools
+	return serverTools
 }


### PR DESCRIPTION
This feature allows selection of the following options:

* Default: 29 tools (all toolsets)
* Read-only: 25 tools (filtered out 4 write operations)
* Specific toolsets: 8 tools (4 pipeline + 4 log tools)
* Dynamic enabled: 32 tools (29 + 3 introspection tools)
* Combined: 12 tools (5 read-only build tools + 4 read-only test tools + 3 introspection tools)

Also add scopes to tools and provide dynamic tool to report on them
