### PR TITLE
feat: move the to chainguard images for the mcp for consistency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,3 +61,8 @@ steps:
           shell: false
           tty: true
           progress: plain
+  
+  # validate the docker file builds correctly as this is used by docker hub for publishing the mcp into their registry
+  - label: ":docker: build image"
+    depends_on: quality-checks
+    command: docker build -t buildkite-mcp-server:latest -f Dockerfile.local .

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 # Build stage
-FROM public.ecr.aws/docker/library/golang:1.24.5 AS builder
+FROM cgr.dev/chainguard/go:latest AS builder
 
 WORKDIR /app
 
@@ -14,10 +14,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -o buildkite-mcp-server ./cmd/buildkite-mcp-server/main.go
 
 # Final stage
-FROM alpine:3.22
-
-# Install ca-certificates for HTTPS requests
-RUN apk --no-cache add ca-certificates
+FROM cgr.dev/chainguard/static:latest
 
 WORKDIR /app
 


### PR DESCRIPTION
I am using latest as I am reluctant to pin a version and create a whole stream of updates for this container.