### PR TITLE
feat: update the get_build to incorporate the get_jobs functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.out
 
 # debugger binaries
 __debug_bin*
+/*.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Variables
 BINARY_NAME := buildkite-mcp-server
-CMD_PATH := ./cmd/$(BINARY_NAME)
+CMD_PACKAGE := ./cmd/$(BINARY_NAME)
+DOCS_PACKAGE := ./cmd/update-docs
 COVERAGE_FILE := coverage.out
 
 # Default target
@@ -14,11 +15,11 @@ help: ## Show this help message
 
 .PHONY: build
 build: ## Build the binary
-	go build -o $(BINARY_NAME) $(CMD_PATH)/main.go
+	go build -o $(BINARY_NAME) $(CMD_PACKAGE)
 
 .PHONY: install
 install: ## Install the binary
-	go install ./cmd/...
+	go install $(CMD_PACKAGE)
 
 .PHONY: snapshot
 snapshot: ## Build snapshot with goreleaser
@@ -26,11 +27,11 @@ snapshot: ## Build snapshot with goreleaser
 
 .PHONY: update-docs
 update-docs: ## Update documentation
-	go run cmd/update-docs/main.go
+	go run $(DOCS_PACKAGE)
 
 .PHONY: run
 run: ## Run the application with stdio
-	go run $(CMD_PATH)/main.go stdio
+	go run $(CMD_PACKAGE) stdio
 
 .PHONY: test
 test: ## Run tests with coverage

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -334,10 +334,6 @@ func CreateBuiltinToolsets(client *gobuildkite.Client, buildkiteLogsClient *buil
 					return tool, mcp.NewTypedToolHandler(handler), scopes
 				}),
 				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
-					tool, handler, scopes := buildkite.GetJobs(client.Builds)
-					return tool, mcp.NewTypedToolHandler(handler), scopes
-				}),
-				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
 					tool, handler, scopes := buildkite.UnblockJob(client.Jobs)
 					return tool, mcp.NewTypedToolHandler(handler), scopes
 				}),


### PR DESCRIPTION
The goal of this change is to collapse what is often a few calls combining get_build and get_jobs with state filter(s) into one call.

As an example we see in actual builds with failed and broken jobs.

```
get_build(detailed)
get_jobs(state=failed)
get_jobs(state=broken)
```

becomes

```
get_build(full, state=failed,broken)
```
