### PR TITLE
extend annotation options

### DIFF
--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -32,7 +32,7 @@ type CreateAnnotationArgs struct {
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
 	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
-	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success\, info\, warning\, or error"`
+	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success, info, warning, or error"`
 	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
 	Context      string `json:"context,omitempty" jsonschema:"Optional annotation context used to identify or append to an annotation"`
 	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`
@@ -60,7 +60,7 @@ type CreateJobAnnotationArgs struct {
 	BuildNumber  string `json:"build_number"`
 	JobID        string `json:"job_id"`
 	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
-	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success\, info\, warning\, or error"`
+	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success, info, warning, or error"`
 	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
 	Context      string `json:"context,omitempty" jsonschema:"Optional annotation context used to identify or append to an annotation"`
 	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -4,25 +4,31 @@ import (
 	"context"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v4"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	annotationScopeBuild = "build"
+	annotationScopeJob   = "job"
 )
 
 // AnnotationsClient describes the subset of the Buildkite client we need for annotations.
 type AnnotationsClient interface {
 	ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
 	Create(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
-	Delete(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error)
 	ListByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
 	CreateForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
-	DeleteForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error)
 }
 
 type ListAnnotationsArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
+	Scope        string `json:"scope,omitempty" jsonschema:"Annotation scope: build or job (defaults to build)"`
+	JobID        string `json:"job_id,omitempty" jsonschema:"Job ID required when scope is job"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
 	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
 }
@@ -31,6 +37,8 @@ type CreateAnnotationArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
+	Scope        string `json:"scope,omitempty" jsonschema:"Annotation scope: build or job (defaults to build)"`
+	JobID        string `json:"job_id,omitempty" jsonschema:"Job ID required when scope is job"`
 	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
 	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success, info, warning, or error"`
 	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
@@ -38,69 +46,71 @@ type CreateAnnotationArgs struct {
 	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`
 }
 
-type DeleteAnnotationArgs struct {
-	OrgSlug      string `json:"org_slug"`
-	PipelineSlug string `json:"pipeline_slug"`
-	BuildNumber  string `json:"build_number"`
-	AnnotationID string `json:"annotation_id"`
+func normalizeAnnotationScope(scope, jobID string) (string, string) {
+	if scope == "" {
+		scope = annotationScopeBuild
+	}
+
+	switch scope {
+	case annotationScopeBuild:
+		return scope, ""
+	case annotationScopeJob:
+		if jobID == "" {
+			return "", "job_id is required when scope is 'job'"
+		}
+		return scope, ""
+	default:
+		return "", "scope must be 'build' or 'job'"
+	}
 }
 
-type ListJobAnnotationsArgs struct {
-	OrgSlug      string `json:"org_slug"`
-	PipelineSlug string `json:"pipeline_slug"`
-	BuildNumber  string `json:"build_number"`
-	JobID        string `json:"job_id"`
-	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
-}
-
-type CreateJobAnnotationArgs struct {
-	OrgSlug      string `json:"org_slug"`
-	PipelineSlug string `json:"pipeline_slug"`
-	BuildNumber  string `json:"build_number"`
-	JobID        string `json:"job_id"`
-	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
-	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success, info, warning, or error"`
-	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
-	Context      string `json:"context,omitempty" jsonschema:"Optional annotation context used to identify or append to an annotation"`
-	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`
-}
-
-type DeleteJobAnnotationArgs struct {
-	OrgSlug      string `json:"org_slug"`
-	PipelineSlug string `json:"pipeline_slug"`
-	BuildNumber  string `json:"build_number"`
-	JobID        string `json:"job_id"`
-	AnnotationID string `json:"annotation_id"`
-}
-
-// ListAnnotations returns an MCP tool + handler pair that lists annotations for a build.
+// ListAnnotations returns an MCP tool + handler pair that lists annotations for a build or job.
 func ListAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListAnnotationsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_annotations",
-			Description: "List all annotations for a build, including their context, scope, style, rendered HTML content, and timestamps",
+			Description: "List annotations for a build or a specific job. Use scope='build' (default) or scope='job' with job_id",
 			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Build Annotations",
+				Title:        "List Annotations",
 				ReadOnlyHint: true,
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListAnnotationsArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ListAnnotations")
 			defer span.End()
 
+			scope, validationErr := normalizeAnnotationScope(args.Scope, args.JobID)
+			if validationErr != "" {
+				return utils.NewToolResultError(validationErr), nil, nil
+			}
+
 			paginationParams := paginationFromArgs(args.Page, args.PerPage)
 
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
+				attribute.String("scope", scope),
+				attribute.String("job_id", args.JobID),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
 			)
 
 			deps := DepsFromContext(ctx)
-			annotations, resp, err := deps.AnnotationsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.AnnotationListOptions{
-				ListOptions: paginationParams,
-			})
+
+			var (
+				annotations []buildkite.Annotation
+				resp        *buildkite.Response
+				err         error
+			)
+
+			if scope == annotationScopeJob {
+				annotations, resp, err = deps.AnnotationsClient.ListByJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, &buildkite.AnnotationListOptions{
+					ListOptions: paginationParams,
+				})
+			} else {
+				annotations, resp, err = deps.AnnotationsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.AnnotationListOptions{
+					ListOptions: paginationParams,
+				})
+			}
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
@@ -120,137 +130,28 @@ func ListAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListAnnotationsArgs, any], 
 		}, []string{"read_builds"}
 }
 
+// CreateAnnotation returns an MCP tool + handler pair that creates an annotation on a build or job.
 func CreateAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateAnnotationArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "create_annotation",
-			Description: "Create a build-level annotation on a Buildkite build using HTML or Markdown content",
+			Description: "Create an annotation on a build or specific job. Use scope='build' (default) or scope='job' with job_id",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Build Annotation",
+				Title: "Create Annotation",
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateAnnotationArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.CreateAnnotation")
 			defer span.End()
 
-			span.SetAttributes(
-				attribute.String("org_slug", args.OrgSlug),
-				attribute.String("pipeline_slug", args.PipelineSlug),
-				attribute.String("build_number", args.BuildNumber),
-				attribute.String("context", args.Context),
-				attribute.String("style", args.Style),
-				attribute.Int("priority", args.Priority),
-				attribute.Bool("append", args.Append),
-			)
-
-			deps := DepsFromContext(ctx)
-			annotation, _, err := deps.AnnotationsClient.Create(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, buildkite.AnnotationCreate{
-				Body:     args.Body,
-				Context:  args.Context,
-				Style:    args.Style,
-				Priority: args.Priority,
-				Append:   args.Append,
-			})
-			if err != nil {
-				return handleBuildkiteError(err)
+			scope, validationErr := normalizeAnnotationScope(args.Scope, args.JobID)
+			if validationErr != "" {
+				return utils.NewToolResultError(validationErr), nil, nil
 			}
-
-			return mcpTextResult(span, &annotation)
-		}, []string{"write_builds"}
-}
-
-func DeleteAnnotation() (mcp.Tool, mcp.ToolHandlerFor[DeleteAnnotationArgs, any], []string) {
-	return mcp.Tool{
-			Name:        "delete_annotation",
-			Description: "Delete a build-level annotation from a Buildkite build",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Delete Build Annotation",
-				DestructiveHint: boolPtr(true),
-			},
-		}, func(ctx context.Context, request *mcp.CallToolRequest, args DeleteAnnotationArgs) (*mcp.CallToolResult, any, error) {
-			ctx, span := trace.Start(ctx, "buildkite.DeleteAnnotation")
-			defer span.End()
 
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
-				attribute.String("annotation_id", args.AnnotationID),
-			)
-
-			deps := DepsFromContext(ctx)
-			_, err := deps.AnnotationsClient.Delete(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.AnnotationID)
-			if err != nil {
-				return handleBuildkiteError(err)
-			}
-
-			return mcpTextResult(span, map[string]any{
-				"deleted":       true,
-				"scope":         "build",
-				"annotation_id": args.AnnotationID,
-			})
-		}, []string{"write_builds"}
-}
-
-func ListJobAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListJobAnnotationsArgs, any], []string) {
-	return mcp.Tool{
-			Name:        "list_job_annotations",
-			Description: "List all annotations for a specific job, including their context, scope, style, rendered HTML content, and timestamps",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Job Annotations",
-				ReadOnlyHint: true,
-			},
-		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListJobAnnotationsArgs) (*mcp.CallToolResult, any, error) {
-			ctx, span := trace.Start(ctx, "buildkite.ListJobAnnotations")
-			defer span.End()
-
-			paginationParams := paginationFromArgs(args.Page, args.PerPage)
-
-			span.SetAttributes(
-				attribute.String("org_slug", args.OrgSlug),
-				attribute.String("pipeline_slug", args.PipelineSlug),
-				attribute.String("build_number", args.BuildNumber),
-				attribute.String("job_id", args.JobID),
-				attribute.Int("page", paginationParams.Page),
-				attribute.Int("per_page", paginationParams.PerPage),
-			)
-
-			deps := DepsFromContext(ctx)
-			annotations, resp, err := deps.AnnotationsClient.ListByJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, &buildkite.AnnotationListOptions{
-				ListOptions: paginationParams,
-			})
-			if err != nil {
-				return handleBuildkiteError(err)
-			}
-
-			result := PaginatedResult[buildkite.Annotation]{
-				Items: annotations,
-				Headers: map[string]string{
-					"Link": resp.Header.Get("Link"),
-				},
-			}
-
-			span.SetAttributes(
-				attribute.Int("item_count", len(annotations)),
-			)
-
-			return mcpTextResult(span, &result)
-		}, []string{"read_builds"}
-}
-
-func CreateJobAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateJobAnnotationArgs, any], []string) {
-	return mcp.Tool{
-			Name:        "create_job_annotation",
-			Description: "Create a job-level annotation on a specific Buildkite job using HTML or Markdown content",
-			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Job Annotation",
-			},
-		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateJobAnnotationArgs) (*mcp.CallToolResult, any, error) {
-			ctx, span := trace.Start(ctx, "buildkite.CreateJobAnnotation")
-			defer span.End()
-
-			span.SetAttributes(
-				attribute.String("org_slug", args.OrgSlug),
-				attribute.String("pipeline_slug", args.PipelineSlug),
-				attribute.String("build_number", args.BuildNumber),
+				attribute.String("scope", scope),
 				attribute.String("job_id", args.JobID),
 				attribute.String("context", args.Context),
 				attribute.String("style", args.Style),
@@ -258,53 +159,30 @@ func CreateJobAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateJobAnnotationArgs
 				attribute.Bool("append", args.Append),
 			)
 
-			deps := DepsFromContext(ctx)
-			annotation, _, err := deps.AnnotationsClient.CreateForJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, buildkite.AnnotationCreate{
+			create := buildkite.AnnotationCreate{
 				Body:     args.Body,
 				Context:  args.Context,
 				Style:    args.Style,
 				Priority: args.Priority,
 				Append:   args.Append,
-			})
+			}
+
+			deps := DepsFromContext(ctx)
+
+			var (
+				annotation buildkite.Annotation
+				err        error
+			)
+
+			if scope == annotationScopeJob {
+				annotation, _, err = deps.AnnotationsClient.CreateForJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, create)
+			} else {
+				annotation, _, err = deps.AnnotationsClient.Create(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, create)
+			}
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
 
 			return mcpTextResult(span, &annotation)
-		}, []string{"write_builds"}
-}
-
-func DeleteJobAnnotation() (mcp.Tool, mcp.ToolHandlerFor[DeleteJobAnnotationArgs, any], []string) {
-	return mcp.Tool{
-			Name:        "delete_job_annotation",
-			Description: "Delete a job-level annotation from a specific job in a Buildkite build",
-			Annotations: &mcp.ToolAnnotations{
-				Title:           "Delete Job Annotation",
-				DestructiveHint: boolPtr(true),
-			},
-		}, func(ctx context.Context, request *mcp.CallToolRequest, args DeleteJobAnnotationArgs) (*mcp.CallToolResult, any, error) {
-			ctx, span := trace.Start(ctx, "buildkite.DeleteJobAnnotation")
-			defer span.End()
-
-			span.SetAttributes(
-				attribute.String("org_slug", args.OrgSlug),
-				attribute.String("pipeline_slug", args.PipelineSlug),
-				attribute.String("build_number", args.BuildNumber),
-				attribute.String("job_id", args.JobID),
-				attribute.String("annotation_id", args.AnnotationID),
-			)
-
-			deps := DepsFromContext(ctx)
-			_, err := deps.AnnotationsClient.DeleteForJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.AnnotationID)
-			if err != nil {
-				return handleBuildkiteError(err)
-			}
-
-			return mcpTextResult(span, map[string]any{
-				"deleted":       true,
-				"scope":         "job",
-				"job_id":        args.JobID,
-				"annotation_id": args.AnnotationID,
-			})
 		}, []string{"write_builds"}
 }

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -12,6 +12,11 @@ import (
 // AnnotationsClient describes the subset of the Buildkite client we need for annotations.
 type AnnotationsClient interface {
 	ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
+	Create(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
+	Delete(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error)
+	ListByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
+	CreateForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
+	DeleteForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error)
 }
 
 type ListAnnotationsArgs struct {
@@ -22,13 +27,60 @@ type ListAnnotationsArgs struct {
 	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
 }
 
+type CreateAnnotationArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
+	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success\, info\, warning\, or error"`
+	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
+	Context      string `json:"context,omitempty" jsonschema:"Optional annotation context used to identify or append to an annotation"`
+	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`
+}
+
+type DeleteAnnotationArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	AnnotationID string `json:"annotation_id"`
+}
+
+type ListJobAnnotationsArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	JobID        string `json:"job_id"`
+	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+}
+
+type CreateJobAnnotationArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	JobID        string `json:"job_id"`
+	Body         string `json:"body" jsonschema:"The annotation body as HTML or Markdown"`
+	Style        string `json:"style,omitempty" jsonschema:"Optional annotation style: success\, info\, warning\, or error"`
+	Priority     int    `json:"priority,omitempty" jsonschema:"Optional annotation priority from 1 to 10"`
+	Context      string `json:"context,omitempty" jsonschema:"Optional annotation context used to identify or append to an annotation"`
+	Append       bool   `json:"append,omitempty" jsonschema:"Append the body to an existing annotation with the same context"`
+}
+
+type DeleteJobAnnotationArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	JobID        string `json:"job_id"`
+	AnnotationID string `json:"annotation_id"`
+}
+
 // ListAnnotations returns an MCP tool + handler pair that lists annotations for a build.
 func ListAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListAnnotationsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_annotations",
-			Description: "List all annotations for a build, including their context, style (success/info/warning/error), rendered HTML content, and creation timestamps",
+			Description: "List all annotations for a build, including their context, scope, style, rendered HTML content, and timestamps",
 			Annotations: &mcp.ToolAnnotations{
-				Title:        "List Annotations",
+				Title:        "List Build Annotations",
 				ReadOnlyHint: true,
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListAnnotationsArgs) (*mcp.CallToolResult, any, error) {
@@ -66,4 +118,193 @@ func ListAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListAnnotationsArgs, any], 
 
 			return mcpTextResult(span, &result)
 		}, []string{"read_builds"}
+}
+
+func CreateAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateAnnotationArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "create_annotation",
+			Description: "Create a build-level annotation on a Buildkite build using HTML or Markdown content",
+			Annotations: &mcp.ToolAnnotations{
+				Title: "Create Build Annotation",
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateAnnotationArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.CreateAnnotation")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("context", args.Context),
+				attribute.String("style", args.Style),
+				attribute.Int("priority", args.Priority),
+				attribute.Bool("append", args.Append),
+			)
+
+			deps := DepsFromContext(ctx)
+			annotation, _, err := deps.AnnotationsClient.Create(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, buildkite.AnnotationCreate{
+				Body:     args.Body,
+				Context:  args.Context,
+				Style:    args.Style,
+				Priority: args.Priority,
+				Append:   args.Append,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, &annotation)
+		}, []string{"write_builds"}
+}
+
+func DeleteAnnotation() (mcp.Tool, mcp.ToolHandlerFor[DeleteAnnotationArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "delete_annotation",
+			Description: "Delete a build-level annotation from a Buildkite build",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Delete Build Annotation",
+				DestructiveHint: boolPtr(true),
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args DeleteAnnotationArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.DeleteAnnotation")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("annotation_id", args.AnnotationID),
+			)
+
+			deps := DepsFromContext(ctx)
+			_, err := deps.AnnotationsClient.Delete(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.AnnotationID)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, map[string]any{
+				"deleted":       true,
+				"scope":         "build",
+				"annotation_id": args.AnnotationID,
+			})
+		}, []string{"write_builds"}
+}
+
+func ListJobAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListJobAnnotationsArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_job_annotations",
+			Description: "List all annotations for a specific job, including their context, scope, style, rendered HTML content, and timestamps",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Job Annotations",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListJobAnnotationsArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListJobAnnotations")
+			defer span.End()
+
+			paginationParams := paginationFromArgs(args.Page, args.PerPage)
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("job_id", args.JobID),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+			)
+
+			deps := DepsFromContext(ctx)
+			annotations, resp, err := deps.AnnotationsClient.ListByJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, &buildkite.AnnotationListOptions{
+				ListOptions: paginationParams,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			result := PaginatedResult[buildkite.Annotation]{
+				Items: annotations,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			span.SetAttributes(
+				attribute.Int("item_count", len(annotations)),
+			)
+
+			return mcpTextResult(span, &result)
+		}, []string{"read_builds"}
+}
+
+func CreateJobAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateJobAnnotationArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "create_job_annotation",
+			Description: "Create a job-level annotation on a specific Buildkite job using HTML or Markdown content",
+			Annotations: &mcp.ToolAnnotations{
+				Title: "Create Job Annotation",
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateJobAnnotationArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.CreateJobAnnotation")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("job_id", args.JobID),
+				attribute.String("context", args.Context),
+				attribute.String("style", args.Style),
+				attribute.Int("priority", args.Priority),
+				attribute.Bool("append", args.Append),
+			)
+
+			deps := DepsFromContext(ctx)
+			annotation, _, err := deps.AnnotationsClient.CreateForJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, buildkite.AnnotationCreate{
+				Body:     args.Body,
+				Context:  args.Context,
+				Style:    args.Style,
+				Priority: args.Priority,
+				Append:   args.Append,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, &annotation)
+		}, []string{"write_builds"}
+}
+
+func DeleteJobAnnotation() (mcp.Tool, mcp.ToolHandlerFor[DeleteJobAnnotationArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "delete_job_annotation",
+			Description: "Delete a job-level annotation from a specific job in a Buildkite build",
+			Annotations: &mcp.ToolAnnotations{
+				Title:           "Delete Job Annotation",
+				DestructiveHint: boolPtr(true),
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args DeleteJobAnnotationArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.DeleteJobAnnotation")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("job_id", args.JobID),
+				attribute.String("annotation_id", args.AnnotationID),
+			)
+
+			deps := DepsFromContext(ctx)
+			_, err := deps.AnnotationsClient.DeleteForJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.AnnotationID)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, map[string]any{
+				"deleted":       true,
+				"scope":         "job",
+				"job_id":        args.JobID,
+				"annotation_id": args.AnnotationID,
+			})
+		}, []string{"write_builds"}
 }

--- a/pkg/buildkite/annotations_test.go
+++ b/pkg/buildkite/annotations_test.go
@@ -12,10 +12,8 @@ import (
 type MockAnnotationsClient struct {
 	ListByBuildFunc  func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
 	CreateFunc       func(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
-	DeleteFunc       func(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error)
 	ListByJobFunc    func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
 	CreateForJobFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
-	DeleteForJobFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error)
 }
 
 func (m *MockAnnotationsClient) ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
@@ -32,13 +30,6 @@ func (m *MockAnnotationsClient) Create(ctx context.Context, org, pipelineSlug, b
 	return buildkite.Annotation{}, nil, nil
 }
 
-func (m *MockAnnotationsClient) Delete(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error) {
-	if m.DeleteFunc != nil {
-		return m.DeleteFunc(ctx, org, pipelineSlug, buildNumber, annotationID)
-	}
-	return nil, nil
-}
-
 func (m *MockAnnotationsClient) ListByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
 	if m.ListByJobFunc != nil {
 		return m.ListByJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, opts)
@@ -53,13 +44,6 @@ func (m *MockAnnotationsClient) CreateForJob(ctx context.Context, org, pipelineS
 	return buildkite.Annotation{}, nil, nil
 }
 
-func (m *MockAnnotationsClient) DeleteForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error) {
-	if m.DeleteForJobFunc != nil {
-		return m.DeleteForJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, annotationID)
-	}
-	return nil, nil
-}
-
 var _ AnnotationsClient = (*MockAnnotationsClient)(nil)
 
 func TestListAnnotations(t *testing.T) {
@@ -68,19 +52,9 @@ func TestListAnnotations(t *testing.T) {
 	client := &MockAnnotationsClient{
 		ListByBuildFunc: func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
 			return []buildkite.Annotation{
-					{
-						ID:       "1",
-						BodyHTML: "Test annotation 1",
-					},
-					{
-						ID:       "2",
-						BodyHTML: "Test annotation 2",
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
+				{ID: "1", BodyHTML: "Test annotation 1"},
+				{ID: "2", BodyHTML: "Test annotation 2"},
+			}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
 		},
 	}
 
@@ -89,16 +63,62 @@ func TestListAnnotations(t *testing.T) {
 	tool, handler, _ := ListAnnotations()
 	assert.NotNil(tool)
 	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, ListAnnotationsArgs{
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListAnnotationsArgs{
 		OrgSlug:      "org",
 		PipelineSlug: "pipeline",
 		BuildNumber:  "1",
 	})
 	assert.NoError(err)
-	textContent := getTextResult(t, result)
 
+	textContent := getTextResult(t, result)
 	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"1","body_html":"Test annotation 1"},{"id":"2","body_html":"Test annotation 2"}]}`, textContent.Text)
+}
+
+func TestListAnnotationsForJobScope(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		ListByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			assert.Equal("job-1", jobID)
+			return []buildkite.Annotation{{ID: "1", Scope: "job", BodyHTML: "Job annotation"}}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := ListAnnotations()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListAnnotationsArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		Scope:        "job",
+		JobID:        "job-1",
+	})
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"1","scope":"job","body_html":"Job annotation"}]}`, textContent.Text)
+}
+
+func TestListAnnotationsRequiresJobIDForJobScope(t *testing.T) {
+	assert := require.New(t)
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: &MockAnnotationsClient{}})
+
+	_, handler, _ := ListAnnotations()
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListAnnotationsArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		Scope:        "job",
+	})
+	assert.NoError(err)
+	assert.True(result.IsError)
+	assert.Contains(getTextResult(t, result).Text, "job_id is required when scope is 'job'")
 }
 
 func TestCreateAnnotation(t *testing.T) {
@@ -133,8 +153,8 @@ func TestCreateAnnotation(t *testing.T) {
 	tool, handler, _ := CreateAnnotation()
 	assert.NotNil(tool)
 	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, CreateAnnotationArgs{
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreateAnnotationArgs{
 		OrgSlug:      "org",
 		PipelineSlug: "pipeline",
 		BuildNumber:  "1",
@@ -145,81 +165,12 @@ func TestCreateAnnotation(t *testing.T) {
 		Append:       true,
 	})
 	assert.NoError(err)
-	textContent := getTextResult(t, result)
 
+	textContent := getTextResult(t, result)
 	assert.JSONEq(`{"id":"ann-1","context":"greeting","style":"info","scope":"build","priority":5,"body_html":"<p>Hello world!</p>"}`, textContent.Text)
 }
 
-func TestDeleteAnnotation(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockAnnotationsClient{
-		DeleteFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error) {
-			assert.Equal("org", org)
-			assert.Equal("pipeline", pipelineSlug)
-			assert.Equal("1", buildNumber)
-			assert.Equal("ann-1", annotationID)
-			return &buildkite.Response{Response: &http.Response{StatusCode: 204}}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
-
-	tool, handler, _ := DeleteAnnotation()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, DeleteAnnotationArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
-		AnnotationID: "ann-1",
-	})
-	assert.NoError(err)
-	textContent := getTextResult(t, result)
-
-	assert.JSONEq(`{"deleted":true,"scope":"build","annotation_id":"ann-1"}`, textContent.Text)
-}
-
-func TestListJobAnnotations(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockAnnotationsClient{
-		ListByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
-			assert.Equal("job-1", jobID)
-			return []buildkite.Annotation{
-					{
-						ID:       "1",
-						Scope:    "job",
-						BodyHTML: "Job annotation",
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
-
-	tool, handler, _ := ListJobAnnotations()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, ListJobAnnotationsArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
-		JobID:        "job-1",
-	})
-	assert.NoError(err)
-	textContent := getTextResult(t, result)
-
-	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"1","scope":"job","body_html":"Job annotation"}]}`, textContent.Text)
-}
-
-func TestCreateJobAnnotation(t *testing.T) {
+func TestCreateAnnotationForJobScope(t *testing.T) {
 	assert := require.New(t)
 
 	client := &MockAnnotationsClient{
@@ -246,14 +197,15 @@ func TestCreateJobAnnotation(t *testing.T) {
 
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
 
-	tool, handler, _ := CreateJobAnnotation()
+	tool, handler, _ := CreateAnnotation()
 	assert.NotNil(tool)
 	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, CreateJobAnnotationArgs{
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreateAnnotationArgs{
 		OrgSlug:      "org",
 		PipelineSlug: "pipeline",
 		BuildNumber:  "1",
+		Scope:        "job",
 		JobID:        "job-1",
 		Body:         "Tests passed",
 		Context:      "test-results",
@@ -261,37 +213,25 @@ func TestCreateJobAnnotation(t *testing.T) {
 		Priority:     3,
 	})
 	assert.NoError(err)
-	textContent := getTextResult(t, result)
 
+	textContent := getTextResult(t, result)
 	assert.JSONEq(`{"id":"ann-job-1","context":"test-results","style":"success","scope":"job","priority":3,"body_html":"<p>Tests passed</p>"}`, textContent.Text)
 }
 
-func TestDeleteJobAnnotation(t *testing.T) {
+func TestCreateAnnotationRejectsInvalidScope(t *testing.T) {
 	assert := require.New(t)
 
-	client := &MockAnnotationsClient{
-		DeleteForJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error) {
-			assert.Equal("job-1", jobID)
-			assert.Equal("ann-job-1", annotationID)
-			return &buildkite.Response{Response: &http.Response{StatusCode: 204}}, nil
-		},
-	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: &MockAnnotationsClient{}})
 
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
-
-	tool, handler, _ := DeleteJobAnnotation()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, DeleteJobAnnotationArgs{
+	_, handler, _ := CreateAnnotation()
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreateAnnotationArgs{
 		OrgSlug:      "org",
 		PipelineSlug: "pipeline",
 		BuildNumber:  "1",
-		JobID:        "job-1",
-		AnnotationID: "ann-job-1",
+		Scope:        "wat",
+		Body:         "Hello world!",
 	})
 	assert.NoError(err)
-	textContent := getTextResult(t, result)
-
-	assert.JSONEq(`{"deleted":true,"scope":"job","job_id":"job-1","annotation_id":"ann-job-1"}`, textContent.Text)
+	assert.True(result.IsError)
+	assert.Contains(getTextResult(t, result).Text, "scope must be 'build' or 'job'")
 }

--- a/pkg/buildkite/annotations_test.go
+++ b/pkg/buildkite/annotations_test.go
@@ -10,8 +10,12 @@ import (
 )
 
 type MockAnnotationsClient struct {
-	ListByBuildFunc func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
-	GetFunc         func(ctx context.Context, org, pipelineSlug, buildNumber, id string) (buildkite.Annotation, *buildkite.Response, error)
+	ListByBuildFunc  func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
+	CreateFunc       func(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
+	DeleteFunc       func(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error)
+	ListByJobFunc    func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error)
+	CreateForJobFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error)
+	DeleteForJobFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error)
 }
 
 func (m *MockAnnotationsClient) ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
@@ -19,6 +23,41 @@ func (m *MockAnnotationsClient) ListByBuild(ctx context.Context, org, pipelineSl
 		return m.ListByBuildFunc(ctx, org, pipelineSlug, buildNumber, opts)
 	}
 	return nil, nil, nil
+}
+
+func (m *MockAnnotationsClient) Create(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error) {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(ctx, org, pipelineSlug, buildNumber, ac)
+	}
+	return buildkite.Annotation{}, nil, nil
+}
+
+func (m *MockAnnotationsClient) Delete(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error) {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, org, pipelineSlug, buildNumber, annotationID)
+	}
+	return nil, nil
+}
+
+func (m *MockAnnotationsClient) ListByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+	if m.ListByJobFunc != nil {
+		return m.ListByJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, opts)
+	}
+	return nil, nil, nil
+}
+
+func (m *MockAnnotationsClient) CreateForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error) {
+	if m.CreateForJobFunc != nil {
+		return m.CreateForJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, ac)
+	}
+	return buildkite.Annotation{}, nil, nil
+}
+
+func (m *MockAnnotationsClient) DeleteForJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error) {
+	if m.DeleteForJobFunc != nil {
+		return m.DeleteForJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, annotationID)
+	}
+	return nil, nil
 }
 
 var _ AnnotationsClient = (*MockAnnotationsClient)(nil)
@@ -60,4 +99,199 @@ func TestListAnnotations(t *testing.T) {
 	textContent := getTextResult(t, result)
 
 	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"1","body_html":"Test annotation 1"},{"id":"2","body_html":"Test annotation 2"}]}`, textContent.Text)
+}
+
+func TestCreateAnnotation(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		CreateFunc: func(ctx context.Context, org, pipelineSlug, buildNumber string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error) {
+			assert.Equal("org", org)
+			assert.Equal("pipeline", pipelineSlug)
+			assert.Equal("1", buildNumber)
+			assert.Equal(buildkite.AnnotationCreate{
+				Body:     "Hello world!",
+				Context:  "greeting",
+				Style:    "info",
+				Priority: 5,
+				Append:   true,
+			}, ac)
+
+			return buildkite.Annotation{
+				ID:       "ann-1",
+				Context:  "greeting",
+				Style:    "info",
+				Scope:    "build",
+				Priority: 5,
+				BodyHTML: "<p>Hello world!</p>",
+			}, &buildkite.Response{Response: &http.Response{StatusCode: 201}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := CreateAnnotation()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, CreateAnnotationArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		Body:         "Hello world!",
+		Context:      "greeting",
+		Style:        "info",
+		Priority:     5,
+		Append:       true,
+	})
+	assert.NoError(err)
+	textContent := getTextResult(t, result)
+
+	assert.JSONEq(`{"id":"ann-1","context":"greeting","style":"info","scope":"build","priority":5,"body_html":"<p>Hello world!</p>"}`, textContent.Text)
+}
+
+func TestDeleteAnnotation(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		DeleteFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, annotationID string) (*buildkite.Response, error) {
+			assert.Equal("org", org)
+			assert.Equal("pipeline", pipelineSlug)
+			assert.Equal("1", buildNumber)
+			assert.Equal("ann-1", annotationID)
+			return &buildkite.Response{Response: &http.Response{StatusCode: 204}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := DeleteAnnotation()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, DeleteAnnotationArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		AnnotationID: "ann-1",
+	})
+	assert.NoError(err)
+	textContent := getTextResult(t, result)
+
+	assert.JSONEq(`{"deleted":true,"scope":"build","annotation_id":"ann-1"}`, textContent.Text)
+}
+
+func TestListJobAnnotations(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		ListByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			assert.Equal("job-1", jobID)
+			return []buildkite.Annotation{
+					{
+						ID:       "1",
+						Scope:    "job",
+						BodyHTML: "Job annotation",
+					},
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: 200,
+					},
+				}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := ListJobAnnotations()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, ListJobAnnotationsArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		JobID:        "job-1",
+	})
+	assert.NoError(err)
+	textContent := getTextResult(t, result)
+
+	assert.JSONEq(`{"headers":{"Link":""},"items":[{"id":"1","scope":"job","body_html":"Job annotation"}]}`, textContent.Text)
+}
+
+func TestCreateJobAnnotation(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		CreateForJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID string, ac buildkite.AnnotationCreate) (buildkite.Annotation, *buildkite.Response, error) {
+			assert.Equal("job-1", jobID)
+			assert.Equal(buildkite.AnnotationCreate{
+				Body:     "Tests passed",
+				Context:  "test-results",
+				Style:    "success",
+				Priority: 3,
+				Append:   false,
+			}, ac)
+
+			return buildkite.Annotation{
+				ID:       "ann-job-1",
+				Context:  "test-results",
+				Style:    "success",
+				Scope:    "job",
+				Priority: 3,
+				BodyHTML: "<p>Tests passed</p>",
+			}, &buildkite.Response{Response: &http.Response{StatusCode: 201}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := CreateJobAnnotation()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, CreateJobAnnotationArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		JobID:        "job-1",
+		Body:         "Tests passed",
+		Context:      "test-results",
+		Style:        "success",
+		Priority:     3,
+	})
+	assert.NoError(err)
+	textContent := getTextResult(t, result)
+
+	assert.JSONEq(`{"id":"ann-job-1","context":"test-results","style":"success","scope":"job","priority":3,"body_html":"<p>Tests passed</p>"}`, textContent.Text)
+}
+
+func TestDeleteJobAnnotation(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockAnnotationsClient{
+		DeleteForJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, annotationID string) (*buildkite.Response, error) {
+			assert.Equal("job-1", jobID)
+			assert.Equal("ann-job-1", annotationID)
+			return &buildkite.Response{Response: &http.Response{StatusCode: 204}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{AnnotationsClient: client})
+
+	tool, handler, _ := DeleteJobAnnotation()
+	assert.NotNil(tool)
+	assert.NotNil(handler)
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, DeleteJobAnnotationArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+		JobID:        "job-1",
+		AnnotationID: "ann-job-1",
+	})
+	assert.NoError(err)
+	textContent := getTextResult(t, result)
+
+	assert.JSONEq(`{"deleted":true,"scope":"job","job_id":"job-1","annotation_id":"ann-job-1"}`, textContent.Text)
 }

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -367,10 +367,6 @@ func CreateBuiltinToolsets() map[string]Toolset {
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.ListAnnotations),
 				newToolDef(buildkite.CreateAnnotation),
-				newToolDef(buildkite.DeleteAnnotation),
-				newToolDef(buildkite.ListJobAnnotations),
-				newToolDef(buildkite.CreateJobAnnotation),
-				newToolDef(buildkite.DeleteJobAnnotation),
 			},
 		},
 		ToolsetUser: {

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -363,9 +363,14 @@ func CreateBuiltinToolsets() map[string]Toolset {
 		},
 		ToolsetAnnotations: {
 			Name:        "Annotation Management",
-			Description: "Tools for managing build annotations",
+			Description: "Tools for managing build and job annotations",
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.ListAnnotations),
+				newToolDef(buildkite.CreateAnnotation),
+				newToolDef(buildkite.DeleteAnnotation),
+				newToolDef(buildkite.ListJobAnnotations),
+				newToolDef(buildkite.CreateJobAnnotation),
+				newToolDef(buildkite.DeleteJobAnnotation),
 			},
 		},
 		ToolsetUser: {


### PR DESCRIPTION
## Description

This PR extends the annotations package in the MCP to support job-level annotations. It also allows for other function like creating and deleting.

## Changes

- adds support for job-level annotations (with tests)
- adds create and list function (job) to annotations for more options via the MCP
- updates the toolset

## Testing

Can be pulled down and tested locally with a annotation-scoped API token (as well as build and pipeline scope for annotation discovery)

```sh
go test ./... -v
```
