### PR TITLE
chore(deps): upgrade go-buildkite to fix issue with list pipelines json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.5
 require (
 	github.com/alecthomas/kong v1.12.1
 	github.com/buildkite/buildkite-logs v0.6.1
-	github.com/buildkite/go-buildkite/v4 v4.9.0
+	github.com/buildkite/go-buildkite/v4 v4.9.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/mark3labs/mcp-go v0.41.1
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,10 @@ github.com/buildkite/buildkite-logs v0.6.1 h1:5SlAsAFYKy1rl3j7GNldgeOzBMbuKYSgdF
 github.com/buildkite/buildkite-logs v0.6.1/go.mod h1:ejxwp0IDk7Wd0yTH0Cvnw8GgRGnpboe6Up4k9SGmWTg=
 github.com/buildkite/go-buildkite/v4 v4.9.0 h1:/zfx4LiEzPtT/oSciSfRxuvKrPmIk+luv4m0oK0Dy1I=
 github.com/buildkite/go-buildkite/v4 v4.9.0/go.mod h1:DlebrRJqpZttXDjCW+MJ1QyW9AN++ZWt/UbPtKdbSSk=
+github.com/buildkite/go-buildkite/v4 v4.9.1-0.20251019231328-cbce06947c8d h1:J40fKUyAlDiYQIJ+06KwrvcOQyFSk+vroXGa8i0IAPA=
+github.com/buildkite/go-buildkite/v4 v4.9.1-0.20251019231328-cbce06947c8d/go.mod h1:DlebrRJqpZttXDjCW+MJ1QyW9AN++ZWt/UbPtKdbSSk=
+github.com/buildkite/go-buildkite/v4 v4.9.1 h1:dA32pinTsHMTCHO84awc9W9Y21knlPjd/ZOSntMPIb0=
+github.com/buildkite/go-buildkite/v4 v4.9.1/go.mod h1:DlebrRJqpZttXDjCW+MJ1QyW9AN++ZWt/UbPtKdbSSk=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/clusters_test.go
+++ b/pkg/buildkite/clusters_test.go
@@ -59,7 +59,7 @@ func TestListClusters(t *testing.T) {
 	assert.NoError(err)
 
 	textContent := getTextResult(t, result)
-	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"cluster-id","name":"cluster-name","created_by":{}}]}`, textContent.Text)
+	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"cluster-id","name":"cluster-name","created_by":{},"maintainers":{}}]}`, textContent.Text)
 }
 
 func TestGetCluster(t *testing.T) {
@@ -91,5 +91,5 @@ func TestGetCluster(t *testing.T) {
 	assert.NoError(err)
 
 	textContent := getTextResult(t, result)
-	assert.JSONEq("{\"id\":\"cluster-id\",\"name\":\"cluster-name\",\"created_by\":{}}", textContent.Text)
+	assert.JSONEq("{\"id\":\"cluster-id\",\"name\":\"cluster-name\",\"created_by\":{},\"maintainers\":{}}", textContent.Text)
 }


### PR DESCRIPTION
The error is as follows.

```
json: cannot unmarshal object into Go struct field Cluster.maintainers of type []buildkite.ClusterMaintainer
```

see https://github.com/buildkite/go-buildkite/pull/251