### PR TITLE
chore(pipeline): publish coverage profile and show total in annotation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,11 +27,12 @@ steps:
     - name: ":go: test"
       artifact_paths:
         - cover-tree.svg
+        - coverage.out
         - junit.xml
       commands:
-        - go run gotest.tools/gotestsum@latest --junitfile junit.xml --format testname -- -coverprofile=cover.out ./...
-        - go run github.com/nikolaydubina/go-cover-treemap@latest -coverprofile cover.out > cover-tree.svg
-        - echo '<details><summary>Coverage tree map</summary><img src="artifact://cover-tree.svg" alt="Test coverage tree map" width="70%"></details>' | buildkite-agent annotate --style "info"
+        - go run gotest.tools/gotestsum@latest --junitfile junit.xml --format testname -- -coverprofile=coverage.out ./...
+        - go run github.com/nikolaydubina/go-cover-treemap@latest -coverprofile coverage.out > cover-tree.svg
+        - echo "<details><summary>Coverage tree map ($(go tool cover -func=coverage.out | tail -1 | awk '{print $NF}'))</summary><img src=\"artifact://cover-tree.svg\" alt=\"Test coverage tree map\" width=\"70%\"></details>" | buildkite-agent annotate --style "info"
       env:
         GOCACHE: /gocache
         GOMODCACHE: /gomodcache


### PR DESCRIPTION
Standardize the coverage profile filename on coverage.out (matching the Makefile) and publish it as a build artifact so coverage can be diffed or fed to external tooling without re-running tests. Also surface the aggregate coverage percentage in the tree-map annotation summary.
