### PR TITLE
feat: adds list_jobs/get_job tools and make build tools build-only

### DIFF
--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -2,10 +2,8 @@ package buildkite
 
 import (
 	"context"
-	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
-	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
@@ -20,12 +18,6 @@ type BuildsClient interface {
 	Rebuild(ctx context.Context, org, pipeline, buildNumber string) (buildkite.Build, error)
 }
 
-// JobSummary represents a summary of jobs grouped by state, with finished jobs classified as passed/failed
-type JobSummary struct {
-	Total   int            `json:"total"`
-	ByState map[string]int `json:"by_state"`
-}
-
 // BuildSummary - Essential build fields for list responses
 type BuildSummary struct {
 	ID        string               `json:"id"`
@@ -38,30 +30,6 @@ type BuildSummary struct {
 	CreatedAt *buildkite.Timestamp `json:"created_at"`
 }
 
-// JobEntry represents a lightweight job reference with just enough info to identify and filter jobs
-type JobEntry struct {
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	State string `json:"state"`
-}
-
-// BuildDetail - Medium detail with lightweight job listing
-type BuildDetail struct {
-	BuildSummary                      // Embed summary fields
-	Source       string               `json:"source"`
-	Author       buildkite.Author     `json:"author"`
-	StartedAt    *buildkite.Timestamp `json:"started_at"`
-	FinishedAt   *buildkite.Timestamp `json:"finished_at"`
-	JobSummary   *JobSummary          `json:"job_summary"`
-	Jobs         []JobEntry           `json:"jobs"`
-}
-
-// BuildWithSummary represents a build with job summary and optionally full job details
-type BuildWithSummary struct {
-	buildkite.Build
-	JobSummary *JobSummary `json:"job_summary"`
-}
-
 // ListBuildsArgs struct with enhanced filtering
 type ListBuildsArgs struct {
 	OrgSlug      string `json:"org_slug"`
@@ -70,7 +38,6 @@ type ListBuildsArgs struct {
 	State        string `json:"state,omitempty" jsonschema:"Filter builds by state (scheduled\\, running\\, passed\\, failed\\, canceled\\, skipped)"`
 	Commit       string `json:"commit,omitempty" jsonschema:"Filter builds by specific commit SHA"`
 	Creator      string `json:"creator,omitempty" jsonschema:"Filter builds by build creator"`
-	DetailLevel  string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default)\\, 'detailed'\\, or 'full'"` // summary, detailed, full
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
 	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
 }
@@ -80,9 +47,6 @@ type GetBuildArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
-	DetailLevel  string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'detailed' (default) or 'full'. Detailed includes job IDs/names/states; full includes complete job objects"`
-	JobState     string `json:"job_state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g.\\, 'failed\\,broken\\,canceled')"`
-	IncludeAgent bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default)\\, only agent.id is included"`
 }
 
 // GetBuildTestEngineRunsArgs struct
@@ -108,40 +72,6 @@ func summarizeBuild(build buildkite.Build) BuildSummary {
 	}
 }
 
-// detailBuild converts a buildkite.Build to BuildDetail with job summary
-// filteredJobs is used for job_summary stats and lightweight job entries
-func detailBuild(build buildkite.Build, filteredJobs []buildkite.Job) BuildDetail {
-	summary := summarizeBuild(build)
-
-	// Create job summary and lightweight job entries from filtered jobs
-	jobSummary := &JobSummary{
-		Total:   len(filteredJobs),
-		ByState: make(map[string]int),
-	}
-	jobEntries := make([]JobEntry, len(filteredJobs))
-
-	for i, job := range filteredJobs {
-		if job.State != "" {
-			jobSummary.ByState[job.State]++
-		}
-		jobEntries[i] = JobEntry{
-			ID:    job.ID,
-			Name:  job.Name,
-			State: job.State,
-		}
-	}
-
-	return BuildDetail{
-		BuildSummary: summary,
-		Source:       build.Source,
-		Author:       build.Author,
-		StartedAt:    build.StartedAt,
-		FinishedAt:   build.FinishedAt,
-		JobSummary:   jobSummary, // job_summary reflects filtered jobs
-		Jobs:         jobEntries,
-	}
-}
-
 // createPaginatedBuildResult creates a paginated result with the appropriate converter
 func createPaginatedBuildResult[T any](builds []buildkite.Build, converter func(buildkite.Build) T, headers map[string]string) PaginatedResult[T] {
 	items := make([]T, len(builds))
@@ -158,7 +88,7 @@ func createPaginatedBuildResult[T any](builds []buildkite.Build, converter func(
 func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_builds",
-			Description: "List builds for a pipeline or across all pipelines in an organization. When pipeline_slug is omitted, lists builds across all pipelines in the organization",
+			Description: "List builds for a pipeline or across all pipelines in an organization, returning a lightweight summary of each build. When pipeline_slug is omitted, lists builds across all pipelines in the organization. Jobs are not included — use list_jobs or get_job for job detail",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Builds",
 				ReadOnlyHint: true,
@@ -175,16 +105,9 @@ func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) 
 				attribute.String("state", args.State),
 				attribute.String("commit", args.Commit),
 				attribute.String("creator", args.Creator),
-				attribute.String("detail_level", args.DetailLevel),
 				attribute.Int("page", args.Page),
 				attribute.Int("per_page", args.PerPage),
 			)
-
-			// Set default detail level
-			detailLevel := args.DetailLevel
-			if detailLevel == "" {
-				detailLevel = "summary"
-			}
 
 			// Set default pagination
 			page := args.Page
@@ -196,31 +119,15 @@ func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) 
 				perPage = 30
 			}
 
+			// Builds are returned as lightweight summaries; jobs and pipeline
+			// detail are excluded. Use list_jobs/get_job for job detail.
 			options := &buildkite.BuildsListOptions{
-				ExcludeJobs: true,
+				ExcludeJobs:     true,
+				ExcludePipeline: true,
 				ListOptions: buildkite.ListOptions{
 					Page:    page,
 					PerPage: perPage,
 				},
-			}
-
-			// Set exclusions based on detail level
-			switch detailLevel {
-			case "summary":
-				options.ExcludeJobs = true
-				// Only exclude pipeline when it's already known from the request
-				if args.PipelineSlug != "" {
-					options.ExcludePipeline = true
-				}
-			case "detailed":
-				options.ExcludeJobs = true
-				if args.PipelineSlug != "" {
-					options.ExcludePipeline = true
-				}
-			case "full":
-				// Include everything
-			default:
-				return utils.NewToolResultError("detail_level must be 'summary', 'detailed', or 'full'"), nil, nil
 			}
 
 			// Apply filters
@@ -254,21 +161,7 @@ func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) 
 				"Link": resp.Header.Get("Link"),
 			}
 
-			var result any
-			switch detailLevel {
-			case "summary":
-				result = createPaginatedBuildResult(builds, summarizeBuild, headers)
-			case "detailed":
-				// For list_builds, use all jobs (no filtering)
-				result = createPaginatedBuildResult(builds, func(b buildkite.Build) BuildDetail {
-					return detailBuild(b, b.Jobs)
-				}, headers)
-			case "full":
-				result = PaginatedResult[buildkite.Build]{
-					Items:   builds,
-					Headers: headers,
-				}
-			}
+			result := createPaginatedBuildResult(builds, summarizeBuild, headers)
 
 			return mcpTextResult(span, result)
 		}, []string{"read_builds"}
@@ -314,7 +207,7 @@ func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRu
 func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build",
-			Description: "Get build information including job IDs, names, and states. Use job_state to filter (e.g. 'failed,broken'). Returns enough detail to identify which jobs to investigate with log and artifact tools",
+			Description: "Get a single build. Jobs are not included — use list_jobs or get_job for job detail",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build",
 				ReadOnlyHint: true,
@@ -328,33 +221,14 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
-				attribute.String("detail_level", args.DetailLevel),
-				attribute.String("job_state", args.JobState),
-				attribute.Bool("include_agent", args.IncludeAgent),
 			)
 
-			// Set default detail level
-			detailLevel := args.DetailLevel
-			if detailLevel == "" {
-				detailLevel = "detailed"
-			}
-
-			// Configure build get options based on detail level
+			// Jobs are excluded; use list_jobs/get_job for job detail.
 			options := &buildkite.BuildGetOptions{
 				BuildsListOptions: buildkite.BuildsListOptions{
 					ExcludeJobs: true,
 				},
 				IncludeTestEngine: true,
-			}
-
-			// Push job state filtering down to the API
-			if args.JobState != "" {
-				states := strings.Split(args.JobState, ",")
-				jobStates := make([]string, len(states))
-				for i, state := range states {
-					jobStates[i] = strings.TrimSpace(state)
-				}
-				options.JobStates = jobStates
 			}
 
 			deps := DepsFromContext(ctx)
@@ -363,45 +237,7 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
-			jobs := build.Jobs
-
-			// Strip agent details if not requested
-			if !args.IncludeAgent && len(jobs) > 0 {
-				jobsWithMinimalAgent := make([]buildkite.Job, len(jobs))
-				for i, job := range jobs {
-					jobCopy := job
-					// Keep only agent ID, strip verbose details
-					jobCopy.Agent = buildkite.Agent{ID: job.Agent.ID}
-					jobsWithMinimalAgent[i] = jobCopy
-				}
-				jobs = jobsWithMinimalAgent
-			}
-
-			var result any
-			switch detailLevel {
-			case "detailed":
-				result = detailBuild(build, jobs)
-			case "full":
-				// Full level returns build with filtered jobs
-				buildCopy := build
-				buildCopy.Pipeline = nil // reduce size by excluding pipeline details
-
-				// Strip fields from jobs
-				for i := range jobs {
-					jobs[i].WebURL = ""       // not useful in MCP
-					jobs[i].RawLogsURL = ""   // provided by another tool
-					jobs[i].ArtifactsURL = "" // provided by another tool
-					jobs[i].LogsURL = ""      // deprecated
-					jobs[i].GraphQLID = ""    // random id not useful in the MCP
-				}
-
-				buildCopy.Jobs = jobs
-				result = buildCopy
-			default:
-				return utils.NewToolResultError("detail_level must be 'detailed' or 'full'"), nil, nil
-			}
-
-			return mcpTextResult(span, &result)
+			return mcpTextResult(span, &build)
 		}, []string{"read_builds"}
 }
 

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -197,6 +197,7 @@ func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) 
 			}
 
 			options := &buildkite.BuildsListOptions{
+				ExcludeJobs: true,
 				ListOptions: buildkite.ListOptions{
 					Page:    page,
 					PerPage: perPage,
@@ -340,6 +341,9 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 
 			// Configure build get options based on detail level
 			options := &buildkite.BuildGetOptions{
+				BuildsListOptions: buildkite.BuildsListOptions{
+					ExcludeJobs: true,
+				},
 				IncludeTestEngine: true,
 			}
 

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -30,6 +30,24 @@ type BuildSummary struct {
 	CreatedAt *buildkite.Timestamp `json:"created_at"`
 }
 
+// BuildDetail includes useful build metadata while omitting jobs, env, and
+// pipeline configuration from the raw Buildkite SDK response.
+type BuildDetail struct {
+	BuildSummary
+	Blocked       bool                          `json:"blocked"`
+	Author        buildkite.Author              `json:"author"`
+	ScheduledAt   *buildkite.Timestamp          `json:"scheduled_at,omitempty"`
+	StartedAt     *buildkite.Timestamp          `json:"started_at,omitempty"`
+	FinishedAt    *buildkite.Timestamp          `json:"finished_at,omitempty"`
+	MetaData      map[string]string             `json:"meta_data,omitempty"`
+	Creator       buildkite.Creator             `json:"creator"`
+	Source        string                        `json:"source,omitempty"`
+	RebuiltFrom   *buildkite.RebuiltFrom        `json:"rebuilt_from,omitempty"`
+	PullRequest   *buildkite.PullRequest        `json:"pull_request,omitempty"`
+	TriggeredFrom *buildkite.TriggeredFrom      `json:"triggered_from,omitempty"`
+	TestEngine    *buildkite.TestEngineProperty `json:"test_engine,omitempty"`
+}
+
 // ListBuildsArgs struct with enhanced filtering
 type ListBuildsArgs struct {
 	OrgSlug      string `json:"org_slug"`
@@ -69,6 +87,24 @@ func summarizeBuild(build buildkite.Build) BuildSummary {
 		Message:   build.Message,
 		WebURL:    build.WebURL,
 		CreatedAt: build.CreatedAt,
+	}
+}
+
+func detailBuild(build buildkite.Build) BuildDetail {
+	return BuildDetail{
+		BuildSummary:  summarizeBuild(build),
+		Blocked:       build.Blocked,
+		Author:        build.Author,
+		ScheduledAt:   build.ScheduledAt,
+		StartedAt:     build.StartedAt,
+		FinishedAt:    build.FinishedAt,
+		MetaData:      build.MetaData,
+		Creator:       build.Creator,
+		Source:        build.Source,
+		RebuiltFrom:   build.RebuiltFrom,
+		PullRequest:   build.PullRequest,
+		TriggeredFrom: build.TriggeredFrom,
+		TestEngine:    build.TestEngine,
 	}
 }
 
@@ -226,7 +262,8 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 			// Jobs are excluded; use list_jobs/get_job for job detail.
 			options := &buildkite.BuildGetOptions{
 				BuildsListOptions: buildkite.BuildsListOptions{
-					ExcludeJobs: true,
+					ExcludeJobs:     true,
+					ExcludePipeline: true,
 				},
 				IncludeTestEngine: true,
 			}
@@ -237,7 +274,8 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
-			return mcpTextResult(span, &build)
+			result := detailBuild(build)
+			return mcpTextResult(span, &result)
 		}, []string{"read_builds"}
 }
 

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -63,334 +63,225 @@ func (m *MockBuildsClient) Rebuild(ctx context.Context, org, pipeline, buildNumb
 
 var _ BuildsClient = (*MockBuildsClient)(nil)
 
-func TestGetBuildDefault(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			// Return build without jobs
-			return buildkite.Build{
-					ID:        "123",
-					Number:    1,
-					State:     "running",
-					CreatedAt: &buildkite.Timestamp{},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := GetBuild()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	// Test default behavior - jobs always excluded, summary always included
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, GetBuildArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
+func TestGetBuild(t *testing.T) {
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, handler, scopes := GetBuild()
+		require.Equal(t, "get_build", tool.Name)
+		require.True(t, tool.Annotations.ReadOnlyHint)
+		require.Equal(t, []string{"read_builds"}, scopes)
+		require.NotNil(t, handler)
 	})
-	assert.NoError(err)
 
-	textContent := getTextResult(t, result)
-	// New format returns BuildDetail (detailed level by default)
-	assert.Contains(textContent.Text, `"id":"123"`)
-	assert.Contains(textContent.Text, `"number":1`)
-	assert.Contains(textContent.Text, `"state":"running"`)
-	assert.Contains(textContent.Text, `"total":0`)
-	assert.Contains(textContent.Text, `"by_state":{}`)
-	assert.NotContains(textContent.Text, `"jobs_total"`)
-}
+	t.Run("ReturnsBuildAndExcludesJobs", func(t *testing.T) {
+		assert := require.New(t)
 
-func TestGetBuildWithJobSummary(t *testing.T) {
-	assert := require.New(t)
+		var capturedOptions *buildkite.BuildGetOptions
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				capturedOptions = opt
+				assert.Equal("org", org)
+				assert.Equal("pipeline", pipeline)
+				assert.Equal("1", id)
+				return buildkite.Build{
+						ID:        "123",
+						Number:    1,
+						State:     "passed",
+						Branch:    "main",
+						CreatedAt: &buildkite.Timestamp{},
+					}, &buildkite.Response{
+						Response: &http.Response{StatusCode: 200},
+					}, nil
+			},
+		}
 
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			// Create a build with some jobs to test summary functionality
-			return buildkite.Build{
-					ID:        "123",
-					Number:    1,
-					State:     "finished",
-					CreatedAt: &buildkite.Timestamp{},
-					Jobs: []buildkite.Job{
-						{ID: "job1", State: "passed"}, // API already coerced
-						{ID: "job2", State: "failed"}, // API already coerced
-						{ID: "job3", State: "running"},
-						{ID: "job4", State: "waiting"},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-	}
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := GetBuild()
 
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildArgs{
+			OrgSlug:      "org",
+			PipelineSlug: "pipeline",
+			BuildNumber:  "1",
+		})
+		assert.NoError(err)
 
-	tool, handler, _ := GetBuild()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"id":"123"`)
+		assert.Contains(text, `"number":1`)
+		assert.Contains(text, `"state":"passed"`)
+		// Job detail lives in list_jobs/get_job, not here.
+		assert.NotContains(text, `"job_summary"`)
 
-	// Test behavior - jobs always excluded, summary always shown
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, GetBuildArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
+		// The handler must exclude jobs from the API request.
+		require.NotNil(t, capturedOptions)
+		assert.True(capturedOptions.ExcludeJobs)
+		assert.True(capturedOptions.IncludeTestEngine)
 	})
-	assert.NoError(err)
 
-	textContent := getTextResult(t, result)
-	assert.Contains(textContent.Text, `"job_summary"`)
-	assert.Contains(textContent.Text, `"total":4`)
-	assert.Contains(textContent.Text, `"by_state":{"failed":1,"passed":1,"running":1,"waiting":1}`)
-	// Lightweight job entries included with correct id, name, and state
-	assert.Contains(textContent.Text, `"jobs":[{"id":"job1"`)
-	assert.Contains(textContent.Text, `{"id":"job1","name":"","state":"passed"}`)
-	assert.Contains(textContent.Text, `{"id":"job2","name":"","state":"failed"}`)
-	assert.Contains(textContent.Text, `{"id":"job3","name":"","state":"running"}`)
-	assert.Contains(textContent.Text, `{"id":"job4","name":"","state":"waiting"}`)
-	// Full job objects should NOT be present (no agent, command, etc.)
-	assert.NotContains(textContent.Text, `"agent"`)
+	t.Run("APIError", func(t *testing.T) {
+		assert := require.New(t)
+
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				return buildkite.Build{}, nil, &buildkite.ErrorResponse{
+					RawBody:  []byte("build not found"),
+					Response: &http.Response{StatusCode: 404},
+				}
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := GetBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildArgs{
+			OrgSlug:      "org",
+			PipelineSlug: "pipeline",
+			BuildNumber:  "1",
+		})
+		assert.NoError(err)
+		assert.True(result.IsError)
+		assert.Contains(getTextResult(t, result).Text, "build not found")
+	})
 }
 
 func TestListBuilds(t *testing.T) {
-	assert := require.New(t)
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, handler, scopes := ListBuilds()
+		require.Equal(t, "list_builds", tool.Name)
+		require.True(t, tool.Annotations.ReadOnlyHint)
+		require.Equal(t, []string{"read_builds"}, scopes)
+		require.NotNil(t, handler)
+	})
 
-	var capturedOptions *buildkite.BuildsListOptions
-	client := &MockBuildsClient{
-		ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			capturedOptions = opt
-			return []buildkite.Build{
-					{
-						ID:        "123",
-						Number:    1,
-						State:     "running",
-						CreatedAt: &buildkite.Timestamp{},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
+	t.Run("DefaultsAndSummaryOutput", func(t *testing.T) {
+		assert := require.New(t)
+
+		var capturedOptions *buildkite.BuildsListOptions
+		client := &MockBuildsClient{
+			ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+				capturedOptions = opt
+				return []buildkite.Build{
+						{ID: "123", Number: 1, State: "running", CreatedAt: &buildkite.Timestamp{}},
+					}, &buildkite.Response{
+						Response: &http.Response{StatusCode: 200},
+					}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := ListBuilds()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListBuildsArgs{
+			OrgSlug:      "org",
+			PipelineSlug: "pipeline",
+		})
+		assert.NoError(err)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"headers":{"Link":""}`)
+		assert.Contains(text, `"items":[`)
+		assert.Contains(text, `"id":"123"`)
+		assert.Contains(text, `"state":"running"`)
+		assert.NotContains(text, `"job_summary"`)
+		assert.NotContains(text, `"jobs":`)
+
+		require.NotNil(t, capturedOptions)
+		assert.Equal(1, capturedOptions.Page)
+		assert.Equal(30, capturedOptions.PerPage)
+		assert.True(capturedOptions.ExcludeJobs)
+		assert.True(capturedOptions.ExcludePipeline)
+		assert.Nil(capturedOptions.Branch)
+	})
+
+	t.Run("CustomPaginationAndFilters", func(t *testing.T) {
+		assert := require.New(t)
+
+		var capturedOptions *buildkite.BuildsListOptions
+		client := &MockBuildsClient{
+			ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+				capturedOptions = opt
+				return []buildkite.Build{}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
 				}, nil
-		},
-	}
+			},
+		}
 
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := ListBuilds()
 
-	tool, handler, _ := ListBuilds()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
+		_, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListBuildsArgs{
+			OrgSlug:      "org",
+			PipelineSlug: "pipeline",
+			Branch:       "feature",
+			State:        "failed",
+			Commit:       "abc123",
+			Creator:      "user-1",
+			Page:         3,
+			PerPage:      50,
+		})
+		assert.NoError(err)
 
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, ListBuildsArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
+		require.NotNil(t, capturedOptions)
+		assert.Equal(3, capturedOptions.Page)
+		assert.Equal(50, capturedOptions.PerPage)
+		assert.Equal([]string{"feature"}, capturedOptions.Branch)
+		assert.Equal([]string{"failed"}, capturedOptions.State)
+		assert.Equal("abc123", capturedOptions.Commit)
+		assert.Equal("user-1", capturedOptions.Creator)
 	})
-	assert.NoError(err)
 
-	textContent := getTextResult(t, result)
+	t.Run("OrgScopedWhenPipelineOmitted", func(t *testing.T) {
+		assert := require.New(t)
 
-	// New format returns BuildSummary (summary level by default)
-	assert.Contains(textContent.Text, `"headers":{"Link":""}`)
-	assert.Contains(textContent.Text, `"items":[`)
-	assert.Contains(textContent.Text, `"id":"123"`)
-	assert.Contains(textContent.Text, `"number":1`)
-	assert.Contains(textContent.Text, `"state":"running"`)
-	assert.NotContains(textContent.Text, `"jobs_total"`)
+		called := false
+		client := &MockBuildsClient{
+			ListByOrgFunc: func(ctx context.Context, org string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+				called = true
+				assert.Equal("org", org)
+				return []buildkite.Build{
+						{ID: "123", Number: 1, State: "passed", CreatedAt: &buildkite.Timestamp{}},
+					}, &buildkite.Response{
+						Response: &http.Response{StatusCode: 200},
+					}, nil
+			},
+			ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+				t.Fatal("ListByPipeline should not be called when pipeline_slug is omitted")
+				return nil, nil, nil
+			},
+		}
 
-	// Verify default pagination parameters - new defaults
-	assert.NotNil(capturedOptions)
-	assert.Equal(1, capturedOptions.Page)
-	assert.Equal(30, capturedOptions.PerPage) // New default
-	assert.Nil(capturedOptions.Branch)        // Branch should be nil when not specified
-}
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := ListBuilds()
 
-func TestListBuildsWithCustomPagination(t *testing.T) {
-	assert := require.New(t)
-
-	var capturedOptions *buildkite.BuildsListOptions
-	client := &MockBuildsClient{
-		ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			capturedOptions = opt
-			return []buildkite.Build{
-					{
-						ID:        "123",
-						Number:    1,
-						State:     "running",
-						CreatedAt: &buildkite.Timestamp{},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := ListBuilds()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	// Test with custom pagination parameters
-	request := createMCPRequest(t, map[string]any{})
-	_, _, err := handler(ctx, request, ListBuildsArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		Page:         3,
-		PerPage:      50,
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListBuildsArgs{
+			OrgSlug: "org",
+		})
+		assert.NoError(err)
+		assert.True(called)
+		assert.Contains(getTextResult(t, result).Text, `"id":"123"`)
 	})
-	assert.NoError(err)
 
-	// Verify custom pagination parameters were used
-	assert.NotNil(capturedOptions)
-	assert.Equal(3, capturedOptions.Page)
-	assert.Equal(50, capturedOptions.PerPage)
-	assert.Nil(capturedOptions.Branch) // Branch should be nil when not specified
-}
+	t.Run("APIError", func(t *testing.T) {
+		assert := require.New(t)
 
-func TestListBuildsWithBranchFilter(t *testing.T) {
-	assert := require.New(t)
+		client := &MockBuildsClient{
+			ListByOrgFunc: func(ctx context.Context, org string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+				return nil, nil, &buildkite.ErrorResponse{
+					RawBody:  []byte("organization not found"),
+					Response: &http.Response{StatusCode: 404},
+				}
+			},
+		}
 
-	var capturedOptions *buildkite.BuildsListOptions
-	client := &MockBuildsClient{
-		ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			capturedOptions = opt
-			return []buildkite.Build{
-					{
-						ID:        "123",
-						Number:    1,
-						State:     "running",
-						CreatedAt: &buildkite.Timestamp{},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-	}
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+		_, handler, _ := ListBuilds()
 
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := ListBuilds()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	// Test with branch filter
-	request := createMCPRequest(t, map[string]any{})
-	_, _, err := handler(ctx, request, ListBuildsArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		Branch:       "main",
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListBuildsArgs{
+			OrgSlug: "bad-org",
+		})
+		assert.NoError(err)
+		assert.True(result.IsError)
+		assert.Contains(getTextResult(t, result).Text, "organization not found")
 	})
-	assert.NoError(err)
-
-	// Verify branch filter was applied
-	assert.NotNil(capturedOptions)
-	assert.Equal([]string{"main"}, capturedOptions.Branch)
-	assert.Equal(1, capturedOptions.Page)
-	assert.Equal(30, capturedOptions.PerPage) // New default
-}
-
-func TestListBuildsByOrg(t *testing.T) {
-	assert := require.New(t)
-
-	var capturedOrg string
-	var capturedOptions *buildkite.BuildsListOptions
-	client := &MockBuildsClient{
-		ListByOrgFunc: func(ctx context.Context, org string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			capturedOrg = org
-			capturedOptions = opt
-			return []buildkite.Build{
-					{
-						ID:        "build-1",
-						Number:    10,
-						State:     "running",
-						CreatedAt: &buildkite.Timestamp{},
-						Pipeline:  &buildkite.Pipeline{Slug: "pipeline-a"},
-					},
-					{
-						ID:        "build-2",
-						Number:    20,
-						State:     "scheduled",
-						CreatedAt: &buildkite.Timestamp{},
-						Pipeline:  &buildkite.Pipeline{Slug: "pipeline-b"},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{
-						StatusCode: 200,
-					},
-				}, nil
-		},
-		ListByPipelineFunc: func(ctx context.Context, org string, pipeline string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			t.Fatal("ListByPipeline should not be called when pipeline_slug is empty")
-			return nil, nil, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := ListBuilds()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	// Test without pipeline_slug — should use ListByOrg
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, ListBuildsArgs{
-		OrgSlug: "my-org",
-		State:   "running",
-	})
-	assert.NoError(err)
-
-	textContent := getTextResult(t, result)
-	assert.Contains(textContent.Text, `"id":"build-1"`)
-	assert.Contains(textContent.Text, `"id":"build-2"`)
-	assert.Equal("my-org", capturedOrg)
-	assert.NotNil(capturedOptions)
-	assert.Equal([]string{"running"}, capturedOptions.State)
-	assert.Equal(1, capturedOptions.Page)
-	assert.Equal(30, capturedOptions.PerPage)
-	// Pipeline info should be included for org-wide queries
-	assert.False(capturedOptions.ExcludePipeline)
-}
-
-func TestListBuildsByOrgError(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockBuildsClient{
-		ListByOrgFunc: func(ctx context.Context, org string, opt *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
-			return nil, nil, &buildkite.ErrorResponse{
-				RawBody: []byte("organization not found"),
-				Response: &http.Response{
-					StatusCode: 404,
-				},
-			}
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	_, handler, _ := ListBuilds()
-
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, ListBuildsArgs{
-		OrgSlug: "bad-org",
-	})
-	assert.NoError(err)
-
-	textContent := getTextResult(t, result)
-	assert.Contains(textContent.Text, "organization not found")
-	assert.True(result.IsError)
 }
 
 func TestGetBuildTestEngineRuns(t *testing.T) {
@@ -549,248 +440,6 @@ func TestCreateBuild(t *testing.T) {
 
 	textContent := getTextResult(t, result)
 	assert.JSONEq(`{"id":"123","number":1,"state":"created","blocked":false,"author":{},"env":{"ENV_VAR":"value"},"created_at":"0001-01-01T00:00:00Z","meta_data":{"meta_key":"meta_value"},"creator":{"avatar_url":"","created_at":null,"email":"","id":"","name":""}}`, textContent.Text)
-}
-
-func TestGetBuildWithJobStateFilter(t *testing.T) {
-	assert := require.New(t)
-
-	// Mock returns jobs matching the requested states (simulating API-side filtering)
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			// Simulate API-side job state filtering
-			allJobs := []buildkite.Job{
-				{ID: "job1", Name: "Test 1", State: "passed", Agent: buildkite.Agent{ID: "agent1", Name: "Agent 1"}},
-				{ID: "job2", Name: "Test 2", State: "failed", Agent: buildkite.Agent{ID: "agent2", Name: "Agent 2"}},
-				{ID: "job3", Name: "Test 3", State: "failed", Agent: buildkite.Agent{ID: "agent3", Name: "Agent 3"}},
-				{ID: "job4", Name: "Test 4", State: "broken", Agent: buildkite.Agent{ID: "agent4", Name: "Agent 4"}},
-			}
-
-			// Filter jobs based on requested states (simulating what the API does)
-			var jobs []buildkite.Job
-			if len(opt.JobStates) > 0 {
-				stateSet := make(map[string]bool, len(opt.JobStates))
-				for _, s := range opt.JobStates {
-					stateSet[s] = true
-				}
-				for _, job := range allJobs {
-					if stateSet[job.State] {
-						jobs = append(jobs, job)
-					}
-				}
-			} else {
-				jobs = allJobs
-			}
-
-			return buildkite.Build{
-					ID:     "123",
-					Number: 1,
-					State:  "failed",
-					Jobs:   jobs,
-				}, &buildkite.Response{
-					Response: &http.Response{StatusCode: 200},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := GetBuild()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	t.Run("filter by single state", func(t *testing.T) {
-		request := createMCPRequest(t, map[string]any{})
-		result, _, err := handler(ctx, request, GetBuildArgs{
-			OrgSlug:      "org",
-			PipelineSlug: "pipeline",
-			BuildNumber:  "1",
-			DetailLevel:  "full",
-			JobState:     "failed",
-		})
-		assert.NoError(err)
-
-		textContent := getTextResult(t, result)
-		assert.Contains(textContent.Text, `"id":"job2"`)
-		assert.Contains(textContent.Text, `"id":"job3"`)
-		assert.NotContains(textContent.Text, `"id":"job1"`)
-		assert.NotContains(textContent.Text, `"id":"job4"`)
-	})
-
-	t.Run("filter by multiple states", func(t *testing.T) {
-		request := createMCPRequest(t, map[string]any{})
-		result, _, err := handler(ctx, request, GetBuildArgs{
-			OrgSlug:      "org",
-			PipelineSlug: "pipeline",
-			BuildNumber:  "1",
-			DetailLevel:  "full",
-			JobState:     "failed,broken",
-		})
-		assert.NoError(err)
-
-		textContent := getTextResult(t, result)
-		assert.Contains(textContent.Text, `"id":"job2"`)
-		assert.Contains(textContent.Text, `"id":"job3"`)
-		assert.Contains(textContent.Text, `"id":"job4"`)
-		assert.NotContains(textContent.Text, `"id":"job1"`)
-	})
-
-	t.Run("filter with whitespace handling", func(t *testing.T) {
-		request := createMCPRequest(t, map[string]any{})
-		result, _, err := handler(ctx, request, GetBuildArgs{
-			OrgSlug:      "org",
-			PipelineSlug: "pipeline",
-			BuildNumber:  "1",
-			DetailLevel:  "full",
-			JobState:     "failed, broken",
-		})
-		assert.NoError(err)
-
-		textContent := getTextResult(t, result)
-		assert.Contains(textContent.Text, `"id":"job2"`)
-		assert.Contains(textContent.Text, `"id":"job3"`)
-		assert.Contains(textContent.Text, `"id":"job4"`)
-	})
-}
-
-func TestGetBuildWithAgentStripping(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			return buildkite.Build{
-					ID:     "123",
-					Number: 1,
-					State:  "passed",
-					Jobs: []buildkite.Job{
-						{ID: "job1", Name: "Test 1", State: "passed", Agent: buildkite.Agent{ID: "agent1", Name: "Agent 1", Hostname: "host1"}},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{StatusCode: 200},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := GetBuild()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	t.Run("include_agent false strips details", func(t *testing.T) {
-		request := createMCPRequest(t, map[string]any{})
-		result, _, err := handler(ctx, request, GetBuildArgs{
-			OrgSlug:      "org",
-			PipelineSlug: "pipeline",
-			BuildNumber:  "1",
-			DetailLevel:  "full",
-			IncludeAgent: false,
-		})
-		assert.NoError(err)
-
-		textContent := getTextResult(t, result)
-		assert.Contains(textContent.Text, `"agent1"`)
-		assert.NotContains(textContent.Text, `"Agent 1"`)
-		assert.NotContains(textContent.Text, `"host1"`)
-	})
-
-	t.Run("include_agent true keeps details", func(t *testing.T) {
-		request := createMCPRequest(t, map[string]any{})
-		result, _, err := handler(ctx, request, GetBuildArgs{
-			OrgSlug:      "org",
-			PipelineSlug: "pipeline",
-			BuildNumber:  "1",
-			DetailLevel:  "full",
-			IncludeAgent: true,
-		})
-		assert.NoError(err)
-
-		textContent := getTextResult(t, result)
-		assert.Contains(textContent.Text, `"agent1"`)
-		assert.Contains(textContent.Text, `"Agent 1"`)
-		assert.Contains(textContent.Text, `"host1"`)
-	})
-}
-
-func TestGetBuildDetailedWithJobStateFilter(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			assert.Equal([]string{"failed"}, opt.JobStates, "JobStates should be passed to the API")
-
-			// API returns only the filtered jobs
-			return buildkite.Build{
-					ID:     "123",
-					Number: 1,
-					State:  "failed",
-					Jobs: []buildkite.Job{
-						{ID: "job2", Name: "Test 2", State: "failed"},
-						{ID: "job3", Name: "Test 3", State: "failed"},
-					},
-				}, &buildkite.Response{
-					Response: &http.Response{StatusCode: 200},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	tool, handler, _ := GetBuild()
-	assert.NotNil(tool)
-	assert.NotNil(handler)
-
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, GetBuildArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
-		DetailLevel:  "detailed",
-		JobState:     "failed",
-	})
-	assert.NoError(err)
-
-	textContent := getTextResult(t, result)
-	assert.NotContains(textContent.Text, `"jobs_total"`)
-	// job_summary.total should reflect filtered jobs (2)
-	assert.Contains(textContent.Text, `"total":2`)
-	// job_summary.by_state should only show failed count
-	assert.Contains(textContent.Text, `"failed":2`)
-	// jobs array should contain only the filtered entries
-	assert.Contains(textContent.Text, `{"id":"job2","name":"Test 2","state":"failed"}`)
-	assert.Contains(textContent.Text, `{"id":"job3","name":"Test 3","state":"failed"}`)
-}
-
-func TestGetBuildInvalidDetailLevel(t *testing.T) {
-	assert := require.New(t)
-
-	client := &MockBuildsClient{
-		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			return buildkite.Build{
-					ID:     "123",
-					Number: 1,
-					State:  "failed",
-				}, &buildkite.Response{
-					Response: &http.Response{StatusCode: 200},
-				}, nil
-		},
-	}
-
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
-
-	_, handler, _ := GetBuild()
-
-	request := createMCPRequest(t, map[string]any{})
-	result, _, err := handler(ctx, request, GetBuildArgs{
-		OrgSlug:      "org",
-		PipelineSlug: "pipeline",
-		BuildNumber:  "1",
-		DetailLevel:  "summary",
-	})
-	assert.NoError(err)
-	assert.True(result.IsError)
-
-	textContent := getTextResult(t, result)
-	assert.Contains(textContent.Text, "detail_level must be 'detailed' or 'full'")
 }
 
 func TestCancelBuild(t *testing.T) {

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -83,10 +83,21 @@ func TestGetBuild(t *testing.T) {
 				assert.Equal("pipeline", pipeline)
 				assert.Equal("1", id)
 				return buildkite.Build{
-						ID:        "123",
-						Number:    1,
-						State:     "passed",
-						Branch:    "main",
+						ID:     "123",
+						Number: 1,
+						State:  "passed",
+						Branch: "main",
+						Env: map[string]any{
+							"SECRET_TOKEN": "redacted",
+						},
+						Jobs: []buildkite.Job{{
+							ID: "job-1",
+						}},
+						Pipeline: &buildkite.Pipeline{
+							ID:            "pipeline-1",
+							Configuration: "steps:\n  - command: echo secret",
+							Env:           map[string]any{"PIPELINE_SECRET": "redacted"},
+						},
 						CreatedAt: &buildkite.Timestamp{},
 					}, &buildkite.Response{
 						Response: &http.Response{StatusCode: 200},
@@ -109,11 +120,18 @@ func TestGetBuild(t *testing.T) {
 		assert.Contains(text, `"number":1`)
 		assert.Contains(text, `"state":"passed"`)
 		// Job detail lives in list_jobs/get_job, not here.
-		assert.NotContains(text, `"job_summary"`)
+		assert.NotContains(text, `"jobs":`)
+		// Build env and pipeline config are intentionally omitted from read_builds.
+		assert.NotContains(text, `"env":`)
+		assert.NotContains(text, `"pipeline":`)
+		assert.NotContains(text, "SECRET_TOKEN")
+		assert.NotContains(text, "PIPELINE_SECRET")
+		assert.NotContains(text, "steps:")
 
-		// The handler must exclude jobs from the API request.
+		// The handler must exclude jobs and pipeline detail from the API request.
 		require.NotNil(t, capturedOptions)
 		assert.True(capturedOptions.ExcludeJobs)
+		assert.True(capturedOptions.ExcludePipeline)
 		assert.True(capturedOptions.IncludeTestEngine)
 	})
 

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -20,6 +20,14 @@ type JobsClient interface {
 	GetJobEnvironmentVariables(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.JobEnvs, *buildkite.Response, error)
 }
 
+func redactUnusedJobFields(job *buildkite.Job) {
+	job.WebURL = ""       // not useful in MCP
+	job.RawLogsURL = ""   // provided by another tool
+	job.ArtifactsURL = "" // provided by another tool
+	job.LogsURL = ""      // deprecated
+	job.GraphQLID = ""    // random id not useful in the MCP
+}
+
 // ListJobsArgs struct for typed parameters
 type ListJobsArgs struct {
 	OrgSlug            string `json:"org_slug"`
@@ -79,6 +87,10 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
+			for i := range jobs.Items {
+				redactUnusedJobFields(&jobs.Items[i])
+			}
+
 			return mcpTextResult(span, &jobs)
 		}, []string{"read_builds"}
 }
@@ -127,6 +139,8 @@ func GetJob() (mcp.Tool, mcp.ToolHandlerFor[GetJobArgs, any], []string) {
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
+
+			redactUnusedJobFields(&job)
 
 			return mcpTextResult(span, &job)
 		}, []string{"read_builds"}

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -2,17 +2,134 @@ package buildkite
 
 import (
 	"context"
+	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 type JobsClient interface {
+	ListByBuild(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error)
+	GetJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error)
+	GetJobByOrg(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error)
 	UnblockJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *buildkite.JobUnblockOptions) (buildkite.Job, *buildkite.Response, error)
 	RetryJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error)
 	GetJobEnvironmentVariables(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.JobEnvs, *buildkite.Response, error)
+}
+
+// ListJobsArgs struct for typed parameters
+type ListJobsArgs struct {
+	OrgSlug            string `json:"org_slug"`
+	PipelineSlug       string `json:"pipeline_slug"`
+	BuildNumber        string `json:"build_number"`
+	State              string `json:"state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g.\\, 'passed\\,failed\\,running')"`
+	IncludeRetriedJobs *bool  `json:"include_retried_jobs,omitempty" jsonschema:"Include retried jobs in the response. Defaults to true on the server when omitted"`
+	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1\\, max 100\\, default 30)"`
+	After              string `json:"after,omitempty" jsonschema:"Cursor for the next page. Take this from the 'links.next' URL of a previous response. Mutually exclusive with 'before'"`
+	Before             string `json:"before,omitempty" jsonschema:"Cursor for the previous page. Take this from a previous response. Mutually exclusive with 'after'"`
+}
+
+func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_jobs",
+			Description: "List jobs for a Buildkite build, with optional state filtering and cursor-based pagination. Returns an object with 'items' (the jobs) and 'links' containing 'next'/'self' URLs; pass the cursor from 'links.next' back as 'after' to fetch the next page",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Jobs",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args ListJobsArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListJobs")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("state", args.State),
+				attribute.Int("per_page", args.PerPage),
+			)
+
+			if args.After != "" && args.Before != "" {
+				return utils.NewToolResultError("'after' and 'before' are mutually exclusive; provide at most one"), nil, nil
+			}
+
+			options := &buildkite.JobsListOptions{
+				IncludeRetriedJobs: args.IncludeRetriedJobs,
+				PerPage:            args.PerPage,
+				After:              args.After,
+				Before:             args.Before,
+			}
+
+			if args.State != "" {
+				states := strings.Split(args.State, ",")
+				jobStates := make([]string, len(states))
+				for i, state := range states {
+					jobStates[i] = strings.TrimSpace(state)
+				}
+				options.State = jobStates
+			}
+
+			deps := DepsFromContext(ctx)
+			jobs, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, options)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, &jobs)
+		}, []string{"read_builds"}
+}
+
+// GetJobArgs struct for typed parameters
+type GetJobArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	JobID        string `json:"job_id"`
+	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Pipeline slug. Provide together with 'build_number' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
+	BuildNumber  string `json:"build_number,omitempty" jsonschema:"Build number. Provide together with 'pipeline_slug' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
+}
+
+func GetJob() (mcp.Tool, mcp.ToolHandlerFor[GetJobArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "get_job",
+			Description: "Get a single job by its UUID. Provide 'pipeline_slug' and 'build_number' for a build-scoped lookup, or omit both to look the job up by organization and job ID alone",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Job",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args GetJobArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetJob")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.String("job_id", args.JobID),
+			)
+
+			// Require both build-scoping fields together, or neither.
+			if (args.PipelineSlug == "") != (args.BuildNumber == "") {
+				return utils.NewToolResultError("provide both 'pipeline_slug' and 'build_number' for a build-scoped lookup, or omit both"), nil, nil
+			}
+
+			deps := DepsFromContext(ctx)
+			var job buildkite.Job
+			var err error
+			if args.PipelineSlug != "" {
+				job, _, err = deps.JobsClient.GetJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID)
+			} else {
+				job, _, err = deps.JobsClient.GetJobByOrg(ctx, args.OrgSlug, args.JobID)
+			}
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, &job)
+		}, []string{"read_builds"}
 }
 
 // GetJobLogsArgs struct for typed parameters

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -38,6 +38,7 @@ type ListJobsArgs struct {
 	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1\\, max 100\\, default 30)"`
 	After              string `json:"after,omitempty" jsonschema:"Cursor for the next page. Take this from the 'links.next' URL of a previous response. Mutually exclusive with 'before'"`
 	Before             string `json:"before,omitempty" jsonschema:"Cursor for the previous page. Take this from a previous response. Mutually exclusive with 'after'"`
+	IncludeAgent       bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default)\\, only agent.id is included"`
 }
 
 func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
@@ -91,6 +92,14 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				redactUnusedJobFields(&jobs.Items[i])
 			}
 
+			if !args.IncludeAgent && len(jobs.Items) > 0 {
+				for i := range jobs.Items {
+					jobs.Items[i].Agent = buildkite.Agent{
+						ID: jobs.Items[i].Agent.ID,
+					}
+				}
+			}
+
 			return mcpTextResult(span, &jobs)
 		}, []string{"read_builds"}
 }
@@ -101,6 +110,7 @@ type GetJobArgs struct {
 	JobID        string `json:"job_id"`
 	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Pipeline slug. Provide together with 'build_number' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
 	BuildNumber  string `json:"build_number,omitempty" jsonschema:"Build number. Provide together with 'pipeline_slug' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
+	IncludeAgent bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default)\\, only agent.id is included"`
 }
 
 func GetJob() (mcp.Tool, mcp.ToolHandlerFor[GetJobArgs, any], []string) {
@@ -141,6 +151,12 @@ func GetJob() (mcp.Tool, mcp.ToolHandlerFor[GetJobArgs, any], []string) {
 			}
 
 			redactUnusedJobFields(&job)
+
+			if !args.IncludeAgent {
+				job.Agent = buildkite.Agent{
+					ID: job.Agent.ID,
+				}
+			}
 
 			return mcpTextResult(span, &job)
 		}, []string{"read_builds"}

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -14,9 +14,33 @@ import (
 
 // MockJobsClient for testing job functionality
 type MockJobsClient struct {
+	ListByBuildFunc                func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error)
+	GetJobFunc                     func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error)
+	GetJobByOrgFunc                func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error)
 	UnblockJobFunc                 func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *buildkite.JobUnblockOptions) (buildkite.Job, *buildkite.Response, error)
 	RetryJobFunc                   func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error)
 	GetJobEnvironmentVariablesFunc func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.JobEnvs, *buildkite.Response, error)
+}
+
+func (m *MockJobsClient) ListByBuild(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+	if m.ListByBuildFunc != nil {
+		return m.ListByBuildFunc(ctx, org, pipeline, buildNumber, opt)
+	}
+	return buildkite.JobsList{}, &buildkite.Response{}, nil
+}
+
+func (m *MockJobsClient) GetJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+	if m.GetJobFunc != nil {
+		return m.GetJobFunc(ctx, org, pipeline, buildNumber, jobID)
+	}
+	return buildkite.Job{}, &buildkite.Response{}, nil
+}
+
+func (m *MockJobsClient) GetJobByOrg(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+	if m.GetJobByOrgFunc != nil {
+		return m.GetJobByOrgFunc(ctx, org, jobID)
+	}
+	return buildkite.Job{}, &buildkite.Response{}, nil
 }
 
 func (m *MockJobsClient) UnblockJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *buildkite.JobUnblockOptions) (buildkite.Job, *buildkite.Response, error) {
@@ -272,5 +296,155 @@ func TestGetJobEnvironmentVariables(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Contains(t, result.Content[0].(*mcp.TextContent).Text, "access denied")
+	})
+}
+
+func TestListJobs(t *testing.T) {
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, handler, scopes := ListJobs()
+		assert.Equal(t, "list_jobs", tool.Name)
+		assert.Contains(t, tool.Description, "List jobs")
+		assert.True(t, tool.Annotations.ReadOnlyHint)
+		assert.Equal(t, []string{"read_builds"}, scopes)
+		assert.NotNil(t, handler)
+	})
+
+	t.Run("SuccessfulListWithFiltersAndPagination", func(t *testing.T) {
+		var captured *buildkite.JobsListOptions
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				captured = opt
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "test-pipeline", pipeline)
+				assert.Equal(t, "123", buildNumber)
+				return buildkite.JobsList{
+					Items: []buildkite.Job{{ID: "job-1", State: "passed"}},
+					Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/v2/...?after=cursor2"},
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug:            "test-org",
+			PipelineSlug:       "test-pipeline",
+			BuildNumber:        "123",
+			State:              "passed, failed",
+			IncludeRetriedJobs: boolPtr(false),
+			PerPage:            50,
+			After:              "cursor1",
+		})
+		require.NoError(t, err)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(t, text, `"items":[`)
+		assert.Contains(t, text, `"id":"job-1"`)
+		assert.Contains(t, text, `"next":"https://api.buildkite.com`)
+
+		require.NotNil(t, captured)
+		assert.Equal(t, []string{"passed", "failed"}, captured.State)
+		require.NotNil(t, captured.IncludeRetriedJobs)
+		assert.False(t, *captured.IncludeRetriedJobs)
+		assert.Equal(t, 50, captured.PerPage)
+		assert.Equal(t, "cursor1", captured.After)
+	})
+
+	t.Run("AfterAndBeforeMutuallyExclusive", func(t *testing.T) {
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: &MockJobsClient{}})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug:      "test-org",
+			PipelineSlug: "test-pipeline",
+			BuildNumber:  "123",
+			After:        "a",
+			Before:       "b",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, getTextResult(t, result).Text, "mutually exclusive")
+	})
+}
+
+func TestGetJob(t *testing.T) {
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, handler, scopes := GetJob()
+		assert.Equal(t, "get_job", tool.Name)
+		assert.Contains(t, tool.Description, "Get a single job")
+		assert.True(t, tool.Annotations.ReadOnlyHint)
+		assert.Equal(t, []string{"read_builds"}, scopes)
+		assert.NotNil(t, handler)
+	})
+
+	t.Run("BuildScopedLookup", func(t *testing.T) {
+		called := false
+		mockJobs := &MockJobsClient{
+			GetJobFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				called = true
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "test-pipeline", pipeline)
+				assert.Equal(t, "123", buildNumber)
+				assert.Equal(t, "job-456", jobID)
+				return buildkite.Job{ID: jobID, State: "passed"}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+			GetJobByOrgFunc: func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				t.Fatal("GetJobByOrg should not be called for a build-scoped lookup")
+				return buildkite.Job{}, nil, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug:      "test-org",
+			PipelineSlug: "test-pipeline",
+			BuildNumber:  "123",
+			JobID:        "job-456",
+		})
+		require.NoError(t, err)
+		assert.True(t, called)
+		assert.Contains(t, getTextResult(t, result).Text, `"id":"job-456"`)
+	})
+
+	t.Run("OrgScopedLookup", func(t *testing.T) {
+		called := false
+		mockJobs := &MockJobsClient{
+			GetJobByOrgFunc: func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				called = true
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "job-456", jobID)
+				return buildkite.Job{ID: jobID, State: "running"}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+			GetJobFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				t.Fatal("GetJob should not be called for an org-scoped lookup")
+				return buildkite.Job{}, nil, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug: "test-org",
+			JobID:   "job-456",
+		})
+		require.NoError(t, err)
+		assert.True(t, called)
+		assert.Contains(t, getTextResult(t, result).Text, `"state":"running"`)
+	})
+
+	t.Run("PartialBuildScopeIsRejected", func(t *testing.T) {
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: &MockJobsClient{}})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug:      "test-org",
+			JobID:        "job-456",
+			PipelineSlug: "test-pipeline", // build_number missing
+		})
+		require.NoError(t, err)
+		assert.Contains(t, getTextResult(t, result).Text, "provide both")
 	})
 }

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -351,6 +352,47 @@ func TestListJobs(t *testing.T) {
 		assert.Equal(t, "cursor1", captured.After)
 	})
 
+	t.Run("RedactsUnusedJobFields", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{
+					Items: []buildkite.Job{{
+						ID:           "job-1",
+						State:        "passed",
+						WebURL:       "https://buildkite.com/test-org/test-pipeline/builds/123#job-1",
+						RawLogsURL:   "https://api.buildkite.com/v2/logs/raw",
+						ArtifactsURL: "https://api.buildkite.com/v2/artifacts",
+						LogsURL:      "https://api.buildkite.com/v2/logs",
+						GraphQLID:    "graphql-job-id",
+					}},
+					Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/v2/...?after=cursor2"},
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug:      "test-org",
+			PipelineSlug: "test-pipeline",
+			BuildNumber:  "123",
+		})
+		require.NoError(t, err)
+
+		var jobs buildkite.JobsList
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
+		require.Len(t, jobs.Items, 1)
+		assert.Equal(t, "job-1", jobs.Items[0].ID)
+		assert.Equal(t, "passed", jobs.Items[0].State)
+		assert.Equal(t, "https://api.buildkite.com/v2/...?after=cursor2", string(jobs.Links.Next))
+		assert.Empty(t, jobs.Items[0].WebURL)
+		assert.Empty(t, jobs.Items[0].RawLogsURL)
+		assert.Empty(t, jobs.Items[0].ArtifactsURL)
+		assert.Empty(t, jobs.Items[0].LogsURL)
+		assert.Empty(t, jobs.Items[0].GraphQLID)
+	})
+
 	t.Run("AfterAndBeforeMutuallyExclusive", func(t *testing.T) {
 		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: &MockJobsClient{}})
 		_, handler, _ := ListJobs()
@@ -406,6 +448,43 @@ func TestGetJob(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, called)
 		assert.Contains(t, getTextResult(t, result).Text, `"id":"job-456"`)
+	})
+
+	t.Run("RedactsUnusedJobFields", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			GetJobByOrgFunc: func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				assert.Equal(t, "test-org", org)
+				assert.Equal(t, "job-456", jobID)
+				return buildkite.Job{
+					ID:           jobID,
+					State:        "running",
+					WebURL:       "https://buildkite.com/test-org/test-pipeline/builds/123#job-456",
+					RawLogsURL:   "https://api.buildkite.com/v2/logs/raw",
+					ArtifactsURL: "https://api.buildkite.com/v2/artifacts",
+					LogsURL:      "https://api.buildkite.com/v2/logs",
+					GraphQLID:    "graphql-job-id",
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug: "test-org",
+			JobID:   "job-456",
+		})
+		require.NoError(t, err)
+
+		var job buildkite.Job
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &job))
+		assert.Equal(t, "job-456", job.ID)
+		assert.Equal(t, "running", job.State)
+		assert.Empty(t, job.WebURL)
+		assert.Empty(t, job.RawLogsURL)
+		assert.Empty(t, job.ArtifactsURL)
+		assert.Empty(t, job.LogsURL)
+		assert.Empty(t, job.GraphQLID)
 	})
 
 	t.Run("OrgScopedLookup", func(t *testing.T) {

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -67,6 +67,15 @@ func (m *MockJobsClient) GetJobEnvironmentVariables(ctx context.Context, org str
 
 var _ JobsClient = (*MockJobsClient)(nil)
 
+func testJobAgent() buildkite.Agent {
+	return buildkite.Agent{
+		ID:       "agent-1",
+		Name:     "agent-name",
+		Hostname: "agent-host",
+		Version:  "3.99.0",
+	}
+}
+
 func TestUnblockJob(t *testing.T) {
 	// Test tool definition
 	t.Run("ToolDefinition", func(t *testing.T) {
@@ -393,6 +402,68 @@ func TestListJobs(t *testing.T) {
 		assert.Empty(t, jobs.Items[0].GraphQLID)
 	})
 
+	t.Run("DefaultsToAgentIDOnly", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{
+					Items: []buildkite.Job{{
+						ID:    "job-1",
+						State: "passed",
+						Agent: testJobAgent(),
+					}},
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug:      "test-org",
+			PipelineSlug: "test-pipeline",
+			BuildNumber:  "123",
+		})
+		require.NoError(t, err)
+
+		var jobs buildkite.JobsList
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
+		require.Len(t, jobs.Items, 1)
+		assert.Equal(t, "agent-1", jobs.Items[0].Agent.ID)
+		assert.Empty(t, jobs.Items[0].Agent.Name)
+		assert.Empty(t, jobs.Items[0].Agent.Hostname)
+		assert.Empty(t, jobs.Items[0].Agent.Version)
+	})
+
+	t.Run("IncludesAgentDetailsWhenRequested", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{
+					Items: []buildkite.Job{{
+						ID:    "job-1",
+						State: "passed",
+						Agent: testJobAgent(),
+					}},
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug:      "test-org",
+			PipelineSlug: "test-pipeline",
+			BuildNumber:  "123",
+			IncludeAgent: true,
+		})
+		require.NoError(t, err)
+
+		var jobs buildkite.JobsList
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
+		require.Len(t, jobs.Items, 1)
+		assert.Equal(t, testJobAgent(), jobs.Items[0].Agent)
+	})
+
 	t.Run("AfterAndBeforeMutuallyExclusive", func(t *testing.T) {
 		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: &MockJobsClient{}})
 		_, handler, _ := ListJobs()
@@ -485,6 +556,60 @@ func TestGetJob(t *testing.T) {
 		assert.Empty(t, job.ArtifactsURL)
 		assert.Empty(t, job.LogsURL)
 		assert.Empty(t, job.GraphQLID)
+	})
+
+	t.Run("DefaultsToAgentIDOnly", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			GetJobByOrgFunc: func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				return buildkite.Job{
+					ID:    jobID,
+					State: "running",
+					Agent: testJobAgent(),
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug: "test-org",
+			JobID:   "job-456",
+		})
+		require.NoError(t, err)
+
+		var job buildkite.Job
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &job))
+		assert.Equal(t, "agent-1", job.Agent.ID)
+		assert.Empty(t, job.Agent.Name)
+		assert.Empty(t, job.Agent.Hostname)
+		assert.Empty(t, job.Agent.Version)
+	})
+
+	t.Run("IncludesAgentDetailsWhenRequested", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			GetJobByOrgFunc: func(ctx context.Context, org string, jobID string) (buildkite.Job, *buildkite.Response, error) {
+				return buildkite.Job{
+					ID:    jobID,
+					State: "running",
+					Agent: testJobAgent(),
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := GetJob()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetJobArgs{
+			OrgSlug:      "test-org",
+			JobID:        "job-456",
+			IncludeAgent: true,
+		})
+		require.NoError(t, err)
+
+		var job buildkite.Job
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &job))
+		assert.Equal(t, testJobAgent(), job.Agent)
 	})
 
 	t.Run("OrgScopedLookup", func(t *testing.T) {

--- a/pkg/buildkite/resources/debug-logs-guide.md
+++ b/pkg/buildkite/resources/debug-logs-guide.md
@@ -75,14 +75,14 @@ Always set `limit` — logs can be very large.
 ## Debugging Workflow
 
 ### Step 0: Identify the Failing Job
-Before pulling any logs, call `get_build` with `job_state=failed,broken` to narrow down which jobs need attention:
+Before pulling any logs, call `list_jobs` with `state=failed,broken` to narrow down which jobs need attention:
 
 ```json
 {
   "org_slug": "<ORG>",
   "pipeline_slug": "<PIPELINE>",
   "build_number": "<BUILD>",
-  "job_state": "failed,broken"
+  "state": "failed,broken"
 }
 ```
 
@@ -162,7 +162,7 @@ Log entries are returned as JSON objects:
 
 ```
 // 1. Identify failed or broken jobs first
-get_build: org_slug=<ORG> pipeline_slug=<PIPELINE> build_number=<BUILD> job_state="failed,broken"
+list_jobs: org_slug=<ORG> pipeline_slug=<PIPELINE> build_number=<BUILD> state="failed,broken"
 
 // 2. Use the id from a failed job as job_id, then check recent output
 tail_logs: org_slug=<ORG> pipeline_slug=<PIPELINE> build_number=<BUILD> job_id=<FAILED_JOB_ID> tail=50

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -38,12 +38,11 @@ func TestListBuildsArgsSchema(t *testing.T) {
 	require.Contains(t, s.Properties, "pipeline_slug")
 	require.Contains(t, s.Properties, "branch")
 	require.Contains(t, s.Properties, "state")
-	require.Contains(t, s.Properties, "detail_level")
 	require.Contains(t, s.Properties, "page")
 	require.Contains(t, s.Properties, "per_page")
 
 	// Optional fields must NOT be in required
-	for _, opt := range []string{"pipeline_slug", "branch", "state", "commit", "creator", "detail_level", "page", "per_page"} {
+	for _, opt := range []string{"pipeline_slug", "branch", "state", "commit", "creator", "page", "per_page"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
 

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -342,6 +342,8 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.CreateBuild),
 				newToolDef(buildkite.CancelBuild),
 				newToolDef(buildkite.RebuildBuild),
+				newToolDef(buildkite.ListJobs),
+				newToolDef(buildkite.GetJob),
 				newToolDef(buildkite.UnblockJob),
 				newToolDef(buildkite.RetryJob),
 				newToolDef(buildkite.GetJobEnvironmentVariables),


### PR DESCRIPTION
Adds dedicated job tools and reworks the build tools so jobs are fetched through them rather than embedded in build responses.

- New `list_jobs` tool, lists jobs for a build with optional state filtering and cursor-based pagination (after/before), returning items + links.
- New `get_job` tool, fetches a single job, either build-scoped (pipeline_slug + build_number) or by org + job ID alone.
- `get_build` / `list_builds` are now build-only, they no longer return jobs. get_build returns the whole build (jobs excluded); list_builds returns paginated build summaries. Removed the detail_level, job_state, and include_agent parameters and the job-embedding types (BuildDetail/JobSummary/JobEntry).
- Updated the debug-logs guide to use `list_jobs` for identifying failed jobs.

## Breaking changes

`get_build` and `list_builds` no longer return job data and no longer accept `detail_level`, `job_state`, or `include_agent`. Use `list_jobs`/`get_job` instead.