### PR TITLE
Trigger content drafts from MCP PRs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,11 @@ cache:
   size: "100g"
 
 steps:
+  - name: ":memo: Trigger docs draft"
+    if: build.branch == "main"
+    soft_fail: true
+    command: .buildkite/trigger-docs-draft
+
   - group: ":mag: Quality Checks"
     key: quality-checks
     steps:

--- a/.buildkite/trigger-docs-draft
+++ b/.buildkite/trigger-docs-draft
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eo pipefail
+
+COMMIT="${BUILDKITE_COMMIT:-HEAD}"
+PR_NUMBER=$(git log -1 --pretty=%B "${COMMIT}" | sed -nE 's/^Merge pull request #([0-9]+).*/\1/p' | head -n 1)
+
+if [[ -z "${PR_NUMBER}" ]]; then
+  echo "No merged PR number found in commit message, skipping docs draft trigger."
+  exit 0
+fi
+
+echo "Triggering docs draft for buildkite/buildkite-mcp-server#${PR_NUMBER}"
+
+buildkite-agent pipeline upload <<EOF
+steps:
+  - trigger: "docs-draft-writer"
+    async: true
+    soft_fail: true
+    build:
+      message: "Docs draft for buildkite/buildkite-mcp-server#${PR_NUMBER}"
+      branch: "main"
+      env:
+        UPSTREAM_REPO: "buildkite/buildkite-mcp-server"
+        UPSTREAM_PR_NUMBER: "${PR_NUMBER}"
+        WRITE_DOCS: "true"
+        WRITE_CHANGELOG: "true"
+        WRITE_SKILLS: "true"
+EOF


### PR DESCRIPTION
## Summary
- add a main-branch Buildkite step that triggers `docs-draft-writer`
- extract the merged PR number from the merge commit message
- request docs, changelog, and skills draft outputs for MCP changes

## Validation
- `bash -n .buildkite/trigger-docs-draft`
- parsed `.buildkite/pipeline.yml` with Ruby YAML
- verified the PR-number extraction against the current merge commit shape
- `git diff --check`

## Notes
- this reuses the existing central `docs-draft-writer` pipeline rather than adding a separate writer