### PR TITLE
[PB-1900] replace get_artifact url arg with structured identifiers

### DIFF
--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"regexp"
-	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
@@ -21,7 +19,7 @@ import (
 type ArtifactsClient interface {
 	ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
 	ListByJob(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
-	DownloadArtifactByURL(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error)
+	DownloadArtifact(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error)
 }
 
 // BuildkiteClientAdapter adapts the buildkite.Client to work with our interfaces
@@ -39,44 +37,26 @@ func (a *BuildkiteClientAdapter) ListByJob(ctx context.Context, org, pipelineSlu
 	return a.Artifacts.ListByJob(ctx, org, pipelineSlug, buildNumber, jobID, opts)
 }
 
-// DownloadArtifactByURL implements ArtifactsClient with URL rewriting support
-func (a *BuildkiteClientAdapter) DownloadArtifactByURL(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
-	// Rewrite URL if it's using the default Buildkite API URL and we have a custom base URL
-	rewrittenURL := a.rewriteArtifactURL(url)
-	return a.Artifacts.DownloadArtifactByURL(ctx, rewrittenURL, writer)
+// DownloadArtifact implements ArtifactsClient. The artifact endpoint is built
+// from the supplied identifiers and resolved relative to the client's configured
+// BaseURL, so proxied installations (with a base-path prefix) are handled by the
+// client and the caller never supplies a raw URL.
+func (a *BuildkiteClientAdapter) DownloadArtifact(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+	return a.Artifacts.DownloadArtifactByURL(ctx, artifactDownloadPath(org, pipelineSlug, buildNumber, jobID, artifactID), writer)
 }
 
-// rewriteArtifactURL rewrites artifact URLs to use the configured base URL
-func (a *BuildkiteClientAdapter) rewriteArtifactURL(inputURL string) string {
-	// Parse the input URL
-	parsedURL, err := url.Parse(inputURL)
-	if err != nil {
-		// If we can't parse the URL, return it as-is
-		return inputURL
-	}
-
-	// Get the configured base URL from the client
-	baseURL := a.BaseURL
-	if baseURL == nil || baseURL.String() == "" {
-		return inputURL
-	}
-
-	// Only rewrite if the base URL is different from the input URL's host and scheme
-	// and the base URL is non-empty
-	if baseURL.Host != parsedURL.Host || baseURL.Scheme != parsedURL.Scheme {
-		// Replace the host and scheme with the configured base URL
-		parsedURL.Scheme = baseURL.Scheme
-		parsedURL.Host = baseURL.Host
-
-		// If the base URL has a path prefix, prepend it to the existing path
-		if baseURL.Path != "" && baseURL.Path != "/" {
-			// Remove trailing slash from base path if present
-			basePath := strings.TrimSuffix(baseURL.Path, "/")
-			parsedURL.Path = basePath + parsedURL.Path
-		}
-	}
-
-	return parsedURL.String()
+// artifactDownloadPath builds the relative Buildkite REST path for an artifact
+// download. Each identifier is path-escaped so a value cannot inject extra path
+// segments, and the fixed endpoint structure is hard-coded, so the request can
+// only ever address an artifact download resource.
+func artifactDownloadPath(org, pipelineSlug, buildNumber, jobID, artifactID string) string {
+	return fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts/%s/download",
+		url.PathEscape(org),
+		url.PathEscape(pipelineSlug),
+		url.PathEscape(buildNumber),
+		url.PathEscape(jobID),
+		url.PathEscape(artifactID),
+	)
 }
 
 type ListArtifactsForBuildArgs struct {
@@ -97,7 +77,11 @@ type ListArtifactsForJobArgs struct {
 }
 
 type GetArtifactArgs struct {
-	URL string `json:"url"`
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+	JobID        string `json:"job_id" jsonschema:"The UUID of the job that produced the artifact"`
+	ArtifactID   string `json:"artifact_id" jsonschema:"The UUID of the artifact to download"`
 }
 
 func ListArtifactsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForBuildArgs, any], []string) {
@@ -194,37 +178,10 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 		}, []string{"read_artifacts"}
 }
 
-// artifactURLPathPattern matches the path of a Buildkite REST API artifact
-// resource, optionally ending in "/download". A leading base-path prefix (used
-// by proxied installations, e.g. "/rest") is permitted, but every segment is a
-// single non-slash component and the pattern is anchored to the end of the path,
-// so the URL cannot be coerced into addressing a different API endpoint such as
-// /v2/access-token.
-var artifactURLPathPattern = regexp.MustCompile(
-	`/v2/organizations/[^/]+/pipelines/[^/]+/builds/[^/]+/jobs/[^/]+/artifacts/[^/]+(?:/download)?$`)
-
-// validateArtifactURL ensures rawURL is an http(s) URL that addresses a Buildkite
-// artifact resource. get_artifact issues an authenticated GET against this URL,
-// so restricting it to the artifact endpoint shape prevents the tool from being
-// used to read unrelated endpoints with the caller's token.
-func validateArtifactURL(rawURL string) (*url.URL, error) {
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-		return nil, fmt.Errorf("invalid URL format: must be an http or https URL")
-	}
-
-	if !artifactURLPathPattern.MatchString(parsedURL.EscapedPath()) {
-		return nil, fmt.Errorf("invalid artifact URL: path must reference a Buildkite artifact " +
-			"(e.g. /v2/organizations/{org}/pipelines/{pipeline}/builds/{build}/jobs/{job}/artifacts/{id}/download)")
-	}
-
-	return parsedURL, nil
-}
-
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
-			Description: "Get detailed information about a specific artifact including its metadata, file size, SHA-1 hash, and download URL",
+			Description: "Download a specific artifact's content, identified by its organization, pipeline, build, job, and artifact identifiers. The content is returned base64-encoded",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Artifact",
 				ReadOnlyHint: true,
@@ -234,22 +191,18 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 			ctx, span := trace.Start(ctx, "buildkite.GetArtifact")
 			defer span.End()
 
-			artifactURL := args.URL
-
-			// Lock the URL to the Buildkite artifact endpoint shape. The handler
-			// performs an authenticated GET against this URL, so accepting arbitrary
-			// URLs would let get_artifact be used to fetch unrelated API endpoints
-			// with the caller's credentials.
-			if _, err := validateArtifactURL(artifactURL); err != nil {
-				return utils.NewToolResultError(err.Error()), nil, nil
-			}
-
-			span.SetAttributes(attribute.String("url", artifactURL))
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("job_id", args.JobID),
+				attribute.String("artifact_id", args.ArtifactID),
+			)
 
 			// Use a buffer to capture the artifact data instead of writing directly to stdout
 			var buffer bytes.Buffer
 			deps := DepsFromContext(ctx)
-			resp, err := deps.ArtifactsClient.DownloadArtifactByURL(ctx, artifactURL, &buffer)
+			resp, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, &buffer)
 			if err != nil {
 				return utils.NewToolResultError(fmt.Sprintf("response failed with error %s", err.Error())), nil, nil
 			}

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
@@ -193,6 +194,33 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 		}, []string{"read_artifacts"}
 }
 
+// artifactURLPathPattern matches the path of a Buildkite REST API artifact
+// resource, optionally ending in "/download". A leading base-path prefix (used
+// by proxied installations, e.g. "/rest") is permitted, but every segment is a
+// single non-slash component and the pattern is anchored to the end of the path,
+// so the URL cannot be coerced into addressing a different API endpoint such as
+// /v2/access-token.
+var artifactURLPathPattern = regexp.MustCompile(
+	`/v2/organizations/[^/]+/pipelines/[^/]+/builds/[^/]+/jobs/[^/]+/artifacts/[^/]+(?:/download)?$`)
+
+// validateArtifactURL ensures rawURL is an http(s) URL that addresses a Buildkite
+// artifact resource. get_artifact issues an authenticated GET against this URL,
+// so restricting it to the artifact endpoint shape prevents the tool from being
+// used to read unrelated endpoints with the caller's token.
+func validateArtifactURL(rawURL string) (*url.URL, error) {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
+		return nil, fmt.Errorf("invalid URL format: must be an http or https URL")
+	}
+
+	if !artifactURLPathPattern.MatchString(parsedURL.EscapedPath()) {
+		return nil, fmt.Errorf("invalid artifact URL: path must reference a Buildkite artifact " +
+			"(e.g. /v2/organizations/{org}/pipelines/{pipeline}/builds/{build}/jobs/{job}/artifacts/{id}/download)")
+	}
+
+	return parsedURL, nil
+}
+
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
@@ -208,10 +236,12 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 
 			artifactURL := args.URL
 
-			// Validate the URL format and scheme
-			parsedURL, err := url.Parse(artifactURL)
-			if err != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") {
-				return utils.NewToolResultError("invalid URL format: must be an http or https URL"), nil, nil
+			// Lock the URL to the Buildkite artifact endpoint shape. The handler
+			// performs an authenticated GET against this URL, so accepting arbitrary
+			// URLs would let get_artifact be used to fetch unrelated API endpoints
+			// with the caller's credentials.
+			if _, err := validateArtifactURL(artifactURL); err != nil {
+				return utils.NewToolResultError(err.Error()), nil, nil
 			}
 
 			span.SetAttributes(attribute.String("url", artifactURL))

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/buildkite/go-buildkite/v5"
@@ -12,9 +13,9 @@ import (
 )
 
 type MockArtifactsClient struct {
-	ListByBuildFunc           func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
-	ListByJobFunc             func(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
-	DownloadArtifactByURLFunc func(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error)
+	ListByBuildFunc      func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
+	ListByJobFunc        func(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
+	DownloadArtifactFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error)
 }
 
 func (m *MockArtifactsClient) ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error) {
@@ -31,9 +32,9 @@ func (m *MockArtifactsClient) ListByJob(ctx context.Context, org, pipelineSlug, 
 	return nil, nil, nil
 }
 
-func (m *MockArtifactsClient) DownloadArtifactByURL(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
-	if m.DownloadArtifactByURLFunc != nil {
-		return m.DownloadArtifactByURLFunc(ctx, url, writer)
+func (m *MockArtifactsClient) DownloadArtifact(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+	if m.DownloadArtifactFunc != nil {
+		return m.DownloadArtifactFunc(ctx, org, pipelineSlug, buildNumber, jobID, artifactID, writer)
 	}
 	return nil, nil
 }
@@ -127,8 +128,11 @@ func TestListArtifactsForJob(t *testing.T) {
 func TestGetArtifact(t *testing.T) {
 	assert := require.New(t)
 
+	var gotArgs []string
 	client := &MockArtifactsClient{
-		DownloadArtifactByURLFunc: func(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			gotArgs = []string{org, pipelineSlug, buildNumber, jobID, artifactID}
+
 			// Simulate writing artifact content to the provided writer
 			_, err := writer.Write([]byte("This is test artifact content"))
 			if err != nil {
@@ -152,9 +156,14 @@ func TestGetArtifact(t *testing.T) {
 
 	request := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, request, GetArtifactArgs{
-		URL: "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
 	})
 	assert.NoError(err)
+	assert.Equal([]string{"myorg", "my-pipeline", "123", "abc", "def"}, gotArgs)
 
 	textContent := getTextResult(t, result)
 
@@ -171,7 +180,7 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 	assert := require.New(t)
 
 	client := &MockArtifactsClient{
-		DownloadArtifactByURLFunc: func(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
 			resp := &http.Response{
 				Request:    &http.Request{Method: "GET"},
 				StatusCode: 404,
@@ -190,210 +199,91 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 
 	req := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, req, GetArtifactArgs{
-		URL: "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/missing/download",
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "missing",
 	})
 	assert.NoError(err)
 	assert.NotNil(result)
 	assert.Contains(getTextResult(t, result).Text, `{"message":"Artifact not found"}`)
 }
 
-func TestGetArtifact_RejectsNonArtifactURL(t *testing.T) {
+func TestArtifactDownloadPath(t *testing.T) {
 	assert := require.New(t)
 
-	var called bool
-	client := &MockArtifactsClient{
-		DownloadArtifactByURLFunc: func(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
-			called = true
-			return &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
-		},
-	}
+	assert.Equal(
+		"v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
+		artifactDownloadPath("myorg", "my-pipeline", "123", "abc", "def"),
+	)
 
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
-	_, handler, _ := GetArtifact()
-
-	// A URL that the caller's token could otherwise reach, but which is not an
-	// artifact resource, must be rejected before any request is issued.
-	req := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, req, GetArtifactArgs{
-		URL: "https://api.buildkite.com/v2/access-token",
-	})
-	assert.NoError(err)
-	assert.NotNil(result)
-	assert.Contains(getTextResult(t, result).Text, "invalid artifact URL")
-	assert.False(called, "download must not be attempted for a non-artifact URL")
+	// Path-unsafe characters in an identifier are escaped so the value cannot
+	// inject extra path segments and alter which endpoint is addressed.
+	assert.Equal(
+		"v2/organizations/o/pipelines/p/builds/b/jobs/j/artifacts/a%2F..%2Faccess-token/download",
+		artifactDownloadPath("o", "p", "b", "j", "a/../access-token"),
+	)
 }
 
-func TestValidateArtifactURL(t *testing.T) {
+func TestBuildkiteClientAdapter_DownloadArtifact(t *testing.T) {
+	assert := require.New(t)
+
+	const wantSuffix = "/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download"
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte("artifact-bytes"))
+	}))
+	defer srv.Close()
+
 	tests := []struct {
-		name    string
-		url     string
-		wantErr bool
+		name     string
+		basePath string // appended to the test server URL to form the base URL
+		wantPath string
 	}{
 		{
-			name: "artifact download URL",
-			url:  "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
+			// The common production shape: host with a root path and trailing
+			// slash. No prefix is added and none is dropped.
+			name:     "default root base url",
+			basePath: "/",
+			wantPath: wantSuffix,
 		},
 		{
-			name: "artifact resource URL without /download",
-			url:  "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def",
+			// A proxied installation serving the REST API under a path prefix;
+			// the prefix must be preserved on the resolved request.
+			name:     "proxy base url with trailing slash",
+			basePath: "/rest/",
+			wantPath: "/rest" + wantSuffix,
 		},
 		{
-			name: "proxied install with base path prefix",
-			url:  "https://buildkite.proxy.com/rest/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-		},
-		{
-			name:    "access-token endpoint",
-			url:     "https://api.buildkite.com/v2/access-token",
-			wantErr: true,
-		},
-		{
-			name:    "user endpoint",
-			url:     "https://api.buildkite.com/v2/user",
-			wantErr: true,
-		},
-		{
-			name:    "artifact prefix but trailing different endpoint",
-			url:     "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download/../../access-token",
-			wantErr: true,
-		},
-		{
-			name:    "extra path segment after artifact id",
-			url:     "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/secrets",
-			wantErr: true,
-		},
-		{
-			name:    "non-http scheme",
-			url:     "file:///etc/passwd",
-			wantErr: true,
-		},
-		{
-			name:    "arbitrary host and path",
-			url:     "https://example.com/artifact",
-			wantErr: true,
+			// Same proxy prefix without a trailing slash — a realistic
+			// misconfiguration the client must normalise to the same request.
+			name:     "proxy base url without trailing slash",
+			basePath: "/rest",
+			wantPath: "/rest" + wantSuffix,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := validateArtifactURL(tt.url)
-			if tt.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
-}
+			gotPath = ""
 
-func TestBuildkiteClientAdapter_URLRewriting(t *testing.T) {
-	assert := require.New(t)
-
-	// Test rewriteArtifactURL method
-	tests := []struct {
-		name        string
-		baseURL     string
-		inputURL    string
-		expectedURL string
-	}{
-		{
-			name:        "should rewrite URLs when base URL has different host",
-			baseURL:     "https://buildkite.proxy.com/rest/",
-			inputURL:    "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-			expectedURL: "https://buildkite.proxy.com/rest/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-		},
-		{
-			name:        "should not rewrite URLs when base URL matches input URL host and scheme",
-			baseURL:     "https://api.buildkite.com/",
-			inputURL:    "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-			expectedURL: "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-		},
-		{
-			name:        "should rewrite URLs when base URL has different host (any domain)",
-			baseURL:     "https://buildkite.proxy.com/rest/",
-			inputURL:    "https://example.com/some/other/url",
-			expectedURL: "https://buildkite.proxy.com/rest/some/other/url",
-		},
-		{
-			name:        "should handle base URL without trailing slash",
-			baseURL:     "https://buildkite.proxy.com/rest",
-			inputURL:    "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-			expectedURL: "https://buildkite.proxy.com/rest/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
-		},
-		{
-			name:        "should handle scheme differences",
-			baseURL:     "http://buildkite.proxy.com/",
-			inputURL:    "https://api.buildkite.com/v2/test",
-			expectedURL: "http://buildkite.proxy.com/v2/test",
-		},
-		{
-			name:        "should not rewrite when hosts and schemes match exactly",
-			baseURL:     "https://api.buildkite.com/",
-			inputURL:    "https://api.buildkite.com/v2/test",
-			expectedURL: "https://api.buildkite.com/v2/test",
-		},
-		{
-			name:        "should handle base URL with complex path prefix",
-			baseURL:     "https://proxy.example.com/buildkite/api/",
-			inputURL:    "https://api.buildkite.com/v2/orgs/test",
-			expectedURL: "https://proxy.example.com/buildkite/api/v2/orgs/test",
-		},
-		{
-			name:        "should return original URL when input URL is malformed",
-			baseURL:     "https://buildkite.proxy.com/",
-			inputURL:    "://malformed-url",
-			expectedURL: "://malformed-url",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a mock buildkite client with the desired base URL
 			client, err := buildkite.NewOpts(
 				buildkite.WithTokenAuth("fake-token"),
-				buildkite.WithBaseURL(tt.baseURL),
+				buildkite.WithBaseURL(srv.URL+tt.basePath),
 			)
 			assert.NoError(err)
 
 			adapter := &BuildkiteClientAdapter{Client: client}
-			result := adapter.rewriteArtifactURL(tt.inputURL)
-			assert.Equal(tt.expectedURL, result)
+
+			var buf bytes.Buffer
+			resp, err := adapter.DownloadArtifact(context.Background(), "myorg", "my-pipeline", "123", "abc", "def", &buf)
+			assert.NoError(err)
+			assert.Equal(200, resp.StatusCode)
+			assert.Equal("artifact-bytes", buf.String())
+			assert.Equal(tt.wantPath, gotPath)
 		})
 	}
-}
-
-func TestBuildkiteClientAdapter_URLRewritingEdgeCases(t *testing.T) {
-	assert := require.New(t)
-
-	// Test edge cases
-	t.Run("should handle nil base URL", func(t *testing.T) {
-		adapter := &BuildkiteClientAdapter{
-			Client: &buildkite.Client{},
-		}
-		result := adapter.rewriteArtifactURL("https://api.buildkite.com/test")
-		assert.Equal("https://api.buildkite.com/test", result)
-	})
-
-	t.Run("should handle empty base URL", func(t *testing.T) {
-		client, err := buildkite.NewOpts(
-			buildkite.WithTokenAuth("fake-token"),
-			buildkite.WithBaseURL(""),
-		)
-		assert.NoError(err)
-
-		adapter := &BuildkiteClientAdapter{Client: client}
-		result := adapter.rewriteArtifactURL("https://api.buildkite.com/test")
-		assert.Equal("https://api.buildkite.com/test", result)
-	})
-
-	t.Run("should handle base URL with only root path", func(t *testing.T) {
-		client, err := buildkite.NewOpts(
-			buildkite.WithTokenAuth("fake-token"),
-			buildkite.WithBaseURL("https://proxy.example.com/"),
-		)
-		assert.NoError(err)
-
-		adapter := &BuildkiteClientAdapter{Client: client}
-		result := adapter.rewriteArtifactURL("https://api.buildkite.com/v2/test")
-		assert.Equal("https://proxy.example.com/v2/test", result)
-	})
 }

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -152,7 +152,7 @@ func TestGetArtifact(t *testing.T) {
 
 	request := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, request, GetArtifactArgs{
-		URL: "https://example.com/artifact",
+		URL: "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
 	})
 	assert.NoError(err)
 
@@ -190,11 +190,99 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 
 	req := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, req, GetArtifactArgs{
-		URL: "https://example.com/nonexistent-artifact",
+		URL: "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/missing/download",
 	})
 	assert.NoError(err)
 	assert.NotNil(result)
 	assert.Contains(getTextResult(t, result).Text, `{"message":"Artifact not found"}`)
+}
+
+func TestGetArtifact_RejectsNonArtifactURL(t *testing.T) {
+	assert := require.New(t)
+
+	var called bool
+	client := &MockArtifactsClient{
+		DownloadArtifactByURLFunc: func(ctx context.Context, url string, writer io.Writer) (*buildkite.Response, error) {
+			called = true
+			return &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	// A URL that the caller's token could otherwise reach, but which is not an
+	// artifact resource, must be rejected before any request is issued.
+	req := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, req, GetArtifactArgs{
+		URL: "https://api.buildkite.com/v2/access-token",
+	})
+	assert.NoError(err)
+	assert.NotNil(result)
+	assert.Contains(getTextResult(t, result).Text, "invalid artifact URL")
+	assert.False(called, "download must not be attempted for a non-artifact URL")
+}
+
+func TestValidateArtifactURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{
+			name: "artifact download URL",
+			url:  "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
+		},
+		{
+			name: "artifact resource URL without /download",
+			url:  "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def",
+		},
+		{
+			name: "proxied install with base path prefix",
+			url:  "https://buildkite.proxy.com/rest/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download",
+		},
+		{
+			name:    "access-token endpoint",
+			url:     "https://api.buildkite.com/v2/access-token",
+			wantErr: true,
+		},
+		{
+			name:    "user endpoint",
+			url:     "https://api.buildkite.com/v2/user",
+			wantErr: true,
+		},
+		{
+			name:    "artifact prefix but trailing different endpoint",
+			url:     "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download/../../access-token",
+			wantErr: true,
+		},
+		{
+			name:    "extra path segment after artifact id",
+			url:     "https://api.buildkite.com/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/secrets",
+			wantErr: true,
+		},
+		{
+			name:    "non-http scheme",
+			url:     "file:///etc/passwd",
+			wantErr: true,
+		},
+		{
+			name:    "arbitrary host and path",
+			url:     "https://example.com/artifact",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateArtifactURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestBuildkiteClientAdapter_URLRewriting(t *testing.T) {

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -196,7 +196,7 @@ func TestListArtifactsForJobArgsSchema(t *testing.T) {
 
 func TestGetArtifactArgsSchema(t *testing.T) {
 	req := sortedRequired[GetArtifactArgs](t)
-	require.Equal(t, []string{"url"}, req)
+	require.Equal(t, []string{"artifact_id", "build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 }
 
 func TestGetTestArgsSchema(t *testing.T) {


### PR DESCRIPTION
## Issue

The `get_artifact` tool accepted a raw `url` argument and issued an authenticated GET against it. Because the URL wasn't constrained to the artifact endpoint, it could be pointed at other REST endpoints (e.g. access-token, user) and read them with the caller's token — a tool-boundary bypass.

## Fix

Remove the `url` argument. `get_artifact` now takes structured identifiers (`org_slug`, `pipeline_slug`, `build_number`, `job_id`, `artifact_id`) and builds the REST path server-side, with each segment path-escaped. The request can only ever address an artifact-download resource, so the bypass is eliminated by construction rather than guarded by validation. Proxy base-pathresolution is delegated to the go-buildkite client.

## Tool changes

`get_artifact` input schema changed:

- removed: `url`
- added (all required): `org_slug`, `pipeline_slug`, `build_number`, `job_id`, `artifact_id`

The identifiers map directly onto the output of `list_artifacts_for_build` / `list_artifacts_for_job` (`job_id` + artifact `id`), so the two tools chain without parsing a URL. No other tools are affected.

Verified end-to-end against the live API