### PR TITLE
feat(artifacts): return json artifacts inline rather than base64 encoded

### DIFF
--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -181,7 +182,7 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
-			Description: "Download a specific artifact's content, identified by its organization, pipeline, build, job, and artifact identifiers. The content is returned base64-encoded",
+			Description: "Download a specific artifact's content, identified by its organization, pipeline, build, job, and artifact identifiers. JSON artifacts are returned inline; other content is returned base64-encoded",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Artifact",
 				ReadOnlyHint: true,
@@ -207,12 +208,18 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 				return utils.NewToolResultError(fmt.Sprintf("response failed with error %s", err.Error())), nil, nil
 			}
 
-			// Create a response with the artifact data encoded safely for JSON
+			content := buffer.Bytes()
 			result := map[string]any{
 				"status":     resp.Status,
 				"statusCode": resp.StatusCode,
-				"data":       base64.StdEncoding.EncodeToString(buffer.Bytes()),
-				"encoding":   "base64",
+			}
+			if json.Valid(content) {
+				result["data"] = json.RawMessage(content)
+				result["encoding"] = "json"
+			} else {
+				// Non-JSON artifacts may be arbitrary bytes, so encode safely for JSON.
+				result["data"] = base64.StdEncoding.EncodeToString(content)
+				result["encoding"] = "base64"
 			}
 
 			return mcpTextResult(span, &result)

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -174,6 +175,58 @@ func TestGetArtifact(t *testing.T) {
 
 	// The base64 encoded "This is test artifact content"
 	assert.Contains(textContent.Text, `"data":"VGhpcyBpcyB0ZXN0IGFydGlmYWN0IGNvbnRlbnQ="`)
+}
+
+func TestGetArtifact_JSONContent(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockArtifactsClient{
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			_, err := writer.Write([]byte(`{"passed":true,"failures":[{"name":"test one"}]}`))
+			if err != nil {
+				return nil, err
+			}
+
+			return &buildkite.Response{
+				Response: &http.Response{
+					StatusCode: 200,
+					Status:     "200 OK",
+				},
+			}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+
+	_, handler, _ := GetArtifact()
+
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+
+	textContent := getTextResult(t, result)
+	assert.Contains(textContent.Text, `"status":"200 OK"`)
+	assert.Contains(textContent.Text, `"statusCode":200`)
+	assert.Contains(textContent.Text, `"encoding":"json"`)
+	assert.NotContains(textContent.Text, `"encoding":"base64"`)
+
+	var response struct {
+		Data struct {
+			Passed   bool `json:"passed"`
+			Failures []struct {
+				Name string `json:"name"`
+			} `json:"failures"`
+		} `json:"data"`
+	}
+	assert.NoError(json.Unmarshal([]byte(textContent.Text), &response))
+	assert.True(response.Data.Passed)
+	assert.Equal("test one", response.Data.Failures[0].Name)
 }
 
 func TestGetArtifact_ErrorResponse(t *testing.T) {


### PR DESCRIPTION
This change removes the unnecessary base64 encoding of JSON when we are already returning JSON, it is easier and more efficient to just inline the artifact.
