### PR TITLE
fix(artifacts): slim down list_artifacts output

### DIFF
--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -189,43 +189,44 @@ func isTextMIMEType(mimeType string) bool {
 }
 
 // artifactListItem is the projection of an artifact returned by the list tools.
-// It deliberately omits the download_url field present on buildkite.Artifact:
-// that URL is the authenticated API redirect endpoint, which behaves differently
-// from the presigned URL get_artifact returns and consistently misled agents into
-// sending Bearer tokens to the wrong place. Callers identify an artifact by
-// filename/path and fetch it via get_artifact using id and job_id, so the field
-// is redundant here (it is exactly url + "/download").
+// It deliberately omits several fields present on buildkite.Artifact to keep list
+// output small (a big build has hundreds of artifacts):
+//
+//   - download_url: the authenticated API redirect endpoint, which behaves
+//     differently from the presigned URL get_artifact returns and consistently
+//     misled agents into sending Bearer tokens to the wrong place.
+//   - url: the authenticated API resource endpoint (download_url minus
+//     "/download"); derivable and unnecessary, as artifacts are fetched via
+//     get_artifact using id and job_id, not by following a URL.
+//   - dirname: always the directory portion of path.
+//   - glob_path, original_path: upload-time internals that are rarely populated
+//     and not actionable.
+//
+// Callers identify an artifact by filename/path and fetch it via get_artifact
+// using id and job_id.
 type artifactListItem struct {
-	ID           string `json:"id,omitempty"`
-	JobID        string `json:"job_id,omitempty"`
-	URL          string `json:"url,omitempty"`
-	State        string `json:"state,omitempty"`
-	Path         string `json:"path,omitempty"`
-	Dirname      string `json:"dirname,omitempty"`
-	Filename     string `json:"filename,omitempty"`
-	MimeType     string `json:"mime_type,omitempty"`
-	FileSize     int64  `json:"file_size,omitempty"`
-	GlobPath     string `json:"glob_path,omitempty"`
-	OriginalPath string `json:"original_path,omitempty"`
-	SHA1         string `json:"sha1sum,omitempty"`
+	ID       string `json:"id,omitempty"`
+	JobID    string `json:"job_id,omitempty"`
+	State    string `json:"state,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
+	FileSize int64  `json:"file_size,omitempty"`
+	SHA1     string `json:"sha1sum,omitempty"`
 }
 
 func toArtifactListItems(artifacts []buildkite.Artifact) []artifactListItem {
 	items := make([]artifactListItem, len(artifacts))
 	for i, a := range artifacts {
 		items[i] = artifactListItem{
-			ID:           a.ID,
-			JobID:        a.JobID,
-			URL:          a.URL,
-			State:        a.State,
-			Path:         a.Path,
-			Dirname:      a.Dirname,
-			Filename:     a.Filename,
-			MimeType:     a.MimeType,
-			FileSize:     a.FileSize,
-			GlobPath:     a.GlobPath,
-			OriginalPath: a.OriginalPath,
-			SHA1:         a.SHA1,
+			ID:       a.ID,
+			JobID:    a.JobID,
+			State:    a.State,
+			Path:     a.Path,
+			Filename: a.Filename,
+			MimeType: a.MimeType,
+			FileSize: a.FileSize,
+			SHA1:     a.SHA1,
 		}
 	}
 	return items

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -188,6 +188,49 @@ func isTextMIMEType(mimeType string) bool {
 	}
 }
 
+// artifactListItem is the projection of an artifact returned by the list tools.
+// It deliberately omits the download_url field present on buildkite.Artifact:
+// that URL is the authenticated API redirect endpoint, which behaves differently
+// from the presigned URL get_artifact returns and consistently misled agents into
+// sending Bearer tokens to the wrong place. Callers identify an artifact by
+// filename/path and fetch it via get_artifact using id and job_id, so the field
+// is redundant here (it is exactly url + "/download").
+type artifactListItem struct {
+	ID           string `json:"id,omitempty"`
+	JobID        string `json:"job_id,omitempty"`
+	URL          string `json:"url,omitempty"`
+	State        string `json:"state,omitempty"`
+	Path         string `json:"path,omitempty"`
+	Dirname      string `json:"dirname,omitempty"`
+	Filename     string `json:"filename,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size,omitempty"`
+	GlobPath     string `json:"glob_path,omitempty"`
+	OriginalPath string `json:"original_path,omitempty"`
+	SHA1         string `json:"sha1sum,omitempty"`
+}
+
+func toArtifactListItems(artifacts []buildkite.Artifact) []artifactListItem {
+	items := make([]artifactListItem, len(artifacts))
+	for i, a := range artifacts {
+		items[i] = artifactListItem{
+			ID:           a.ID,
+			JobID:        a.JobID,
+			URL:          a.URL,
+			State:        a.State,
+			Path:         a.Path,
+			Dirname:      a.Dirname,
+			Filename:     a.Filename,
+			MimeType:     a.MimeType,
+			FileSize:     a.FileSize,
+			GlobPath:     a.GlobPath,
+			OriginalPath: a.OriginalPath,
+			SHA1:         a.SHA1,
+		}
+	}
+	return items
+}
+
 type ListArtifactsForBuildArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
@@ -216,7 +259,7 @@ type GetArtifactArgs struct {
 func ListArtifactsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForBuildArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_artifacts_for_build",
-			Description: "List all artifacts for a build across all jobs, including file details, paths, sizes, MIME types, and download URLs",
+			Description: "List all artifacts for a build across all jobs, including filenames, paths, sizes, and MIME types. Output can be large for big builds — use per_page and paginate. To fetch an artifact's contents or a download URL, call get_artifact with that artifact's id and job_id.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Build Artifact List",
 				ReadOnlyHint: true,
@@ -244,8 +287,8 @@ func ListArtifactsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForBuild
 				return handleBuildkiteError(err)
 			}
 
-			result := PaginatedResult[buildkite.Artifact]{
-				Items: artifacts,
+			result := PaginatedResult[artifactListItem]{
+				Items: toArtifactListItems(artifacts),
 				Headers: map[string]string{
 					"Link": resp.Header.Get("Link"),
 				},
@@ -262,7 +305,7 @@ func ListArtifactsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForBuild
 func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_artifacts_for_job",
-			Description: "List all artifacts for an individual job, including file details, paths, sizes, MIME types, and download URLs",
+			Description: "List all artifacts for an individual job, including filenames, paths, sizes, and MIME types. To fetch an artifact's contents or a download URL, call get_artifact with that artifact's id and job_id.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Job Artifact List",
 				ReadOnlyHint: true,
@@ -291,8 +334,8 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 				return handleBuildkiteError(err)
 			}
 
-			result := PaginatedResult[buildkite.Artifact]{
-				Items: artifacts,
+			result := PaginatedResult[artifactListItem]{
+				Items: toArtifactListItems(artifacts),
 				Headers: map[string]string{
 					"Link": resp.Header.Get("Link"),
 				},
@@ -310,7 +353,7 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
-			Description: "Get a specific artifact by organization, pipeline, build, job, and artifact identifiers. Small text artifacts are returned inline; large or binary artifacts return metadata plus a download URL",
+			Description: "Get a specific artifact by organization, pipeline, build, job, and artifact identifiers. Text artifacts under 64 KiB are returned inline in `content`; larger or binary artifacts return metadata plus a short-lived `download_url`. When `download_url_auth` is \"none\" the URL is presigned (a buildkiteartifacts.com S3 link) — fetch it with a plain GET and NO Authorization header. It expires after `download_url_expires_in_seconds`; if it has expired, call this tool again for a fresh URL. (Note: the `download_url` returned by list_artifacts_for_build/list_artifacts_for_job is different — that one is an authenticated API endpoint requiring your token.)",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Artifact",
 				ReadOnlyHint: true,
@@ -408,10 +451,13 @@ func downloadURLExpiresInSeconds(downloadURL string) int {
 // (e.g. " because it was larger than expected"); pass "" for no specific reason.
 func urlArtifactResult(reason string, artifact buildkite.Artifact, downloadURL, downloadURLAuth string, expiresInSeconds int) map[string]any {
 	result := artifactResult("url", artifact, downloadURL, downloadURLAuth, expiresInSeconds)
-	if downloadURL == "" {
+	switch {
+	case downloadURL == "":
 		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s, and no download URL was available.", reason)
-	} else {
-		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s. Use download_url to fetch it directly.", reason)
+	case downloadURLAuth == "none":
+		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s. Fetch download_url with a plain GET and no Authorization header (it is a presigned URL). It is short-lived (see download_url_expires_in_seconds); if it has expired, call get_artifact again for a fresh URL.", reason)
+	default:
+		result["note"] = fmt.Sprintf("Artifact content was not returned inline%s. Use download_url to fetch it directly; it is an authenticated Buildkite API endpoint and requires your API token (Authorization: Bearer <token>).", reason)
 	}
 	return result
 }

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -354,7 +354,7 @@ func ListArtifactsForJob() (mcp.Tool, mcp.ToolHandlerFor[ListArtifactsForJobArgs
 func GetArtifact() (mcp.Tool, mcp.ToolHandlerFor[GetArtifactArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_artifact",
-			Description: "Get a specific artifact by organization, pipeline, build, job, and artifact identifiers. Text artifacts under 64 KiB are returned inline in `content`; larger or binary artifacts return metadata plus a short-lived `download_url`. When `download_url_auth` is \"none\" the URL is presigned (a buildkiteartifacts.com S3 link) — fetch it with a plain GET and NO Authorization header. It expires after `download_url_expires_in_seconds`; if it has expired, call this tool again for a fresh URL. (Note: the `download_url` returned by list_artifacts_for_build/list_artifacts_for_job is different — that one is an authenticated API endpoint requiring your token.)",
+			Description: "Get a specific artifact by organization, pipeline, build, job, and artifact identifiers. Text artifacts under 64 KiB are returned inline in `content`; larger or binary artifacts return metadata plus a short-lived `download_url`. When `download_url_auth` is \"none\" the URL is presigned (a buildkiteartifacts.com S3 link) — fetch it with a plain GET and NO Authorization header. It expires after `download_url_expires_in_seconds`; if it has expired, call this tool again for a fresh URL.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Artifact",
 				ReadOnlyHint: true,

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -77,6 +77,8 @@ func TestListArtifactsForBuild(t *testing.T) {
 					{
 						ID:          "abc123",
 						JobID:       "job-789",
+						URL:         "https://example.com/artifact-resource",
+						Dirname:     "build/logs",
 						Filename:    "test-artifact.txt",
 						State:       "finished",
 						DownloadURL: "https://example.com/artifact",
@@ -108,9 +110,11 @@ func TestListArtifactsForBuild(t *testing.T) {
 	assert.Contains(textContent.Text, `"job_id":"job-789"`)
 	assert.Contains(textContent.Text, `"filename":"test-artifact.txt"`)
 	assert.Contains(textContent.Text, `"state":"finished"`)
-	// download_url is intentionally stripped from list results; agents fetch via
-	// get_artifact using id and job_id instead.
+	// download_url and url are intentionally stripped from list results to keep
+	// them small; agents fetch via get_artifact using id and job_id instead.
 	assert.NotContains(textContent.Text, `"download_url"`)
+	assert.NotContains(textContent.Text, `"url"`)
+	assert.NotContains(textContent.Text, `"dirname"`)
 }
 
 func TestListArtifactsForJob(t *testing.T) {
@@ -122,6 +126,8 @@ func TestListArtifactsForJob(t *testing.T) {
 					{
 						ID:          "abc123",
 						JobID:       "job-789",
+						URL:         "https://example.com/artifact-resource",
+						Dirname:     "build/logs",
 						Filename:    "test-artifact.txt",
 						State:       "finished",
 						DownloadURL: "https://example.com/artifact",
@@ -154,9 +160,11 @@ func TestListArtifactsForJob(t *testing.T) {
 	assert.Contains(textContent.Text, `"job_id":"job-789"`)
 	assert.Contains(textContent.Text, `"filename":"test-artifact.txt"`)
 	assert.Contains(textContent.Text, `"state":"finished"`)
-	// download_url is intentionally stripped from list results; agents fetch via
-	// get_artifact using id and job_id instead.
+	// download_url and url are intentionally stripped from list results to keep
+	// them small; agents fetch via get_artifact using id and job_id instead.
 	assert.NotContains(textContent.Text, `"download_url"`)
+	assert.NotContains(textContent.Text, `"url"`)
+	assert.NotContains(textContent.Text, `"dirname"`)
 }
 
 func TestGetArtifact_TextInline(t *testing.T) {

--- a/pkg/buildkite/artifacts_test.go
+++ b/pkg/buildkite/artifacts_test.go
@@ -76,6 +76,7 @@ func TestListArtifactsForBuild(t *testing.T) {
 			return []buildkite.Artifact{
 					{
 						ID:          "abc123",
+						JobID:       "job-789",
 						Filename:    "test-artifact.txt",
 						State:       "finished",
 						DownloadURL: "https://example.com/artifact",
@@ -104,9 +105,12 @@ func TestListArtifactsForBuild(t *testing.T) {
 
 	textContent := getTextResult(t, result)
 	assert.Contains(textContent.Text, `"id":"abc123"`)
+	assert.Contains(textContent.Text, `"job_id":"job-789"`)
 	assert.Contains(textContent.Text, `"filename":"test-artifact.txt"`)
 	assert.Contains(textContent.Text, `"state":"finished"`)
-	assert.Contains(textContent.Text, `"download_url":"https://example.com/artifact"`)
+	// download_url is intentionally stripped from list results; agents fetch via
+	// get_artifact using id and job_id instead.
+	assert.NotContains(textContent.Text, `"download_url"`)
 }
 
 func TestListArtifactsForJob(t *testing.T) {
@@ -117,6 +121,7 @@ func TestListArtifactsForJob(t *testing.T) {
 			return []buildkite.Artifact{
 					{
 						ID:          "abc123",
+						JobID:       "job-789",
 						Filename:    "test-artifact.txt",
 						State:       "finished",
 						DownloadURL: "https://example.com/artifact",
@@ -146,9 +151,12 @@ func TestListArtifactsForJob(t *testing.T) {
 
 	textContent := getTextResult(t, result)
 	assert.Contains(textContent.Text, `"id":"abc123"`)
+	assert.Contains(textContent.Text, `"job_id":"job-789"`)
 	assert.Contains(textContent.Text, `"filename":"test-artifact.txt"`)
 	assert.Contains(textContent.Text, `"state":"finished"`)
-	assert.Contains(textContent.Text, `"download_url":"https://example.com/artifact"`)
+	// download_url is intentionally stripped from list results; agents fetch via
+	// get_artifact using id and job_id instead.
+	assert.NotContains(textContent.Text, `"download_url"`)
 }
 
 func TestGetArtifact_TextInline(t *testing.T) {


### PR DESCRIPTION
The `list_artifacts_for_build` / `list_artifacts_for_job` tools returned two download URLs with different auth semantics, which misled agents, plus several redundant fields that bloated output (~74.5k chars per 100-item page on large builds).

This change results in ~55% smaller list output (~74.5k → ~33.7k chars per 100-item page), easing the token-limit issues on big builds.

## Changes
* Drop `download_url` — it's the authenticated API redirect endpoint, which behaves differently from the presigned URL `get_artifact` returns (`download_url_auth: "none"`). Agents kept sending Bearer tokens to the wrong one. It's also exactly `url + "/download"`.
* Drop `url`, `dirname`, `glob_path`, `original_path` — `url` is the same authenticated endpoint minus `/download`; `dirname` is just `dir(path)`; the glob fields are rarely-populated upload internals.
* List items now carry `id`, `job_id`, `state`, `path`, `filename`, `mime_type`, `file_size`, `sha1sum`.
* Tool descriptions updated to direct callers to `get_artifact` (using `id` + `job_id`) for contents or a download URL.

## Breaking
* List output no longer includes `download_url`/`url`. Fetch via `get_artifact` instead — all required fields (`id`, `job_id`) remain in the list.

This is a follow up for #295 after reviewing the changes in a couple of different agents.