### PR TITLE
feat: return smart artifact downloads

### DIFF
--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -102,10 +102,11 @@ func run(ctx context.Context, cmd *kong.Context) error {
 		log.Info().Str("path", cli.Replay).Msg("Replaying API calls from HAR file")
 	}
 
+	httpClient := trace.NewHTTPClientWithHeadersAndTransport(headers, innerTransport)
 	client, err := gobuildkite.NewOpts(
 		gobuildkite.WithTokenAuth(apiToken),
 		gobuildkite.WithUserAgent(commands.UserAgent(version)),
-		gobuildkite.WithHTTPClient(trace.NewHTTPClientWithHeadersAndTransport(headers, innerTransport)),
+		gobuildkite.WithHTTPClient(httpClient),
 		gobuildkite.WithBaseURL(cli.BaseURL),
 	)
 	if err != nil {
@@ -135,7 +136,7 @@ func run(ctx context.Context, cmd *kong.Context) error {
 		log.Ctx(ctx).Debug().Str("org", result.Org).Str("pipeline", result.Pipeline).Str("build", result.Build).Str("job", result.Job).Dur("time_taken", result.Duration).Msg("Stored logs to blob storage")
 	})
 
-	return cmd.Run(&commands.Globals{Version: version, Client: client, BuildkiteLogsClient: buildkiteLogsClient})
+	return cmd.Run(&commands.Globals{Version: version, Client: client, HTTPClient: httpClient, BuildkiteLogsClient: buildkiteLogsClient})
 }
 
 func setupLogger(debug bool) zerolog.Logger {

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os/exec"
 	"runtime"
 
@@ -13,6 +14,7 @@ import (
 
 type Globals struct {
 	Client              *gobuildkite.Client
+	HTTPClient          *http.Client
 	BuildkiteLogsClient *buildkitelogs.Client
 	Version             string
 }

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -33,7 +33,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 		ClustersClient:          globals.Client.Clusters,
 		ClusterQueuesClient:     globals.Client.ClusterQueues,
 		AgentsClient:            globals.Client.Agents,
-		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client},
+		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client, HTTPClient: globals.HTTPClient},
 		AnnotationsClient:       globals.Client.Annotations,
 		OrganizationsClient:     globals.Client.Organizations,
 		UserClient:              globals.Client.User,

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -27,7 +27,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 		ClustersClient:          globals.Client.Clusters,
 		ClusterQueuesClient:     globals.Client.ClusterQueues,
 		AgentsClient:            globals.Client.Agents,
-		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client},
+		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client, HTTPClient: globals.HTTPClient},
 		AnnotationsClient:       globals.Client.Annotations,
 		OrganizationsClient:     globals.Client.Organizations,
 		UserClient:              globals.Client.User,

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -21,6 +21,31 @@ import (
 
 const textArtifactInlineLimit int64 = 65536 // 64 KiB
 
+// inlineLimitWriter buffers up to limit bytes of artifact content and discards
+// the remainder, recording whether the source exceeded the limit. It bounds the
+// memory used when inlining an artifact whose reported size under-reports the
+// actual content. Write always reports success so the underlying download is
+// drained to completion.
+type inlineLimitWriter struct {
+	buf      bytes.Buffer
+	limit    int64
+	overflow bool
+}
+
+func (w *inlineLimitWriter) Write(p []byte) (int, error) {
+	if remaining := w.limit - int64(w.buf.Len()); remaining > 0 {
+		if int64(len(p)) > remaining {
+			w.buf.Write(p[:remaining])
+			w.overflow = true
+		} else {
+			w.buf.Write(p)
+		}
+	} else if len(p) > 0 {
+		w.overflow = true
+	}
+	return len(p), nil
+}
+
 type ArtifactsClient interface {
 	ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
 	ListByJob(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
@@ -316,35 +341,34 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 
 			downloadURL, downloadURLAuth, expiresInSeconds := artifactDownloadURL(ctx, deps.ArtifactsClient, args, artifact)
 
+			// A reported size of zero is an empty file, which is cheap and safe to
+			// inline. The download below is capped regardless, so an artifact whose
+			// reported size under-reports its real content cannot exhaust memory.
 			isInlineText := isTextMIMEType(artifact.MimeType) &&
-				artifact.FileSize > 0 &&
 				artifact.FileSize <= textArtifactInlineLimit
 
 			if isInlineText {
-				var buffer bytes.Buffer
-				_, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, &buffer)
+				writer := &inlineLimitWriter{limit: textArtifactInlineLimit}
+				_, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, writer)
 				if err != nil {
 					return handleBuildkiteError(err)
 				}
-				if !utf8.Valid(buffer.Bytes()) {
-					result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
-					result["note"] = "Artifact content was not returned inline because it was not valid UTF-8. Use download_url to fetch it directly."
-					if downloadURL == "" {
-						result["note"] = "Artifact content was not returned inline because it was not valid UTF-8, and no download URL was available."
-					}
+
+				switch {
+				case writer.overflow:
+					result := urlArtifactResult(" because it was larger than expected", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
+					return mcpTextResult(span, &result)
+				case !utf8.Valid(writer.buf.Bytes()):
+					result := urlArtifactResult(" because it was not valid UTF-8", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
 					return mcpTextResult(span, &result)
 				}
 
 				result := artifactResult("text", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
-				result["content"] = buffer.String()
+				result["content"] = writer.buf.String()
 				return mcpTextResult(span, &result)
 			}
 
-			result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
-			result["note"] = "Artifact content was not returned inline. Use download_url to fetch it directly."
-			if downloadURL == "" {
-				result["note"] = "Artifact content was not returned inline, and no download URL was available."
-			}
+			result := urlArtifactResult("", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
 			return mcpTextResult(span, &result)
 		}, []string{"read_artifacts"}
 }
@@ -377,6 +401,19 @@ func downloadURLExpiresInSeconds(downloadURL string) int {
 	}
 
 	return seconds
+}
+
+// urlArtifactResult builds a non-inline result that points the caller at the
+// download URL. reason is appended after "not returned inline" to explain why
+// (e.g. " because it was larger than expected"); pass "" for no specific reason.
+func urlArtifactResult(reason string, artifact buildkite.Artifact, downloadURL, downloadURLAuth string, expiresInSeconds int) map[string]any {
+	result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
+	if downloadURL == "" {
+		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s, and no download URL was available.", reason)
+	} else {
+		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s. Use download_url to fetch it directly.", reason)
+	}
+	return result
 }
 
 func artifactResult(encoding string, artifact buildkite.Artifact, downloadURL, downloadURLAuth string, expiresInSeconds int) map[string]any {

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -3,23 +3,29 @@ package buildkite
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
-	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const textArtifactInlineLimit int64 = 65536 // 64 KiB
+
 type ArtifactsClient interface {
 	ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
 	ListByJob(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
+	GetByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error)
 	DownloadArtifact(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error)
+	ResolveDownloadURL(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error)
 }
 
 // BuildkiteClientAdapter adapts the buildkite.Client to work with our interfaces
@@ -37,12 +43,71 @@ func (a *BuildkiteClientAdapter) ListByJob(ctx context.Context, org, pipelineSlu
 	return a.Artifacts.ListByJob(ctx, org, pipelineSlug, buildNumber, jobID, opts)
 }
 
+// GetByJob implements ArtifactsClient. The request path is built locally so
+// artifact identifiers are path-escaped consistently with downloads.
+func (a *BuildkiteClientAdapter) GetByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+	req, err := a.NewRequest(ctx, http.MethodGet, artifactMetadataPath(org, pipelineSlug, buildNumber, jobID, artifactID), nil)
+	if err != nil {
+		return buildkite.Artifact{}, nil, err
+	}
+
+	var artifact buildkite.Artifact
+	resp, err := a.Do(req, &artifact)
+	if err != nil {
+		return buildkite.Artifact{}, resp, err
+	}
+
+	return artifact, resp, nil
+}
+
 // DownloadArtifact implements ArtifactsClient. The artifact endpoint is built
 // from the supplied identifiers and resolved relative to the client's configured
 // BaseURL, so proxied installations (with a base-path prefix) are handled by the
 // client and the caller never supplies a raw URL.
 func (a *BuildkiteClientAdapter) DownloadArtifact(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
 	return a.Artifacts.DownloadArtifactByURL(ctx, artifactDownloadPath(org, pipelineSlug, buildNumber, jobID, artifactID), writer)
+}
+
+// ResolveDownloadURL resolves Buildkite's authenticated artifact download
+// endpoint to the short-lived redirected URL without following the redirect.
+func (a *BuildkiteClientAdapter) ResolveDownloadURL(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+	req, err := a.NewRequest(ctx, http.MethodGet, artifactDownloadPath(org, pipelineSlug, buildNumber, jobID, artifactID), nil)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusMultipleChoices || resp.StatusCode >= http.StatusBadRequest {
+		return "", fmt.Errorf("expected artifact download redirect, got status %d", resp.StatusCode)
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", errors.New("artifact download redirect did not include Location header")
+	}
+
+	return location, nil
+}
+
+func artifactMetadataPath(org, pipelineSlug, buildNumber, jobID, artifactID string) string {
+	return fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts/%s",
+		url.PathEscape(org),
+		url.PathEscape(pipelineSlug),
+		url.PathEscape(buildNumber),
+		url.PathEscape(jobID),
+		url.PathEscape(artifactID),
+	)
 }
 
 // artifactDownloadPath builds the relative Buildkite REST path for an artifact
@@ -57,6 +122,41 @@ func artifactDownloadPath(org, pipelineSlug, buildNumber, jobID, artifactID stri
 		url.PathEscape(jobID),
 		url.PathEscape(artifactID),
 	)
+}
+
+func isTextMIMEType(mimeType string) bool {
+	if i := strings.IndexByte(mimeType, ';'); i >= 0 {
+		mimeType = mimeType[:i]
+	}
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+
+	if mimeType == "text/html" ||
+		mimeType == "text/xml" ||
+		mimeType == "application/xml" ||
+		mimeType == "application/xhtml+xml" ||
+		strings.HasSuffix(mimeType, "+xml") {
+		return false
+	}
+
+	if strings.HasPrefix(mimeType, "text/") {
+		return true
+	}
+	if strings.HasSuffix(mimeType, "+json") {
+		return true
+	}
+
+	switch mimeType {
+	case "application/json",
+		"application/yaml",
+		"application/x-yaml",
+		"application/javascript",
+		"application/x-javascript",
+		"application/x-sh",
+		"application/x-ndjson":
+		return true
+	default:
+		return false
+	}
 }
 
 type ListArtifactsForBuildArgs struct {
@@ -181,7 +281,7 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
-			Description: "Download a specific artifact's content, identified by its organization, pipeline, build, job, and artifact identifiers. The content is returned base64-encoded",
+			Description: "Get a specific artifact by organization, pipeline, build, job, and artifact identifiers. Small text artifacts are returned inline; large or binary artifacts return metadata plus a download URL",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Artifact",
 				ReadOnlyHint: true,
@@ -199,22 +299,87 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 				attribute.String("artifact_id", args.ArtifactID),
 			)
 
-			// Use a buffer to capture the artifact data instead of writing directly to stdout
-			var buffer bytes.Buffer
 			deps := DepsFromContext(ctx)
-			resp, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, &buffer)
+			artifact, _, err := deps.ArtifactsClient.GetByJob(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID)
 			if err != nil {
-				return utils.NewToolResultError(fmt.Sprintf("response failed with error %s", err.Error())), nil, nil
+				return handleBuildkiteError(err)
 			}
 
-			// Create a response with the artifact data encoded safely for JSON
-			result := map[string]any{
-				"status":     resp.Status,
-				"statusCode": resp.StatusCode,
-				"data":       base64.StdEncoding.EncodeToString(buffer.Bytes()),
-				"encoding":   "base64",
+			span.SetAttributes(
+				attribute.String("mime_type", artifact.MimeType),
+				attribute.Int64("file_size", artifact.FileSize),
+			)
+
+			downloadURL, downloadURLAuth, expiresInSeconds := artifactDownloadURL(ctx, deps.ArtifactsClient, args, artifact)
+
+			isInlineText := isTextMIMEType(artifact.MimeType) &&
+				artifact.FileSize > 0 &&
+				artifact.FileSize <= textArtifactInlineLimit
+
+			if isInlineText {
+				var buffer bytes.Buffer
+				_, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, &buffer)
+				if err != nil {
+					return handleBuildkiteError(err)
+				}
+
+				result := artifactResult("text", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
+				result["content"] = buffer.String()
+				return mcpTextResult(span, &result)
 			}
 
+			result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
+			result["note"] = "Artifact content was not returned inline. Use download_url to fetch it directly."
+			if downloadURL == "" {
+				result["note"] = "Artifact content was not returned inline, and no download URL was available."
+			}
 			return mcpTextResult(span, &result)
 		}, []string{"read_artifacts"}
+}
+
+func artifactDownloadURL(ctx context.Context, client ArtifactsClient, args GetArtifactArgs, artifact buildkite.Artifact) (string, string, int) {
+	downloadURL, err := client.ResolveDownloadURL(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID)
+	if err == nil && downloadURL != "" {
+		return downloadURL, "none", downloadURLExpiresInSeconds(downloadURL)
+	}
+	if artifact.DownloadURL != "" {
+		return artifact.DownloadURL, "requires Buildkite API authentication", 0
+	}
+	return "", "", 0
+}
+
+func downloadURLExpiresInSeconds(downloadURL string) int {
+	u, err := url.Parse(downloadURL)
+	if err != nil {
+		return 60
+	}
+
+	expires := u.Query().Get("X-Amz-Expires")
+	if expires == "" {
+		return 60
+	}
+
+	seconds, err := strconv.Atoi(expires)
+	if err != nil || seconds <= 0 {
+		return 60
+	}
+
+	return seconds
+}
+
+func artifactResult(encoding string, artifact buildkite.Artifact, downloadURL, downloadURLAuth string, expiresInSeconds int) map[string]any {
+	result := map[string]any{
+		"encoding":  encoding,
+		"mime_type": artifact.MimeType,
+		"file_size": artifact.FileSize,
+		"filename":  artifact.Filename,
+	}
+	if downloadURL != "" {
+		result["download_url"] = downloadURL
+	}
+	if downloadURLAuth != "" {
+		result["download_url_auth"] = downloadURLAuth
+		result["download_url_expires_in_seconds"] = expiresInSeconds
+	}
+	return result
 }

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/tokens"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
@@ -31,6 +32,7 @@ type ArtifactsClient interface {
 // BuildkiteClientAdapter adapts the buildkite.Client to work with our interfaces
 type BuildkiteClientAdapter struct {
 	*buildkite.Client
+	HTTPClient *http.Client
 }
 
 // ListByBuild implements ArtifactsClient
@@ -76,10 +78,12 @@ func (a *BuildkiteClientAdapter) ResolveDownloadURL(ctx context.Context, org, pi
 		return "", err
 	}
 
-	client := &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	client := http.Client{}
+	if a.HTTPClient != nil {
+		client = *a.HTTPClient
+	}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
 	}
 
 	resp, err := client.Do(req)
@@ -321,6 +325,14 @@ func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string
 				_, err := deps.ArtifactsClient.DownloadArtifact(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, args.JobID, args.ArtifactID, &buffer)
 				if err != nil {
 					return handleBuildkiteError(err)
+				}
+				if !utf8.Valid(buffer.Bytes()) {
+					result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
+					result["note"] = "Artifact content was not returned inline because it was not valid UTF-8. Use download_url to fetch it directly."
+					if downloadURL == "" {
+						result["note"] = "Artifact content was not returned inline because it was not valid UTF-8, and no download URL was available."
+					}
+					return mcpTextResult(span, &result)
 				}
 
 				result := artifactResult("text", artifact, downloadURL, downloadURLAuth, expiresInSeconds)

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -425,23 +425,24 @@ func TestGetArtifact_BinaryReturnsURL(t *testing.T) {
 	assert.NotContains(got, "content")
 }
 
-func TestGetArtifact_UnknownSizeTextReturnsURL(t *testing.T) {
+func TestGetArtifact_EmptyTextInline(t *testing.T) {
 	assert := require.New(t)
 
 	downloadCalled := false
 	client := &MockArtifactsClient{
 		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
 			return buildkite.Artifact{
-				Filename: "artifact.txt",
+				Filename: "empty.txt",
 				MimeType: "text/plain",
 				FileSize: 0,
 			}, nil, nil
 		},
 		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
-			return "https://example.com/artifact.txt", nil
+			return "https://example.com/empty.txt", nil
 		},
 		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
 			downloadCalled = true
+			// Empty file: nothing is written to the buffer.
 			return nil, nil
 		},
 	}
@@ -457,11 +458,53 @@ func TestGetArtifact_UnknownSizeTextReturnsURL(t *testing.T) {
 		ArtifactID:   "def",
 	})
 	assert.NoError(err)
-	assert.False(downloadCalled)
+	assert.True(downloadCalled)
+
+	got := getJSONResult(t, result)
+	assert.Equal("text", got["encoding"])
+	assert.Empty(got["content"])
+	assert.Equal("https://example.com/empty.txt", got["download_url"])
+}
+
+func TestGetArtifact_OversizedTextReturnsURL(t *testing.T) {
+	assert := require.New(t)
+
+	downloadCalled := false
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "liar.txt",
+				MimeType: "text/plain",
+				FileSize: 10, // metadata under-reports the real content
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/liar.txt", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			downloadCalled = true
+			_, err := writer.Write(bytes.Repeat([]byte("a"), int(textArtifactInlineLimit)+1))
+			return nil, err
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+	assert.True(downloadCalled)
 
 	got := getJSONResult(t, result)
 	assert.Equal("url", got["encoding"])
-	assert.Equal("https://example.com/artifact.txt", got["download_url"])
+	assert.Equal("https://example.com/liar.txt", got["download_url"])
+	assert.Contains(got["note"], "larger than expected")
 	assert.NotContains(got, "content")
 }
 
@@ -617,6 +660,34 @@ func TestDownloadURLExpiresInSeconds(t *testing.T) {
 			require.Equal(t, tt.want, downloadURLExpiresInSeconds(tt.downloadURL))
 		})
 	}
+}
+
+func TestInlineLimitWriter(t *testing.T) {
+	assert := require.New(t)
+
+	// Writing exactly the limit buffers everything without flagging overflow.
+	w := &inlineLimitWriter{limit: 4}
+	n, err := w.Write([]byte("abcd"))
+	assert.NoError(err)
+	assert.Equal(4, n)
+	assert.False(w.overflow)
+	assert.Equal("abcd", w.buf.String())
+
+	// A further write past the limit is discarded but still reports success so
+	// the underlying download drains to completion.
+	n, err = w.Write([]byte("e"))
+	assert.NoError(err)
+	assert.Equal(1, n)
+	assert.True(w.overflow)
+	assert.Equal("abcd", w.buf.String())
+
+	// A single oversized write is truncated to the limit.
+	w2 := &inlineLimitWriter{limit: 4}
+	n, err = w2.Write([]byte("abcdef"))
+	assert.NoError(err)
+	assert.Equal(6, n)
+	assert.True(w2.overflow)
+	assert.Equal("abcd", w2.buf.String())
 }
 
 func TestArtifactDownloadPath(t *testing.T) {

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -3,19 +3,25 @@ package buildkite
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/go-buildkite/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
 
 type MockArtifactsClient struct {
-	ListByBuildFunc      func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
-	ListByJobFunc        func(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
-	DownloadArtifactFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error)
+	ListByBuildFunc        func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
+	ListByJobFunc          func(ctx context.Context, org, pipelineSlug, buildNumber string, jobID string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error)
+	GetByJobFunc           func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error)
+	DownloadArtifactFunc   func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error)
+	ResolveDownloadURLFunc func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error)
 }
 
 func (m *MockArtifactsClient) ListByBuild(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.ArtifactListOptions) ([]buildkite.Artifact, *buildkite.Response, error) {
@@ -37,6 +43,20 @@ func (m *MockArtifactsClient) DownloadArtifact(ctx context.Context, org, pipelin
 		return m.DownloadArtifactFunc(ctx, org, pipelineSlug, buildNumber, jobID, artifactID, writer)
 	}
 	return nil, nil
+}
+
+func (m *MockArtifactsClient) GetByJob(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+	if m.GetByJobFunc != nil {
+		return m.GetByJobFunc(ctx, org, pipelineSlug, buildNumber, jobID, artifactID)
+	}
+	return buildkite.Artifact{}, nil, nil
+}
+
+func (m *MockArtifactsClient) ResolveDownloadURL(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+	if m.ResolveDownloadURLFunc != nil {
+		return m.ResolveDownloadURLFunc(ctx, org, pipelineSlug, buildNumber, jobID, artifactID)
+	}
+	return "", nil
 }
 
 // Ensure MockArtifactsClient implements ArtifactsClient interface
@@ -125,15 +145,23 @@ func TestListArtifactsForJob(t *testing.T) {
 	assert.Contains(textContent.Text, `"download_url":"https://example.com/artifact"`)
 }
 
-func TestGetArtifact(t *testing.T) {
+func TestGetArtifact_TextInline(t *testing.T) {
 	assert := require.New(t)
 
 	var gotArgs []string
 	client := &MockArtifactsClient{
-		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
 			gotArgs = []string{org, pipelineSlug, buildNumber, jobID, artifactID}
-
-			// Simulate writing artifact content to the provided writer
+			return buildkite.Artifact{
+				Filename: "artifact.txt",
+				MimeType: "text/plain",
+				FileSize: 29,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/resolved-artifact?X-Amz-Expires=600", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
 			_, err := writer.Write([]byte("This is test artifact content"))
 			if err != nil {
 				return nil, err
@@ -165,31 +193,314 @@ func TestGetArtifact(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]string{"myorg", "my-pipeline", "123", "abc", "def"}, gotArgs)
 
-	textContent := getTextResult(t, result)
+	got := getJSONResult(t, result)
+	assert.Equal("text", got["encoding"])
+	assert.Equal("This is test artifact content", got["content"])
+	assert.Equal("text/plain", got["mime_type"])
+	assert.Equal(int64(29), got["file_size"])
+	assert.Equal("artifact.txt", got["filename"])
+	assert.Equal("https://example.com/resolved-artifact?X-Amz-Expires=600", got["download_url"])
+	assert.Equal("none", got["download_url_auth"])
+	assert.Equal(int64(600), got["download_url_expires_in_seconds"])
+}
 
-	// Check the structure of the response
-	assert.Contains(textContent.Text, `"status":"200 OK"`)
-	assert.Contains(textContent.Text, `"statusCode":200`)
-	assert.Contains(textContent.Text, `"encoding":"base64"`)
+func TestGetArtifact_StructuredJSONInline(t *testing.T) {
+	assert := require.New(t)
 
-	// The base64 encoded "This is test artifact content"
-	assert.Contains(textContent.Text, `"data":"VGhpcyBpcyB0ZXN0IGFydGlmYWN0IGNvbnRlbnQ="`)
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "clippy.sarif",
+				MimeType: "application/sarif+json",
+				FileSize: 18,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/clippy.sarif", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			_, err := writer.Write([]byte(`{"version":"2.1.0"}`))
+			return nil, err
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+
+	got := getJSONResult(t, result)
+	assert.Equal("text", got["encoding"])
+	assert.JSONEq(`{"version":"2.1.0"}`, got["content"].(string))
+	assert.Equal("application/sarif+json", got["mime_type"])
+}
+
+func TestGetArtifact_MarkupReturnsURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		filename string
+	}{
+		{name: "xml", mimeType: "text/xml", filename: "junit.xml"},
+		{name: "html", mimeType: "text/html", filename: "report.html"},
+		{name: "structured xml", mimeType: "application/atom+xml", filename: "feed.xml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+
+			downloadCalled := false
+			client := &MockArtifactsClient{
+				GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+					return buildkite.Artifact{
+						Filename: tt.filename,
+						MimeType: tt.mimeType,
+						FileSize: 42,
+					}, nil, nil
+				},
+				ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+					return "https://example.com/artifact", nil
+				},
+				DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+					downloadCalled = true
+					return nil, nil
+				},
+			}
+
+			ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+			_, handler, _ := GetArtifact()
+
+			result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+				OrgSlug:      "myorg",
+				PipelineSlug: "my-pipeline",
+				BuildNumber:  "123",
+				JobID:        "abc",
+				ArtifactID:   "def",
+			})
+			assert.NoError(err)
+			assert.False(downloadCalled)
+
+			got := getJSONResult(t, result)
+			assert.Equal("url", got["encoding"])
+			assert.Equal(tt.mimeType, got["mime_type"])
+			assert.Equal("https://example.com/artifact", got["download_url"])
+			assert.NotContains(got, "content")
+		})
+	}
+}
+
+func TestGetArtifact_TextTooLargeReturnsURL(t *testing.T) {
+	assert := require.New(t)
+
+	downloadCalled := false
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "large.txt",
+				MimeType: "text/plain",
+				FileSize: textArtifactInlineLimit + 1,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/large", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			downloadCalled = true
+			return nil, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+	assert.False(downloadCalled)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.Equal("https://example.com/large", got["download_url"])
+	assert.NotContains(got, "content")
+}
+
+func TestGetArtifact_BinaryReturnsURL(t *testing.T) {
+	assert := require.New(t)
+
+	downloadCalled := false
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "artifact.zip",
+				MimeType: "application/zip",
+				FileSize: 4096,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/artifact.zip", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			downloadCalled = true
+			return nil, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+	assert.False(downloadCalled)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.Equal("application/zip", got["mime_type"])
+	assert.Equal("https://example.com/artifact.zip", got["download_url"])
+	assert.Equal("none", got["download_url_auth"])
+	assert.NotContains(got, "content")
+}
+
+func TestGetArtifact_UnknownSizeTextReturnsURL(t *testing.T) {
+	assert := require.New(t)
+
+	downloadCalled := false
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "artifact.txt",
+				MimeType: "text/plain",
+				FileSize: 0,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/artifact.txt", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			downloadCalled = true
+			return nil, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+	assert.False(downloadCalled)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.Equal("https://example.com/artifact.txt", got["download_url"])
+	assert.NotContains(got, "content")
+}
+
+func TestGetArtifact_ResolveDownloadURLFailureFallsBack(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename:    "artifact.zip",
+				MimeType:    "application/zip",
+				FileSize:    4096,
+				DownloadURL: "https://api.buildkite.com/v2/download",
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "", errors.New("no redirect")
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.Equal("https://api.buildkite.com/v2/download", got["download_url"])
+	assert.Equal("requires Buildkite API authentication", got["download_url_auth"])
+	assert.Equal(int64(0), got["download_url_expires_in_seconds"])
+}
+
+func TestGetArtifact_NoDownloadURLAvailable(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "artifact.zip",
+				MimeType: "application/zip",
+				FileSize: 4096,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "", errors.New("no redirect")
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.NotContains(got, "download_url")
+	assert.Contains(got["note"], "no download URL was available")
 }
 
 func TestGetArtifact_ErrorResponse(t *testing.T) {
 	assert := require.New(t)
 
 	client := &MockArtifactsClient{
-		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
 			resp := &http.Response{
 				Request:    &http.Request{Method: "GET"},
 				StatusCode: 404,
 				Status:     "404 Not Found",
 				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"Artifact not found"}`)),
 			}
-			return &buildkite.Response{
-				Response: resp,
-			}, &buildkite.ErrorResponse{Response: resp, Message: `{"message":"Artifact not found"}`}
+			return buildkite.Artifact{}, &buildkite.Response{Response: resp}, &buildkite.ErrorResponse{Response: resp, Message: `{"message":"Artifact not found"}`}
 		},
 	}
 
@@ -210,6 +521,58 @@ func TestGetArtifact_ErrorResponse(t *testing.T) {
 	assert.Contains(getTextResult(t, result).Text, `{"message":"Artifact not found"}`)
 }
 
+func TestIsTextMIMEType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{name: "text plain", mimeType: "text/plain", want: true},
+		{name: "text csv", mimeType: "text/csv", want: true},
+		{name: "text html", mimeType: "text/html", want: false},
+		{name: "uppercase text", mimeType: "TEXT/PLAIN", want: true},
+		{name: "text with charset", mimeType: "text/plain; charset=utf-8", want: true},
+		{name: "json", mimeType: "application/json", want: true},
+		{name: "sarif json", mimeType: "application/sarif+json", want: true},
+		{name: "text xml", mimeType: "text/xml", want: false},
+		{name: "xml", mimeType: "application/xml", want: false},
+		{name: "atom xml", mimeType: "application/atom+xml", want: false},
+		{name: "xhtml", mimeType: "application/xhtml+xml", want: false},
+		{name: "yaml", mimeType: "application/yaml", want: true},
+		{name: "x yaml", mimeType: "application/x-yaml", want: true},
+		{name: "javascript", mimeType: "application/javascript", want: true},
+		{name: "ndjson", mimeType: "application/x-ndjson", want: true},
+		{name: "image", mimeType: "image/png", want: false},
+		{name: "zip", mimeType: "application/zip", want: false},
+		{name: "empty", mimeType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isTextMIMEType(tt.mimeType))
+		})
+	}
+}
+
+func TestDownloadURLExpiresInSeconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		downloadURL string
+		want        int
+	}{
+		{name: "s3 expires", downloadURL: "https://example.com/artifact?X-Amz-Expires=600", want: 600},
+		{name: "missing expires", downloadURL: "https://example.com/artifact", want: 60},
+		{name: "invalid expires", downloadURL: "https://example.com/artifact?X-Amz-Expires=nope", want: 60},
+		{name: "negative expires", downloadURL: "https://example.com/artifact?X-Amz-Expires=-1", want: 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, downloadURLExpiresInSeconds(tt.downloadURL))
+		})
+	}
+}
+
 func TestArtifactDownloadPath(t *testing.T) {
 	assert := require.New(t)
 
@@ -224,6 +587,64 @@ func TestArtifactDownloadPath(t *testing.T) {
 		"v2/organizations/o/pipelines/p/builds/b/jobs/j/artifacts/a%2F..%2Faccess-token/download",
 		artifactDownloadPath("o", "p", "b", "j", "a/../access-token"),
 	)
+}
+
+func TestArtifactMetadataPath(t *testing.T) {
+	assert := require.New(t)
+
+	assert.Equal(
+		"v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def",
+		artifactMetadataPath("myorg", "my-pipeline", "123", "abc", "def"),
+	)
+
+	assert.Equal(
+		"v2/organizations/o/pipelines/p/builds/b/jobs/j/artifacts/a%2F..%2Faccess-token",
+		artifactMetadataPath("o", "p", "b", "j", "a/../access-token"),
+	)
+}
+
+func TestBuildkiteClientAdapter_GetByJob(t *testing.T) {
+	assert := require.New(t)
+
+	const wantSuffix = "/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def"
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"def","filename":"artifact.txt","mime_type":"text/plain","file_size":12}`))
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		basePath string
+		wantPath string
+	}{
+		{name: "default root base url", basePath: "/", wantPath: wantSuffix},
+		{name: "proxy base url with trailing slash", basePath: "/rest/", wantPath: "/rest" + wantSuffix},
+		{name: "proxy base url without trailing slash", basePath: "/rest", wantPath: "/rest" + wantSuffix},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath = ""
+
+			client, err := buildkite.NewOpts(
+				buildkite.WithTokenAuth("fake-token"),
+				buildkite.WithBaseURL(srv.URL+tt.basePath),
+			)
+			assert.NoError(err)
+
+			adapter := &BuildkiteClientAdapter{Client: client}
+
+			artifact, resp, err := adapter.GetByJob(context.Background(), "myorg", "my-pipeline", "123", "abc", "def")
+			assert.NoError(err)
+			assert.Equal(200, resp.StatusCode)
+			assert.Equal("artifact.txt", artifact.Filename)
+			assert.Equal(tt.wantPath, gotPath)
+		})
+	}
 }
 
 func TestBuildkiteClientAdapter_DownloadArtifact(t *testing.T) {
@@ -286,4 +707,73 @@ func TestBuildkiteClientAdapter_DownloadArtifact(t *testing.T) {
 			assert.Equal(tt.wantPath, gotPath)
 		})
 	}
+}
+
+func TestBuildkiteClientAdapter_ResolveDownloadURL(t *testing.T) {
+	assert := require.New(t)
+
+	const wantSuffix = "/v2/organizations/myorg/pipelines/my-pipeline/builds/123/jobs/abc/artifacts/def/download"
+	const resolvedURL = "https://storage.example.com/artifact"
+
+	var gotPath string
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		http.Redirect(w, r, resolvedURL, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name     string
+		basePath string
+		wantPath string
+	}{
+		{name: "default root base url", basePath: "/", wantPath: wantSuffix},
+		{name: "proxy base url with trailing slash", basePath: "/rest/", wantPath: "/rest" + wantSuffix},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath = ""
+			gotAuth = ""
+
+			client, err := buildkite.NewOpts(
+				buildkite.WithTokenAuth("fake-token"),
+				buildkite.WithBaseURL(srv.URL+tt.basePath),
+			)
+			assert.NoError(err)
+
+			adapter := &BuildkiteClientAdapter{Client: client}
+
+			gotURL, err := adapter.ResolveDownloadURL(context.Background(), "myorg", "my-pipeline", "123", "abc", "def")
+			assert.NoError(err)
+			assert.Equal(resolvedURL, gotURL)
+			assert.Equal(tt.wantPath, gotPath)
+			assert.Equal("Bearer fake-token", gotAuth)
+		})
+	}
+}
+
+func getJSONResult(t *testing.T, result *mcp.CallToolResult) map[string]any {
+	t.Helper()
+
+	text := getTextResult(t, result).Text
+	decoder := json.NewDecoder(strings.NewReader(text))
+	decoder.UseNumber()
+
+	var got map[string]any
+	require.NoError(t, decoder.Decode(&got))
+
+	normalized := make(map[string]any, len(got))
+	for key, value := range got {
+		if n, ok := value.(json.Number); ok {
+			i, err := n.Int64()
+			require.NoError(t, err)
+			normalized[key] = i
+			continue
+		}
+		normalized[key] = value
+	}
+	return normalized
 }

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -62,6 +62,12 @@ func (m *MockArtifactsClient) ResolveDownloadURL(ctx context.Context, org, pipel
 // Ensure MockArtifactsClient implements ArtifactsClient interface
 var _ ArtifactsClient = (*MockArtifactsClient)(nil)
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func TestListArtifactsForBuild(t *testing.T) {
 	assert := require.New(t)
 
@@ -202,6 +208,46 @@ func TestGetArtifact_TextInline(t *testing.T) {
 	assert.Equal("https://example.com/resolved-artifact?X-Amz-Expires=600", got["download_url"])
 	assert.Equal("none", got["download_url_auth"])
 	assert.Equal(int64(600), got["download_url_expires_in_seconds"])
+}
+
+func TestGetArtifact_NonUTF8TextReturnsURL(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockArtifactsClient{
+		GetByJobFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (buildkite.Artifact, *buildkite.Response, error) {
+			return buildkite.Artifact{
+				Filename: "latin1.txt",
+				MimeType: "text/plain; charset=iso-8859-1",
+				FileSize: 4,
+			}, nil, nil
+		},
+		ResolveDownloadURLFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string) (string, error) {
+			return "https://example.com/latin1.txt", nil
+		},
+		DownloadArtifactFunc: func(ctx context.Context, org, pipelineSlug, buildNumber, jobID, artifactID string, writer io.Writer) (*buildkite.Response, error) {
+			_, err := writer.Write([]byte{0xff, 0xfe, 0xfd, '\n'})
+			return nil, err
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ArtifactsClient: client})
+	_, handler, _ := GetArtifact()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetArtifactArgs{
+		OrgSlug:      "myorg",
+		PipelineSlug: "my-pipeline",
+		BuildNumber:  "123",
+		JobID:        "abc",
+		ArtifactID:   "def",
+	})
+	assert.NoError(err)
+
+	got := getJSONResult(t, result)
+	assert.Equal("url", got["encoding"])
+	assert.Equal("text/plain; charset=iso-8859-1", got["mime_type"])
+	assert.Equal("https://example.com/latin1.txt", got["download_url"])
+	assert.Contains(got["note"], "not valid UTF-8")
+	assert.NotContains(got, "content")
 }
 
 func TestGetArtifact_StructuredJSONInline(t *testing.T) {
@@ -753,6 +799,40 @@ func TestBuildkiteClientAdapter_ResolveDownloadURL(t *testing.T) {
 			assert.Equal("Bearer fake-token", gotAuth)
 		})
 	}
+}
+
+func TestBuildkiteClientAdapter_ResolveDownloadURLUsesConfiguredHTTPClient(t *testing.T) {
+	assert := require.New(t)
+
+	const resolvedURL = "https://storage.example.com/artifact"
+
+	var gotInjectedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotInjectedHeader = r.Header.Get("X-Transport-Was-Here")
+		http.Redirect(w, r, resolvedURL, http.StatusFound)
+	}))
+	defer srv.Close()
+
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			req.Header.Set("X-Transport-Was-Here", "yes")
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+	client, err := buildkite.NewOpts(
+		buildkite.WithTokenAuth("fake-token"),
+		buildkite.WithBaseURL(srv.URL+"/"),
+		buildkite.WithHTTPClient(httpClient),
+	)
+	assert.NoError(err)
+
+	adapter := &BuildkiteClientAdapter{Client: client, HTTPClient: httpClient}
+
+	gotURL, err := adapter.ResolveDownloadURL(context.Background(), "myorg", "my-pipeline", "123", "abc", "def")
+	assert.NoError(err)
+	assert.Equal(resolvedURL, gotURL)
+	assert.Equal("yes", gotInjectedHeader)
+	assert.Nil(httpClient.CheckRedirect)
 }
 
 func getJSONResult(t *testing.T, result *mcp.CallToolResult) map[string]any {


### PR DESCRIPTION
Currently, `get_artifact` returned large artifacts as base64 inline, which made the response noisy, expensive, and awkward to turn into files. With the new behavior:

* Small text artifacts still return inline content, which is convenient.
* Larger artifacts return metadata plus a presigned `download_url`.
* The metadata includes size, filename, MIME type, encoding, auth mode, and expiry.
* The result is much easier to use safely from an agent: inspect metadata first, then download only when needed.
* It avoids dumping large XML/base64 blobs into the conversation.
 
Added tests for MIME handling, URL expiry, fallback behavior, path escaping, and adapter requests.