### PR TITLE
Revert "fix: include required MCP fields in WaitForBuild progress notifications"

### DIFF
--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -724,14 +724,17 @@ func WaitForBuild(client BuildsClient) (tool mcp.Tool, handler mcp.TypedToolHand
 							b.Reset()
 						}
 
-						completed := total - remaining
 						err := server.SendNotificationToClient(
 							ctx,
 							"notifications/progress",
 							map[string]any{
-								"progressToken": progressToken,
-								"progress":      completed,
-								"total":         total,
+								"build_number":        build.Number,
+								"status":              build.State,
+								"total_job_count":     total,
+								"remaining_job_count": remaining,
+								"percentage_complete": calculatePercentage(total, remaining),
+								"created_at":          getTimestampStringOrNil(build.CreatedAt),
+								"started_at":          getTimestampStringOrNil(build.StartedAt),
 							},
 						)
 						if err != nil {
@@ -763,6 +766,14 @@ func convertEntries(entries []Entry) map[string]string {
 		result[entry.Key] = entry.Value
 	}
 	return result
+}
+
+func getTimestampStringOrNil(ts *buildkite.Timestamp) *string {
+	if ts == nil {
+		return nil
+	}
+	str := ts.Format(time.RFC3339)
+	return &str
 }
 
 // see https://buildkite.com/docs/pipelines/configure/notifications#build-states


### PR DESCRIPTION
Reverts buildkite/buildkite-mcp-server#215

After a review of this change, although it works it is limited to only waiting for builds up to 1 minute.

I am doing some refactoring which will allow us to implement using a long running task model.

Currently the wait for build tool works with claude code so the issue is isolated to Cursor.

