### PR TITLE
chore: remove the log info tool as it is rarely used

### DIFF
--- a/pkg/buildkite/joblogs_test.go
+++ b/pkg/buildkite/joblogs_test.go
@@ -193,33 +193,6 @@ func TestTailLogsHandler(t *testing.T) {
 	})
 }
 
-func TestGetLogsInfoHandler(t *testing.T) {
-	assert := require.New(t)
-	ctx := context.Background()
-
-	mockClient := &MockBuildkiteLogsClient{
-		DownloadAndCacheFunc: func(ctx context.Context, org, pipeline, build, job string, cacheTTL time.Duration, forceRefresh bool) (string, error) {
-			return "/tmp/test.parquet", nil
-		},
-	}
-
-	_, handler, _ := GetLogsInfo(mockClient)
-
-	params := JobLogsBaseParams{
-		OrgSlug:      "test-org",
-		PipelineSlug: "test-pipeline",
-		BuildNumber:  "123",
-		JobID:        "job-456",
-	}
-
-	// This will fail due to the parquet file not existing, but we can test the flow
-	result, err := handler(ctx, mcp.CallToolRequest{}, params)
-	assert.NoError(err)
-	textContent, ok := result.Content[0].(mcp.TextContent)
-	assert.True(ok)
-	assert.Contains(textContent.Text, "Failed to get file info")
-}
-
 func TestReadLogsHandler(t *testing.T) {
 	assert := require.New(t)
 	ctx := context.Background()

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -372,10 +372,6 @@ func CreateBuiltinToolsets(client *gobuildkite.Client, buildkiteLogsClient *buil
 					return tool, mcp.NewTypedToolHandler(handler), scopes
 				}),
 				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
-					tool, handler, scopes := buildkite.GetLogsInfo(buildkiteLogsClient)
-					return tool, mcp.NewTypedToolHandler(handler), scopes
-				}),
-				newToolFromFunc(func() (mcp.Tool, server.ToolHandlerFunc, []string) {
 					tool, handler, scopes := buildkite.ReadLogs(buildkiteLogsClient)
 					return tool, mcp.NewTypedToolHandler(handler), scopes
 				}),


### PR DESCRIPTION
The goal of this tool was to provide information about rowcount and size of a log, however in practice most agents / LLMs don't care. For this reason I am elimiting this tool as it a waste of context.
