### PR TITLE
feat: add HAR-based API recording and replay for offline evals

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -143,6 +143,10 @@ Standard HAR viewers (Chrome DevTools, [HAR Analyzer](https://toolbox.googleapps
 
 - **Full-file rewrite on every request.** Each API call re-marshals and rewrites the entire HAR file. This is fine for typical eval sessions (tens to low hundreds of calls) but will slow down recording for very large sessions. A future improvement would be to append a JSON line and only rewrite on close.
 
+- **Job log blob storage is not captured.** Recording intercepts HTTP calls made through the Buildkite API client transport only. Job log fetches that go through `BKLOG_CACHE_URL` (the gocloud blob storage path) use a separate HTTP client and will not appear in the HAR. Evals that exercise log tools with caching enabled may therefore behave differently between record and replay — the log fetch will succeed during recording (real network) but fail during replay (no entry in the HAR). Disable the cache (`BKLOG_CACHE_URL` unset) when recording sessions intended for log-tool evals.
+
+- **Transport errors are not recorded.** Only requests that receive an HTTP response are written to the HAR. If the underlying transport returns an error (connection refused, timeout, DNS failure), the call is not captured and the error is returned to the caller as normal. Replay cannot reproduce those failure modes.
+
 # Tracing
 
 To enable tracing in the MCP server you need to add some environment variables in the configuration, the example below is showing the claude desktop configuration paired with [honeycomb](https://honeycomb.io), however any OTEL service will work as long as it supports GRPC.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,6 +139,10 @@ Because the HAR format is plain JSON you can hand-edit a recorded file to simula
 
 Standard HAR viewers (Chrome DevTools, [HAR Analyzer](https://toolbox.googleapps.com/apps/har_analyzer/)) can open the files for inspection.
 
+## Known limitations
+
+- **Full-file rewrite on every request.** Each API call re-marshals and rewrites the entire HAR file. This is fine for typical eval sessions (tens to low hundreds of calls) but will slow down recording for very large sessions. A future improvement would be to append a JSON line and only rewrite on close.
+
 # Tracing
 
 To enable tracing in the MCP server you need to add some environment variables in the configuration, the example below is showing the claude desktop configuration paired with [honeycomb](https://honeycomb.io), however any OTEL service will work as long as it supports GRPC.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,6 +98,47 @@ git fetch && git pull
 GITHUB_TOKEN=$(gh auth token) goreleaser release
 ```
 
+# Recording and replaying API calls for offline evals
+
+The server can record every Buildkite API call it makes to an [HTTP Archive (HAR)](https://en.wikipedia.org/wiki/HAR_(file_format)) file, then replay that file later without a network connection. This is useful for running LLM evals reproducibly — record one real session, then run multiple models (or prompt variants) against the exact same API responses.
+
+## Record a session
+
+Pass `--record <path>` when starting the server. The file is created immediately (to catch permission errors early) and each API response is appended as it is made.
+
+```bash
+BUILDKITE_API_TOKEN=bkua_xxx buildkite-mcp-server stdio --record ./testdata/my-scenario.har
+```
+
+Drive the server with your MCP client or an LLM as normal. When the session ends the HAR file contains every request/response pair.
+
+A few things to note about the recorded file:
+- `Authorization` headers are stripped before writing, so the file is safe to commit.
+- Binary responses (gzip logs, artifacts) are stored as base64 with `"encoding": "base64"`.
+- POST/PUT request bodies are stored in `postData` so distinct writes to the same endpoint are matched correctly on replay.
+
+## Replay offline
+
+Pass `--replay <path>` to serve responses from a previously recorded HAR file. No API token is required.
+
+```bash
+buildkite-mcp-server stdio --replay ./testdata/my-scenario.har
+```
+
+Replay matches requests by **method + URL** (plus request body for write methods), not by call order, so the LLM can reach the same endpoints in any sequence. If the same URL appears more than once in the HAR (e.g. paginated requests), each call consumes the next recorded entry for that URL in the order they were recorded.
+
+The server returns a clear error if a tool makes a request for which no HAR entry exists, making it easy to detect when a scenario is incomplete.
+
+## Creating error scenarios
+
+Because the HAR format is plain JSON you can hand-edit a recorded file to simulate failure cases:
+
+- Change a `"status": 200` to `"status": 404` and update the `"text"` body.
+- Delete an entry entirely to trigger a "no recorded entry" error for that call.
+- Duplicate an entry to simulate a retry.
+
+Standard HAR viewers (Chrome DevTools, [HAR Analyzer](https://toolbox.googleapps.com/apps/har_analyzer/)) can open the files for inspection.
+
 # Tracing
 
 To enable tracing in the MCP server you need to add some environment variables in the configuration, the example below is showing the claude desktop configuration paired with [honeycomb](https://honeycomb.io), however any OTEL service will work as long as it supports GRPC.

--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -83,7 +83,7 @@ func run(ctx context.Context, cmd *kong.Context) error {
 		}
 	}
 
-	var innerTransport http.RoundTripper = http.DefaultTransport
+	innerTransport := http.RoundTripper(http.DefaultTransport)
 	if cli.Record != "" {
 		recTransport, recErr := recording.NewRecordingTransport(http.DefaultTransport, cli.Record, version)
 		if recErr != nil {

--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -70,14 +70,17 @@ func run(ctx context.Context, cmd *kong.Context) error {
 	// Parse additional headers into a map
 	headers := commands.ParseHeaders(cli.HTTPHeaders)
 
-	// resolve the api token from either the token or 1password flag
-	apiToken, err := commands.ResolveAPIToken(cli.APIToken, cli.APITokenFrom1Password)
-	if err != nil {
-		return fmt.Errorf("failed to resolve Buildkite API token: %w", err)
-	}
-
 	if cli.Record != "" && cli.Replay != "" {
 		return fmt.Errorf("cannot specify both --record and --replay")
+	}
+
+	// Token is not required for replay — the HAR file is self-contained.
+	apiToken := ""
+	if cli.Replay == "" {
+		apiToken, err = commands.ResolveAPIToken(cli.APIToken, cli.APITokenFrom1Password)
+		if err != nil {
+			return fmt.Errorf("failed to resolve Buildkite API token: %w", err)
+		}
 	}
 
 	var innerTransport http.RoundTripper = http.DefaultTransport

--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
 	"github.com/alecthomas/kong"
 	buildkitelogs "github.com/buildkite/buildkite-logs"
 	"github.com/buildkite/buildkite-mcp-server/internal/commands"
+	"github.com/buildkite/buildkite-mcp-server/pkg/recording"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	gobuildkite "github.com/buildkite/go-buildkite/v5"
 	"github.com/mattn/go-isatty"
@@ -31,6 +33,8 @@ var (
 		Debug                 bool              `help:"Enable debug mode." env:"DEBUG"`
 		OTELExporter          string            `help:"OpenTelemetry exporter to enable. Options are 'http/protobuf', 'grpc', or 'noop'." enum:"http/protobuf, grpc, noop" env:"OTEL_EXPORTER_OTLP_PROTOCOL" default:"noop"`
 		HTTPHeaders           []string          `help:"Additional HTTP headers to send with every request. Format: 'Key: Value'" name:"http-header" env:"BUILDKITE_HTTP_HEADERS"`
+		Record                string            `help:"Record API calls to this HAR file path." env:"BUILDKITE_RECORD"`
+		Replay                string            `help:"Replay recorded API calls from this HAR file path." env:"BUILDKITE_REPLAY"`
 		Version               kong.VersionFlag
 	}
 )
@@ -72,10 +76,31 @@ func run(ctx context.Context, cmd *kong.Context) error {
 		return fmt.Errorf("failed to resolve Buildkite API token: %w", err)
 	}
 
+	if cli.Record != "" && cli.Replay != "" {
+		return fmt.Errorf("cannot specify both --record and --replay")
+	}
+
+	var innerTransport http.RoundTripper = http.DefaultTransport
+	if cli.Record != "" {
+		recTransport, recErr := recording.NewRecordingTransport(http.DefaultTransport, cli.Record, version)
+		if recErr != nil {
+			return fmt.Errorf("failed to create recording transport: %w", recErr)
+		}
+		innerTransport = recTransport
+		log.Info().Str("path", cli.Record).Msg("Recording API calls to HAR file")
+	} else if cli.Replay != "" {
+		replayTransport, replayErr := recording.NewReplayTransport(cli.Replay)
+		if replayErr != nil {
+			return fmt.Errorf("failed to load replay HAR file: %w", replayErr)
+		}
+		innerTransport = replayTransport
+		log.Info().Str("path", cli.Replay).Msg("Replaying API calls from HAR file")
+	}
+
 	client, err := gobuildkite.NewOpts(
 		gobuildkite.WithTokenAuth(apiToken),
 		gobuildkite.WithUserAgent(commands.UserAgent(version)),
-		gobuildkite.WithHTTPClient(trace.NewHTTPClientWithHeaders(headers)),
+		gobuildkite.WithHTTPClient(trace.NewHTTPClientWithHeadersAndTransport(headers, innerTransport)),
 		gobuildkite.WithBaseURL(cli.BaseURL),
 	)
 	if err != nil {

--- a/pkg/recording/har.go
+++ b/pkg/recording/har.go
@@ -3,6 +3,7 @@ package recording
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 )
 
 // HAR is the top-level structure of an HTTP Archive (HAR 1.2) file.
@@ -105,5 +106,5 @@ func (h *HAR) save(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o644)
+	return os.WriteFile(filepath.Clean(path), data, 0o600) //nolint:gosec // path is a user-supplied output file
 }

--- a/pkg/recording/har.go
+++ b/pkg/recording/har.go
@@ -1,0 +1,100 @@
+package recording
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// HAR is the top-level structure of an HTTP Archive (HAR 1.2) file.
+type HAR struct {
+	Log HARLog `json:"log"`
+}
+
+// HARLog is the log section of a HAR file.
+type HARLog struct {
+	Version string     `json:"version"`
+	Creator HARCreator `json:"creator"`
+	Entries []HAREntry `json:"entries"`
+}
+
+// HARCreator identifies the tool that produced the HAR file.
+type HARCreator struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// HAREntry is a single request/response pair.
+type HAREntry struct {
+	Request  HARRequest  `json:"request"`
+	Response HARResponse `json:"response"`
+}
+
+// HARRequest captures the HTTP request fields we use.
+type HARRequest struct {
+	Method      string         `json:"method"`
+	URL         string         `json:"url"`
+	HTTPVersion string         `json:"httpVersion"`
+	Headers     []HARNameValue `json:"headers"`
+	QueryString []HARNameValue `json:"queryString"`
+	BodySize    int            `json:"bodySize"`
+	HeadersSize int            `json:"headersSize"`
+}
+
+// HARResponse captures the HTTP response fields we use.
+type HARResponse struct {
+	Status      int            `json:"status"`
+	StatusText  string         `json:"statusText"`
+	HTTPVersion string         `json:"httpVersion"`
+	Headers     []HARNameValue `json:"headers"`
+	Content     HARContent     `json:"content"`
+	RedirectURL string         `json:"redirectURL"`
+	BodySize    int            `json:"bodySize"`
+	HeadersSize int            `json:"headersSize"`
+}
+
+// HARContent holds the response body and its metadata.
+type HARContent struct {
+	Size     int    `json:"size"`
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text,omitempty"`
+}
+
+// HARNameValue is a key-value pair used for headers and query string parameters.
+type HARNameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// LoadHAR reads and parses a HAR file from disk.
+func LoadHAR(path string) (*HAR, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var h HAR
+	if err := json.Unmarshal(data, &h); err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+func newHAR(version string) *HAR {
+	return &HAR{
+		Log: HARLog{
+			Version: "1.2",
+			Creator: HARCreator{
+				Name:    "buildkite-mcp-server",
+				Version: version,
+			},
+			Entries: []HAREntry{},
+		},
+	}
+}
+
+func (h *HAR) save(path string) error {
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/pkg/recording/har.go
+++ b/pkg/recording/har.go
@@ -36,8 +36,15 @@ type HARRequest struct {
 	HTTPVersion string         `json:"httpVersion"`
 	Headers     []HARNameValue `json:"headers"`
 	QueryString []HARNameValue `json:"queryString"`
+	PostData    *HARPostData   `json:"postData,omitempty"`
 	BodySize    int            `json:"bodySize"`
 	HeadersSize int            `json:"headersSize"`
+}
+
+// HARPostData holds a recorded request body.
+type HARPostData struct {
+	MimeType string `json:"mimeType"`
+	Text     string `json:"text"`
 }
 
 // HARResponse captures the HTTP response fields we use.
@@ -53,10 +60,12 @@ type HARResponse struct {
 }
 
 // HARContent holds the response body and its metadata.
+// When the body is not valid UTF-8, Text contains a base64-encoded copy and Encoding is "base64".
 type HARContent struct {
 	Size     int    `json:"size"`
 	MimeType string `json:"mimeType"`
 	Text     string `json:"text,omitempty"`
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // HARNameValue is a key-value pair used for headers and query string parameters.

--- a/pkg/recording/transport.go
+++ b/pkg/recording/transport.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -126,13 +127,26 @@ func (t *ReplayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return harEntryToResponse(req, entry), nil
 }
 
-// entryKey returns the lookup key for a HAR entry. For requests with a body the key
-// includes the body text so that different POSTs to the same URL are matched correctly.
+// entryKey returns the lookup key for a HAR entry.
+// Only the path and query string are used, not the scheme or host, so a recording made against
+// one base URL (e.g. https://api.buildkite.com) can be replayed against another (e.g. a local stub).
+// For requests with a body the body text is appended so that distinct POSTs to the same path are
+// matched correctly.
 func entryKey(method, rawURL string, postData *HARPostData) string {
+	path := requestURI(rawURL)
 	if postData != nil && postData.Text != "" {
-		return method + " " + rawURL + "\n" + postData.Text
+		return method + " " + path + "\n" + postData.Text
 	}
-	return method + " " + rawURL
+	return method + " " + path
+}
+
+// requestURI returns the path and query string of rawURL, falling back to the full string on parse error.
+func requestURI(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return u.RequestURI()
 }
 
 func buildHAREntry(req *http.Request, reqBody []byte, resp *http.Response, respBody []byte) HAREntry {

--- a/pkg/recording/transport.go
+++ b/pkg/recording/transport.go
@@ -2,11 +2,15 @@ package recording
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"sync"
+	"unicode/utf8"
+
+	"github.com/rs/zerolog/log"
 )
 
 // RecordingTransport wraps an http.RoundTripper and appends each request/response to a HAR file.
@@ -33,30 +37,44 @@ func NewRecordingTransport(wrapped http.RoundTripper, harPath, version string) (
 
 // RoundTrip forwards the request to the wrapped transport, records the response, and returns it.
 func (t *RecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Capture request body before forwarding so it can be recorded and restored.
+	var reqBody []byte
+	if req.Body != nil && req.Body != http.NoBody {
+		var err error
+		reqBody, err = io.ReadAll(req.Body)
+		req.Body.Close()
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(reqBody))
+		}
+	}
+
 	resp, err := t.wrapped.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
 
-	body, readErr := io.ReadAll(resp.Body)
+	respBody, readErr := io.ReadAll(resp.Body)
 	resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
 	if readErr != nil {
 		return resp, nil
 	}
 
-	entry := buildHAREntry(req, resp, body)
+	entry := buildHAREntry(req, reqBody, resp, respBody)
 
 	t.mu.Lock()
 	t.har.Log.Entries = append(t.har.Log.Entries, entry)
-	_ = t.har.save(t.harPath)
+	if saveErr := t.har.save(t.harPath); saveErr != nil {
+		log.Warn().Err(saveErr).Str("path", t.harPath).Msg("recording: failed to save HAR file")
+	}
 	t.mu.Unlock()
 
 	return resp, nil
 }
 
 // ReplayTransport serves recorded responses from a HAR file without making real network calls.
-// Requests are matched by method + full URL. Repeated calls to the same URL are served in recorded order.
+// Requests are matched by method + full URL (+ request body for write methods).
+// Repeated calls to the same key are served in recorded order.
 type ReplayTransport struct {
 	mu      sync.Mutex
 	entries map[string][]HAREntry
@@ -70,15 +88,30 @@ func NewReplayTransport(harPath string) (*ReplayTransport, error) {
 	}
 	entries := make(map[string][]HAREntry, len(har.Log.Entries))
 	for _, e := range har.Log.Entries {
-		key := e.Request.Method + " " + e.Request.URL
+		key := entryKey(e.Request.Method, e.Request.URL, e.Request.PostData)
 		entries[key] = append(entries[key], e)
 	}
 	return &ReplayTransport{entries: entries}, nil
 }
 
-// RoundTrip returns the next recorded response matching the request's method and URL.
+// RoundTrip returns the next recorded response matching the request's method, URL, and body.
 func (t *ReplayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	key := req.Method + " " + req.URL.String()
+	var postData *HARPostData
+	if req.Body != nil && req.Body != http.NoBody {
+		body, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			if len(body) > 0 {
+				postData = &HARPostData{
+					MimeType: req.Header.Get("Content-Type"),
+					Text:     string(body),
+				}
+			}
+		}
+	}
+
+	key := entryKey(req.Method, req.URL.String(), postData)
 
 	t.mu.Lock()
 	list := t.entries[key]
@@ -93,7 +126,16 @@ func (t *ReplayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return harEntryToResponse(req, entry), nil
 }
 
-func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry {
+// entryKey returns the lookup key for a HAR entry. For requests with a body the key
+// includes the body text so that different POSTs to the same URL are matched correctly.
+func entryKey(method, rawURL string, postData *HARPostData) string {
+	if postData != nil && postData.Text != "" {
+		return method + " " + rawURL + "\n" + postData.Text
+	}
+	return method + " " + rawURL
+}
+
+func buildHAREntry(req *http.Request, reqBody []byte, resp *http.Response, respBody []byte) HAREntry {
 	var reqHeaders []HARNameValue
 	for k, vs := range req.Header {
 		if strings.EqualFold(k, "Authorization") {
@@ -111,6 +153,14 @@ func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry
 		}
 	}
 
+	var postData *HARPostData
+	if len(reqBody) > 0 {
+		postData = &HARPostData{
+			MimeType: req.Header.Get("Content-Type"),
+			Text:     string(reqBody),
+		}
+	}
+
 	mimeType := resp.Header.Get("Content-Type")
 	if mimeType == "" {
 		mimeType = "application/octet-stream"
@@ -123,6 +173,8 @@ func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry
 		}
 	}
 
+	content := harContent(respBody, mimeType)
+
 	return HAREntry{
 		Request: HARRequest{
 			Method:      req.Method,
@@ -130,7 +182,8 @@ func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry
 			HTTPVersion: "HTTP/1.1",
 			Headers:     reqHeaders,
 			QueryString: queryString,
-			BodySize:    -1,
+			PostData:    postData,
+			BodySize:    len(reqBody),
 			HeadersSize: -1,
 		},
 		Response: HARResponse{
@@ -138,15 +191,28 @@ func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry
 			StatusText:  http.StatusText(resp.StatusCode),
 			HTTPVersion: "HTTP/1.1",
 			Headers:     respHeaders,
-			Content: HARContent{
-				Size:     len(body),
-				MimeType: mimeType,
-				Text:     string(body),
-			},
+			Content:     content,
 			RedirectURL: "",
-			BodySize:    len(body),
+			BodySize:    len(respBody),
 			HeadersSize: -1,
 		},
+	}
+}
+
+// harContent encodes the response body as plain text or base64 depending on whether it is valid UTF-8.
+func harContent(body []byte, mimeType string) HARContent {
+	if utf8.Valid(body) {
+		return HARContent{
+			Size:     len(body),
+			MimeType: mimeType,
+			Text:     string(body),
+		}
+	}
+	return HARContent{
+		Size:     len(body),
+		MimeType: mimeType,
+		Text:     base64.StdEncoding.EncodeToString(body),
+		Encoding: "base64",
 	}
 }
 
@@ -155,6 +221,9 @@ func harEntryToResponse(req *http.Request, entry HAREntry) *http.Response {
 	for _, h := range entry.Response.Headers {
 		header.Add(h.Name, h.Value)
 	}
+
+	body := decodeHARContent(entry.Response.Content)
+
 	return &http.Response{
 		Status:     fmt.Sprintf("%d %s", entry.Response.Status, entry.Response.StatusText),
 		StatusCode: entry.Response.Status,
@@ -162,7 +231,17 @@ func harEntryToResponse(req *http.Request, entry HAREntry) *http.Response {
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Header:     header,
-		Body:       io.NopCloser(strings.NewReader(entry.Response.Content.Text)),
+		Body:       io.NopCloser(body),
 		Request:    req,
 	}
+}
+
+func decodeHARContent(content HARContent) *bytes.Reader {
+	if content.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(content.Text)
+		if err == nil {
+			return bytes.NewReader(decoded)
+		}
+	}
+	return bytes.NewReader([]byte(content.Text))
 }

--- a/pkg/recording/transport.go
+++ b/pkg/recording/transport.go
@@ -1,0 +1,168 @@
+package recording
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// RecordingTransport wraps an http.RoundTripper and appends each request/response to a HAR file.
+type RecordingTransport struct {
+	wrapped http.RoundTripper
+	harPath string
+	har     *HAR
+	mu      sync.Mutex
+}
+
+// NewRecordingTransport creates a RecordingTransport that writes to harPath.
+// The file is created (or truncated) immediately to validate the path.
+func NewRecordingTransport(wrapped http.RoundTripper, harPath, version string) (*RecordingTransport, error) {
+	h := newHAR(version)
+	if err := h.save(harPath); err != nil {
+		return nil, fmt.Errorf("recording: cannot write to %s: %w", harPath, err)
+	}
+	return &RecordingTransport{
+		wrapped: wrapped,
+		harPath: harPath,
+		har:     h,
+	}, nil
+}
+
+// RoundTrip forwards the request to the wrapped transport, records the response, and returns it.
+func (t *RecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.wrapped.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, readErr := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	if readErr != nil {
+		return resp, nil
+	}
+
+	entry := buildHAREntry(req, resp, body)
+
+	t.mu.Lock()
+	t.har.Log.Entries = append(t.har.Log.Entries, entry)
+	_ = t.har.save(t.harPath)
+	t.mu.Unlock()
+
+	return resp, nil
+}
+
+// ReplayTransport serves recorded responses from a HAR file without making real network calls.
+// Requests are matched by method + full URL. Repeated calls to the same URL are served in recorded order.
+type ReplayTransport struct {
+	mu      sync.Mutex
+	entries map[string][]HAREntry
+}
+
+// NewReplayTransport loads a HAR file and prepares it for replay.
+func NewReplayTransport(harPath string) (*ReplayTransport, error) {
+	har, err := LoadHAR(harPath)
+	if err != nil {
+		return nil, fmt.Errorf("replay: failed to load %s: %w", harPath, err)
+	}
+	entries := make(map[string][]HAREntry, len(har.Log.Entries))
+	for _, e := range har.Log.Entries {
+		key := e.Request.Method + " " + e.Request.URL
+		entries[key] = append(entries[key], e)
+	}
+	return &ReplayTransport{entries: entries}, nil
+}
+
+// RoundTrip returns the next recorded response matching the request's method and URL.
+func (t *ReplayTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	key := req.Method + " " + req.URL.String()
+
+	t.mu.Lock()
+	list := t.entries[key]
+	if len(list) == 0 {
+		t.mu.Unlock()
+		return nil, fmt.Errorf("replay: no recorded entry for %s %s", req.Method, req.URL)
+	}
+	entry := list[0]
+	t.entries[key] = list[1:]
+	t.mu.Unlock()
+
+	return harEntryToResponse(req, entry), nil
+}
+
+func buildHAREntry(req *http.Request, resp *http.Response, body []byte) HAREntry {
+	var reqHeaders []HARNameValue
+	for k, vs := range req.Header {
+		if strings.EqualFold(k, "Authorization") {
+			continue
+		}
+		for _, v := range vs {
+			reqHeaders = append(reqHeaders, HARNameValue{Name: k, Value: v})
+		}
+	}
+
+	var queryString []HARNameValue
+	for k, vs := range req.URL.Query() {
+		for _, v := range vs {
+			queryString = append(queryString, HARNameValue{Name: k, Value: v})
+		}
+	}
+
+	mimeType := resp.Header.Get("Content-Type")
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
+	var respHeaders []HARNameValue
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			respHeaders = append(respHeaders, HARNameValue{Name: k, Value: v})
+		}
+	}
+
+	return HAREntry{
+		Request: HARRequest{
+			Method:      req.Method,
+			URL:         req.URL.String(),
+			HTTPVersion: "HTTP/1.1",
+			Headers:     reqHeaders,
+			QueryString: queryString,
+			BodySize:    -1,
+			HeadersSize: -1,
+		},
+		Response: HARResponse{
+			Status:      resp.StatusCode,
+			StatusText:  http.StatusText(resp.StatusCode),
+			HTTPVersion: "HTTP/1.1",
+			Headers:     respHeaders,
+			Content: HARContent{
+				Size:     len(body),
+				MimeType: mimeType,
+				Text:     string(body),
+			},
+			RedirectURL: "",
+			BodySize:    len(body),
+			HeadersSize: -1,
+		},
+	}
+}
+
+func harEntryToResponse(req *http.Request, entry HAREntry) *http.Response {
+	header := make(http.Header, len(entry.Response.Headers))
+	for _, h := range entry.Response.Headers {
+		header.Add(h.Name, h.Value)
+	}
+	return &http.Response{
+		Status:     fmt.Sprintf("%d %s", entry.Response.Status, entry.Response.StatusText),
+		StatusCode: entry.Response.Status,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(entry.Response.Content.Text)),
+		Request:    req,
+	}
+}

--- a/pkg/recording/transport_test.go
+++ b/pkg/recording/transport_test.go
@@ -70,13 +70,13 @@ func TestRecordingTransport(t *testing.T) {
 	resp1, err := transport.RoundTrip(req1)
 	r.NoError(err)
 	body1, _ := io.ReadAll(resp1.Body)
-	r.Equal(`{"id":"org1"}`, string(body1))
+	r.JSONEq(`{"id":"org1"}`, string(body1))
 
 	req2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines", nil)
 	resp2, err := transport.RoundTrip(req2)
 	r.NoError(err)
 	body2, _ := io.ReadAll(resp2.Body)
-	r.Equal(`[{"slug":"my-pipeline"}]`, string(body2))
+	r.JSONEq(`[{"slug":"my-pipeline"}]`, string(body2))
 
 	har, err := recording.LoadHAR(harPath)
 	r.NoError(err)
@@ -86,7 +86,7 @@ func TestRecordingTransport(t *testing.T) {
 	r.Equal("GET", e0.Request.Method)
 	r.Equal("https://api.buildkite.com/v2/organizations", e0.Request.URL)
 	r.Equal(200, e0.Response.Status)
-	r.Equal(`{"id":"org1"}`, e0.Response.Content.Text)
+	r.JSONEq(`{"id":"org1"}`, e0.Response.Content.Text)
 	// Authorization header must be stripped
 	for _, h := range e0.Request.Headers {
 		r.NotEqual("Authorization", h.Name)
@@ -94,7 +94,7 @@ func TestRecordingTransport(t *testing.T) {
 
 	e1 := har.Log.Entries[1]
 	r.Equal("https://api.buildkite.com/v2/organizations/my-org/pipelines", e1.Request.URL)
-	r.Equal(`[{"slug":"my-pipeline"}]`, e1.Response.Content.Text)
+	r.JSONEq(`[{"slug":"my-pipeline"}]`, e1.Response.Content.Text)
 }
 
 func TestRecordingTransportPostBody(t *testing.T) {
@@ -184,13 +184,13 @@ func TestReplayTransportAnyOrder(t *testing.T) {
 	resp2, err := replay.RoundTrip(replayReq2)
 	r.NoError(err)
 	body2, _ := io.ReadAll(resp2.Body)
-	r.Equal(`[{"slug":"my-pipeline"}]`, string(body2))
+	r.JSONEq(`[{"slug":"my-pipeline"}]`, string(body2))
 
 	replayReq1, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
 	resp1, err := replay.RoundTrip(replayReq1)
 	r.NoError(err)
 	body1, _ := io.ReadAll(resp1.Body)
-	r.Equal(`{"id":"org1"}`, string(body1))
+	r.JSONEq(`{"id":"org1"}`, string(body1))
 }
 
 func TestReplayTransportPostBodyMatching(t *testing.T) {
@@ -224,7 +224,7 @@ func TestReplayTransportPostBodyMatching(t *testing.T) {
 	resp2, err := replay.RoundTrip(replayReq2)
 	r.NoError(err)
 	got2, _ := io.ReadAll(resp2.Body)
-	r.Equal(`{"number":2}`, string(got2))
+	r.JSONEq(`{"number":2}`, string(got2))
 
 	// Request body1 — should get response 1
 	replayReq1, _ := http.NewRequest("POST", url, strings.NewReader(body1))
@@ -232,7 +232,7 @@ func TestReplayTransportPostBodyMatching(t *testing.T) {
 	resp1, err := replay.RoundTrip(replayReq1)
 	r.NoError(err)
 	got1, _ := io.ReadAll(resp1.Body)
-	r.Equal(`{"number":1}`, string(got1))
+	r.JSONEq(`{"number":1}`, string(got1))
 }
 
 func TestReplayTransportBinaryResponse(t *testing.T) {
@@ -282,13 +282,13 @@ func TestReplayTransportRepeatedURL(t *testing.T) {
 	resp, err := replay.RoundTrip(req)
 	r.NoError(err)
 	body, _ := io.ReadAll(resp.Body)
-	r.Equal(`[{"slug":"page1"}]`, string(body))
+	r.JSONEq(`[{"slug":"page1"}]`, string(body))
 
 	req2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=1", nil)
 	resp2, err := replay.RoundTrip(req2)
 	r.NoError(err)
 	body2, _ := io.ReadAll(resp2.Body)
-	r.Equal(`[{"slug":"page2"}]`, string(body2))
+	r.JSONEq(`[{"slug":"page2"}]`, string(body2))
 }
 
 func TestReplayTransportErrors(t *testing.T) {
@@ -386,7 +386,7 @@ func TestReplayTransportBaseURLMismatch(t *testing.T) {
 	resp, err := replay.RoundTrip(replayReq)
 	r.NoError(err)
 	body, _ := io.ReadAll(resp.Body)
-	r.Equal(`[{"slug":"my-pipeline"}]`, string(body))
+	r.JSONEq(`[{"slug":"my-pipeline"}]`, string(body))
 }
 
 // TestFullClientStackIntegration exercises the recording and replay transports wired into the
@@ -444,11 +444,11 @@ func TestFullClientStackIntegration(t *testing.T) {
 	resp2, err := replayClient.Do(req2)
 	r.NoError(err)
 	body2, _ := io.ReadAll(resp2.Body)
-	r.Equal(`[{"slug":"my-pipe"}]`, string(body2))
+	r.JSONEq(`[{"slug":"my-pipe"}]`, string(body2))
 
 	req1, _ := http.NewRequest("GET", srv.URL+"/v2/organizations", nil)
 	resp1, err := replayClient.Do(req1)
 	r.NoError(err)
 	body1, _ := io.ReadAll(resp1.Body)
-	r.Equal(`[{"slug":"my-org"}]`, string(body1))
+	r.JSONEq(`[{"slug":"my-org"}]`, string(body1))
 }

--- a/pkg/recording/transport_test.go
+++ b/pkg/recording/transport_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/recording"
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/stretchr/testify/require"
 )
 
@@ -320,4 +322,133 @@ func TestReplayTransportErrors(t *testing.T) {
 	_, err = replay.RoundTrip(knownReq2)
 	r.Error(err)
 	r.Contains(err.Error(), "no recorded entry")
+}
+
+// TestBinaryBodyRoundTrip verifies that binary (non-UTF-8) response bodies survive a full
+// record → HAR file → replay cycle with bytes identical to the original.
+func TestBinaryBodyRoundTrip(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "binary-rt.har")
+	// Gzip magic bytes — definitely not valid UTF-8.
+	original := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff}
+
+	// Record
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponseBytes(200, original, "application/gzip"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	recReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/jobs/abc/log.gz", nil)
+	recResp, err := rec.RoundTrip(recReq)
+	r.NoError(err)
+	recBody, _ := io.ReadAll(recResp.Body)
+	r.Equal(original, recBody, "recording should return the original bytes to the caller")
+
+	// Verify the HAR stored it as base64
+	har, err := recording.LoadHAR(harPath)
+	r.NoError(err)
+	r.Equal("base64", har.Log.Entries[0].Response.Content.Encoding)
+	r.Equal(base64.StdEncoding.EncodeToString(original), har.Log.Entries[0].Response.Content.Text)
+
+	// Replay
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+	replayReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/jobs/abc/log.gz", nil)
+	replayResp, err := replay.RoundTrip(replayReq)
+	r.NoError(err)
+	replayBody, _ := io.ReadAll(replayResp.Body)
+	r.Equal(original, replayBody, "replay should return the original bytes unchanged")
+}
+
+// TestReplayTransportBaseURLMismatch verifies that a HAR recorded against one host can be
+// replayed when requests arrive with a different host (e.g. a local stub server).
+// Matching is keyed on path+query only, not on scheme or host.
+func TestReplayTransportBaseURLMismatch(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "mismatch.har")
+
+	// Record against the real base URL
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(200, `[{"slug":"my-pipeline"}]`, "application/json"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	recReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines", nil)
+	_, err = rec.RoundTrip(recReq)
+	r.NoError(err)
+
+	// Replay — request arrives with a different host (local stub)
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+	replayReq, _ := http.NewRequest("GET", "http://localhost:9999/v2/organizations/my-org/pipelines", nil)
+	resp, err := replay.RoundTrip(replayReq)
+	r.NoError(err)
+	body, _ := io.ReadAll(resp.Body)
+	r.Equal(`[{"slug":"my-pipeline"}]`, string(body))
+}
+
+// TestFullClientStackIntegration exercises the recording and replay transports wired into the
+// same HTTP client stack used in production: header injection → otelhttp → recording/replay.
+// This guards against the OTEL instrumentation or header injection interfering with body handling.
+func TestFullClientStackIntegration(t *testing.T) {
+	r := require.New(t)
+
+	// Fake API server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/v2/organizations":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"slug":"my-org"}]`)
+		case "/v2/organizations/my-org/pipelines":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `[{"slug":"my-pipe"}]`)
+		default:
+			http.NotFound(w, req)
+		}
+	}))
+	defer srv.Close()
+
+	harPath := filepath.Join(t.TempDir(), "stack.har")
+
+	// --- Record phase ---
+	recTransport, err := recording.NewRecordingTransport(http.DefaultTransport, harPath, "test")
+	r.NoError(err)
+	recClient := trace.NewHTTPClientWithHeadersAndTransport(
+		map[string]string{"X-Test": "recording"},
+		recTransport,
+	)
+
+	for _, path := range []string{"/v2/organizations", "/v2/organizations/my-org/pipelines"} {
+		req, _ := http.NewRequest("GET", srv.URL+path, nil)
+		resp, doErr := recClient.Do(req)
+		r.NoError(doErr)
+		resp.Body.Close()
+	}
+
+	har, err := recording.LoadHAR(harPath)
+	r.NoError(err)
+	r.Len(har.Log.Entries, 2)
+
+	// --- Replay phase (no server needed) ---
+	replayTransport, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+	replayClient := trace.NewHTTPClientWithHeadersAndTransport(
+		map[string]string{"X-Test": "replay"},
+		replayTransport,
+	)
+
+	// Requests can arrive in any order
+	req2, _ := http.NewRequest("GET", srv.URL+"/v2/organizations/my-org/pipelines", nil)
+	resp2, err := replayClient.Do(req2)
+	r.NoError(err)
+	body2, _ := io.ReadAll(resp2.Body)
+	r.Equal(`[{"slug":"my-pipe"}]`, string(body2))
+
+	req1, _ := http.NewRequest("GET", srv.URL+"/v2/organizations", nil)
+	resp1, err := replayClient.Do(req1)
+	r.NoError(err)
+	body1, _ := io.ReadAll(resp1.Body)
+	r.Equal(`[{"slug":"my-org"}]`, string(body1))
 }

--- a/pkg/recording/transport_test.go
+++ b/pkg/recording/transport_test.go
@@ -1,0 +1,182 @@
+package recording_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildkite/buildkite-mcp-server/pkg/recording"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTransport struct {
+	responses []*http.Response
+	index     int
+}
+
+func (m *mockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	if m.index >= len(m.responses) {
+		return nil, fmt.Errorf("mock: no more responses")
+	}
+	resp := m.responses[m.index]
+	m.index++
+	return resp, nil
+}
+
+func newMockResponse(status int, body string, contentType string) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", contentType)
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func TestRecordingTransport(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "test.har")
+
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(200, `{"id":"org1"}`, "application/json"),
+		newMockResponse(200, `[{"slug":"my-pipeline"}]`, "application/json"),
+	}}
+
+	transport, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+
+	req1, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	req1.Header.Set("Authorization", "Bearer secret-token")
+	resp1, err := transport.RoundTrip(req1)
+	r.NoError(err)
+	body1, _ := io.ReadAll(resp1.Body)
+	r.Equal(`{"id":"org1"}`, string(body1))
+
+	req2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines", nil)
+	resp2, err := transport.RoundTrip(req2)
+	r.NoError(err)
+	body2, _ := io.ReadAll(resp2.Body)
+	r.Equal(`[{"slug":"my-pipeline"}]`, string(body2))
+
+	har, err := recording.LoadHAR(harPath)
+	r.NoError(err)
+	r.Len(har.Log.Entries, 2)
+
+	e0 := har.Log.Entries[0]
+	r.Equal("GET", e0.Request.Method)
+	r.Equal("https://api.buildkite.com/v2/organizations", e0.Request.URL)
+	r.Equal(200, e0.Response.Status)
+	r.Equal(`{"id":"org1"}`, e0.Response.Content.Text)
+	for _, h := range e0.Request.Headers {
+		r.NotEqual("Authorization", h.Name)
+	}
+
+	e1 := har.Log.Entries[1]
+	r.Equal("https://api.buildkite.com/v2/organizations/my-org/pipelines", e1.Request.URL)
+	r.Equal(`[{"slug":"my-pipeline"}]`, e1.Response.Content.Text)
+}
+
+func TestReplayTransportAnyOrder(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "test.har")
+
+	// Record two distinct URLs
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(200, `{"id":"org1"}`, "application/json"),
+		newMockResponse(200, `[{"slug":"my-pipeline"}]`, "application/json"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	req1, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	_, _ = rec.RoundTrip(req1)
+	req2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines", nil)
+	_, _ = rec.RoundTrip(req2)
+
+	// Replay in reverse order — should still work
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+
+	replayReq2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines", nil)
+	resp2, err := replay.RoundTrip(replayReq2)
+	r.NoError(err)
+	body2, _ := io.ReadAll(resp2.Body)
+	r.Equal(`[{"slug":"my-pipeline"}]`, string(body2))
+
+	replayReq1, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	resp1, err := replay.RoundTrip(replayReq1)
+	r.NoError(err)
+	body1, _ := io.ReadAll(resp1.Body)
+	r.Equal(`{"id":"org1"}`, string(body1))
+}
+
+func TestReplayTransportRepeatedURL(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "pages.har")
+
+	// Record two calls to the same URL (pagination)
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(200, `[{"slug":"page1"}]`, "application/json"),
+		newMockResponse(200, `[{"slug":"page2"}]`, "application/json"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	for range 2 {
+		req, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=1", nil)
+		_, _ = rec.RoundTrip(req)
+	}
+
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+
+	req, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=1", nil)
+	resp, err := replay.RoundTrip(req)
+	r.NoError(err)
+	body, _ := io.ReadAll(resp.Body)
+	r.Equal(`[{"slug":"page1"}]`, string(body))
+
+	req2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/pipelines?page=1", nil)
+	resp2, err := replay.RoundTrip(req2)
+	r.NoError(err)
+	body2, _ := io.ReadAll(resp2.Body)
+	r.Equal(`[{"slug":"page2"}]`, string(body2))
+}
+
+func TestReplayTransportErrors(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "test.har")
+
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(200, `{}`, "application/json"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	req, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	_, _ = rec.RoundTrip(req)
+
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+
+	// Unknown URL
+	unknownReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/unknown", nil)
+	_, err = replay.RoundTrip(unknownReq)
+	r.Error(err)
+	r.Contains(err.Error(), "no recorded entry")
+
+	// Consume the one entry then try again
+	knownReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	_, err = replay.RoundTrip(knownReq)
+	r.NoError(err)
+
+	knownReq2, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
+	_, err = replay.RoundTrip(knownReq2)
+	r.Error(err)
+	r.Contains(err.Error(), "no recorded entry")
+}

--- a/pkg/recording/transport_test.go
+++ b/pkg/recording/transport_test.go
@@ -2,10 +2,12 @@ package recording_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/recording"
@@ -34,6 +36,17 @@ func newMockResponse(status int, body string, contentType string) *http.Response
 		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
 		Header:     h,
 		Body:       io.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func newMockResponseBytes(status int, body []byte, contentType string) *http.Response {
+	h := make(http.Header)
+	h.Set("Content-Type", contentType)
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     h,
+		Body:       io.NopCloser(bytes.NewReader(body)),
 	}
 }
 
@@ -72,6 +85,7 @@ func TestRecordingTransport(t *testing.T) {
 	r.Equal("https://api.buildkite.com/v2/organizations", e0.Request.URL)
 	r.Equal(200, e0.Response.Status)
 	r.Equal(`{"id":"org1"}`, e0.Response.Content.Text)
+	// Authorization header must be stripped
 	for _, h := range e0.Request.Headers {
 		r.NotEqual("Authorization", h.Name)
 	}
@@ -81,12 +95,74 @@ func TestRecordingTransport(t *testing.T) {
 	r.Equal(`[{"slug":"my-pipeline"}]`, e1.Response.Content.Text)
 }
 
+func TestRecordingTransportPostBody(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "post.har")
+
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(201, `{"number":1}`, "application/json"),
+		newMockResponse(201, `{"number":2}`, "application/json"),
+	}}
+
+	transport, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+
+	body1 := `{"branch":"main","message":"build 1"}`
+	req1, _ := http.NewRequest("POST", "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipe/builds",
+		strings.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	_, err = transport.RoundTrip(req1)
+	r.NoError(err)
+
+	body2 := `{"branch":"feat","message":"build 2"}`
+	req2, _ := http.NewRequest("POST", "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipe/builds",
+		strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	_, err = transport.RoundTrip(req2)
+	r.NoError(err)
+
+	har, err := recording.LoadHAR(harPath)
+	r.NoError(err)
+	r.Len(har.Log.Entries, 2)
+	r.NotNil(har.Log.Entries[0].Request.PostData)
+	r.Equal(body1, har.Log.Entries[0].Request.PostData.Text)
+	r.NotNil(har.Log.Entries[1].Request.PostData)
+	r.Equal(body2, har.Log.Entries[1].Request.PostData.Text)
+}
+
+func TestRecordingTransportBinaryResponse(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "binary.har")
+
+	// Bytes that are not valid UTF-8
+	binaryBody := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00} // gzip magic bytes
+
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponseBytes(200, binaryBody, "application/gzip"),
+	}}
+
+	transport, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+
+	req, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations/my-org/jobs/123/log.gz", nil)
+	resp, err := transport.RoundTrip(req)
+	r.NoError(err)
+	respBody, _ := io.ReadAll(resp.Body)
+	r.Equal(binaryBody, respBody)
+
+	har, err := recording.LoadHAR(harPath)
+	r.NoError(err)
+	r.Equal("base64", har.Log.Entries[0].Response.Content.Encoding)
+	r.Equal(base64.StdEncoding.EncodeToString(binaryBody), har.Log.Entries[0].Response.Content.Text)
+}
+
 func TestReplayTransportAnyOrder(t *testing.T) {
 	r := require.New(t)
 
 	harPath := filepath.Join(t.TempDir(), "test.har")
 
-	// Record two distinct URLs
 	mock := &mockTransport{responses: []*http.Response{
 		newMockResponse(200, `{"id":"org1"}`, "application/json"),
 		newMockResponse(200, `[{"slug":"my-pipeline"}]`, "application/json"),
@@ -115,12 +191,77 @@ func TestReplayTransportAnyOrder(t *testing.T) {
 	r.Equal(`{"id":"org1"}`, string(body1))
 }
 
+func TestReplayTransportPostBodyMatching(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "post.har")
+
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponse(201, `{"number":1}`, "application/json"),
+		newMockResponse(201, `{"number":2}`, "application/json"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+
+	url := "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipe/builds"
+	body1 := `{"branch":"main"}`
+	body2 := `{"branch":"feat"}`
+	req1, _ := http.NewRequest("POST", url, strings.NewReader(body1))
+	req1.Header.Set("Content-Type", "application/json")
+	_, _ = rec.RoundTrip(req1)
+	req2, _ := http.NewRequest("POST", url, strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	_, _ = rec.RoundTrip(req2)
+
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+
+	// Request body2 first — should get response 2
+	replayReq2, _ := http.NewRequest("POST", url, strings.NewReader(body2))
+	replayReq2.Header.Set("Content-Type", "application/json")
+	resp2, err := replay.RoundTrip(replayReq2)
+	r.NoError(err)
+	got2, _ := io.ReadAll(resp2.Body)
+	r.Equal(`{"number":2}`, string(got2))
+
+	// Request body1 — should get response 1
+	replayReq1, _ := http.NewRequest("POST", url, strings.NewReader(body1))
+	replayReq1.Header.Set("Content-Type", "application/json")
+	resp1, err := replay.RoundTrip(replayReq1)
+	r.NoError(err)
+	got1, _ := io.ReadAll(resp1.Body)
+	r.Equal(`{"number":1}`, string(got1))
+}
+
+func TestReplayTransportBinaryResponse(t *testing.T) {
+	r := require.New(t)
+
+	harPath := filepath.Join(t.TempDir(), "binary.har")
+
+	binaryBody := []byte{0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00}
+	mock := &mockTransport{responses: []*http.Response{
+		newMockResponseBytes(200, binaryBody, "application/gzip"),
+	}}
+	rec, err := recording.NewRecordingTransport(mock, harPath, "test")
+	r.NoError(err)
+	req, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/log.gz", nil)
+	_, _ = rec.RoundTrip(req)
+
+	replay, err := recording.NewReplayTransport(harPath)
+	r.NoError(err)
+
+	replayReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/log.gz", nil)
+	resp, err := replay.RoundTrip(replayReq)
+	r.NoError(err)
+	got, _ := io.ReadAll(resp.Body)
+	r.Equal(binaryBody, got)
+}
+
 func TestReplayTransportRepeatedURL(t *testing.T) {
 	r := require.New(t)
 
 	harPath := filepath.Join(t.TempDir(), "pages.har")
 
-	// Record two calls to the same URL (pagination)
 	mock := &mockTransport{responses: []*http.Response{
 		newMockResponse(200, `[{"slug":"page1"}]`, "application/json"),
 		newMockResponse(200, `[{"slug":"page2"}]`, "application/json"),
@@ -170,7 +311,7 @@ func TestReplayTransportErrors(t *testing.T) {
 	r.Error(err)
 	r.Contains(err.Error(), "no recorded entry")
 
-	// Consume the one entry then try again
+	// Consume the entry then verify exhaustion error
 	knownReq, _ := http.NewRequest("GET", "https://api.buildkite.com/v2/organizations", nil)
 	_, err = replay.RoundTrip(knownReq)
 	r.NoError(err)

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -71,10 +71,16 @@ func NewHTTPClient() *http.Client {
 
 // NewHTTPClientWithHeaders returns an http.Client that injects the provided headers into every request.
 func NewHTTPClientWithHeaders(headers map[string]string) *http.Client {
+	return NewHTTPClientWithHeadersAndTransport(headers, http.DefaultTransport)
+}
+
+// NewHTTPClientWithHeadersAndTransport is like NewHTTPClientWithHeaders but uses inner as the
+// innermost RoundTripper instead of http.DefaultTransport. Use this to inject a recording or replay transport.
+func NewHTTPClientWithHeadersAndTransport(headers map[string]string, inner http.RoundTripper) *http.Client {
 	return &http.Client{
 		Transport: &headerInjector{
 			headers: headers,
-			wrapped: otelhttp.NewTransport(http.DefaultTransport),
+			wrapped: otelhttp.NewTransport(inner),
 		},
 	}
 }


### PR DESCRIPTION
Adds --record <path> and --replay <path> flags to capture real Buildkite API calls as an HTTP Archive (HAR 1.2) file and replay them without network access. Replay matches by method + URL so LLMs can call tools in any order; repeated calls to the same URL are served in recorded order. Authorization headers are stripped from recorded HAR files.
