### PR TITLE
fix: set DestructiveHint consistently on write tools

### DIFF
--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -133,7 +133,8 @@ func CreateAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateAnnotationArgs, any]
 			Name:        "create_annotation",
 			Description: "Create an annotation on a build or specific job. Use scope='build' (default) or scope='job' with job_id",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Annotation",
+				Title:           "Create Annotation",
+				DestructiveHint: boolPtr(false),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateAnnotationArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.CreateAnnotation")

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -134,7 +134,7 @@ func CreateAnnotation() (mcp.Tool, mcp.ToolHandlerFor[CreateAnnotationArgs, any]
 			Description: "Create an annotation on a build or specific job. Use scope='build' (default) or scope='job' with job_id",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Create Annotation",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreateAnnotationArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.CreateAnnotation")

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -300,7 +300,8 @@ func CreateBuild() (mcp.Tool, mcp.ToolHandlerFor[CreateBuildArgs, any], []string
 			Name:        "create_build",
 			Description: "Trigger a new build on a Buildkite pipeline for a specific commit and branch, with optional environment variables, metadata, and author information",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Build",
+				Title:           "Create Build",
+				DestructiveHint: boolPtr(false),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args CreateBuildArgs) (*mcp.CallToolResult, any, error) {
@@ -343,7 +344,8 @@ func CancelBuild() (mcp.Tool, mcp.ToolHandlerFor[CancelBuildArgs, any], []string
 			Name:        "cancel_build",
 			Description: "Cancel a running build on a Buildkite pipeline",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Cancel Build",
+				Title:           "Cancel Build",
+				DestructiveHint: boolPtr(true),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args CancelBuildArgs) (*mcp.CallToolResult, any, error) {
@@ -377,7 +379,8 @@ func RebuildBuild() (mcp.Tool, mcp.ToolHandlerFor[RebuildBuildArgs, any], []stri
 			Name:        "rebuild_build",
 			Description: "Rebuild/retry an entire build on a Buildkite pipeline",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Rebuild Build",
+				Title:           "Rebuild Build",
+				DestructiveHint: boolPtr(false),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args RebuildBuildArgs) (*mcp.CallToolResult, any, error) {

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -380,7 +380,7 @@ func RebuildBuild() (mcp.Tool, mcp.ToolHandlerFor[RebuildBuildArgs, any], []stri
 			Description: "Rebuild/retry an entire build on a Buildkite pipeline",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Rebuild Build",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args RebuildBuildArgs) (*mcp.CallToolResult, any, error) {

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -528,6 +528,7 @@ func TestRebuildBuild(t *testing.T) {
 		tool, _, _ := RebuildBuild()
 		require.Equal(t, "rebuild_build", tool.Name)
 		require.Contains(t, tool.Description, "Rebuild")
+		require.Equal(t, boolPtr(true), tool.Annotations.DestructiveHint)
 	})
 
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -234,7 +234,7 @@ func ResumeClusterQueueDispatch() (mcp.Tool, mcp.ToolHandlerFor[ResumeClusterQue
 			Description: "Resume dispatch on a paused cluster queue, allowing jobs to be dispatched to agents again",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Resume Cluster Queue Dispatch",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args ResumeClusterQueueDispatchArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.ResumeClusterQueueDispatch")

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -168,7 +168,7 @@ func UpdateClusterQueue() (mcp.Tool, mcp.ToolHandlerFor[UpdateClusterQueueArgs, 
 			Description: "Update an existing cluster queue's description or retry agent affinity",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Update Cluster Queue",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args UpdateClusterQueueArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.UpdateClusterQueue")

--- a/pkg/buildkite/cluster_queue_test.go
+++ b/pkg/buildkite/cluster_queue_test.go
@@ -295,7 +295,7 @@ func TestResumeClusterQueueDispatch(t *testing.T) {
 
 	tool, handler, scopes := ResumeClusterQueueDispatch()
 	assert.Equal("resume_cluster_queue_dispatch", tool.Name)
-	assert.Equal(boolPtr(false), tool.Annotations.DestructiveHint)
+	assert.Equal(boolPtr(true), tool.Annotations.DestructiveHint)
 	assert.Contains(scopes, "write_clusters")
 
 	request := createMCPRequest(t, map[string]any{})

--- a/pkg/buildkite/cluster_queue_test.go
+++ b/pkg/buildkite/cluster_queue_test.go
@@ -191,7 +191,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 
 	tool, handler, scopes := UpdateClusterQueue()
 	assert.Equal("update_cluster_queue", tool.Name)
-	assert.Equal(boolPtr(false), tool.Annotations.DestructiveHint)
+	assert.Equal(boolPtr(true), tool.Annotations.DestructiveHint)
 	assert.Contains(scopes, "write_clusters")
 
 	request := createMCPRequest(t, map[string]any{})

--- a/pkg/buildkite/clusters.go
+++ b/pkg/buildkite/clusters.go
@@ -153,7 +153,7 @@ func UpdateCluster() (mcp.Tool, mcp.ToolHandlerFor[UpdateClusterArgs, any], []st
 			Description: "Update an existing cluster's name, description, emoji, color, or default queue",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Update Cluster",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args UpdateClusterArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.UpdateCluster")

--- a/pkg/buildkite/clusters_test.go
+++ b/pkg/buildkite/clusters_test.go
@@ -174,7 +174,7 @@ func TestUpdateCluster(t *testing.T) {
 
 	tool, handler, scopes := UpdateCluster()
 	assert.Equal("update_cluster", tool.Name)
-	assert.Equal(boolPtr(false), tool.Annotations.DestructiveHint)
+	assert.Equal(boolPtr(true), tool.Annotations.DestructiveHint)
 	assert.Contains(scopes, "write_clusters")
 
 	request := createMCPRequest(t, map[string]any{})

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -184,7 +184,8 @@ func UnblockJob() (mcp.Tool, mcp.ToolHandlerFor[UnblockJobArgs, any], []string) 
 			Name:        "unblock_job",
 			Description: "Unblock a blocked job in a Buildkite build to allow it to continue execution",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Unblock Job",
+				Title:           "Unblock Job",
+				DestructiveHint: boolPtr(false),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args UnblockJobArgs) (*mcp.CallToolResult, any, error) {
@@ -228,7 +229,8 @@ func RetryJob() (mcp.Tool, mcp.ToolHandlerFor[RetryJobArgs, any], []string) {
 			Name:        "retry_job",
 			Description: "Retry a specific failed or timed out job in a Buildkite build",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Retry Job",
+				Title:           "Retry Job",
+				DestructiveHint: boolPtr(false),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args RetryJobArgs) (*mcp.CallToolResult, any, error) {

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -185,7 +185,7 @@ func UnblockJob() (mcp.Tool, mcp.ToolHandlerFor[UnblockJobArgs, any], []string) 
 			Description: "Unblock a blocked job in a Buildkite build to allow it to continue execution",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Unblock Job",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args UnblockJobArgs) (*mcp.CallToolResult, any, error) {
@@ -230,7 +230,7 @@ func RetryJob() (mcp.Tool, mcp.ToolHandlerFor[RetryJobArgs, any], []string) {
 			Description: "Retry a specific failed or timed out job in a Buildkite build",
 			Annotations: &mcp.ToolAnnotations{
 				Title:           "Retry Job",
-				DestructiveHint: boolPtr(false),
+				DestructiveHint: boolPtr(true),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args RetryJobArgs) (*mcp.CallToolResult, any, error) {

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -82,6 +82,7 @@ func TestUnblockJob(t *testing.T) {
 		tool, _, _ := UnblockJob()
 		assert.Equal(t, "unblock_job", tool.Name)
 		assert.Contains(t, tool.Description, "Unblock a blocked job")
+		assert.Equal(t, boolPtr(true), tool.Annotations.DestructiveHint)
 	})
 
 	// Test successful unblock
@@ -192,6 +193,7 @@ func TestRetryJob(t *testing.T) {
 		tool, _, _ := RetryJob()
 		assert.Equal(t, "retry_job", tool.Name)
 		assert.Contains(t, tool.Description, "Retry")
+		assert.Equal(t, boolPtr(true), tool.Annotations.DestructiveHint)
 	})
 
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/buildkite/pipeline_schedules.go
+++ b/pkg/buildkite/pipeline_schedules.go
@@ -118,7 +118,8 @@ func CreatePipelineSchedule() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineSchedu
 			Name:        "create_pipeline_schedule",
 			Description: "Create a new pipeline schedule that triggers builds on a cron-driven interval",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Pipeline Schedule",
+				Title:           "Create Pipeline Schedule",
+				DestructiveHint: boolPtr(false),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args CreatePipelineScheduleArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.CreatePipelineSchedule")
@@ -168,7 +169,8 @@ func UpdatePipelineSchedule() (mcp.Tool, mcp.ToolHandlerFor[UpdatePipelineSchedu
 			Name:        "update_pipeline_schedule",
 			Description: "Modify an existing pipeline schedule's cron expression, branch, environment variables, or enabled state",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Update Pipeline Schedule",
+				Title:           "Update Pipeline Schedule",
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args UpdatePipelineScheduleArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.UpdatePipelineSchedule")

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -256,7 +256,8 @@ func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []
 			Name:        "create_pipeline",
 			Description: "Set up a new CI/CD pipeline in Buildkite with YAML configuration, repository connection, and cluster assignment",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Create Pipeline",
+				Title:           "Create Pipeline",
+				DestructiveHint: boolPtr(false),
 			},
 		},
 		func(ctx context.Context, request *mcp.CallToolRequest, args CreatePipelineArgs) (*mcp.CallToolResult, any, error) {
@@ -334,7 +335,8 @@ func UpdatePipeline() (mcp.Tool, mcp.ToolHandlerFor[UpdatePipelineArgs, any], []
 			Name:        "update_pipeline",
 			Description: "Modify an existing Buildkite pipeline's configuration, repository, settings, or metadata",
 			Annotations: &mcp.ToolAnnotations{
-				Title: "Update Pipeline",
+				Title:           "Update Pipeline",
+				DestructiveHint: boolPtr(true),
 			},
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args UpdatePipelineArgs) (*mcp.CallToolResult, any, error) {
 			ctx, span := trace.Start(ctx, "buildkite.UpdatePipeline")


### PR DESCRIPTION
Annotate additive create tools as non-destructive and state-changing overwrite, cancel, retry, unblock, pause, resume, and update tools as destructive so clients get accurate risk hints.

| Tool | Change |
|------|--------|
| `create_annotation` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `create_build` | `DestructiveHint: false` (was unset → default `true`) |
| `rebuild_build` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `create_pipeline` | `DestructiveHint: false` (was unset → default `true`) |
| `create_pipeline_schedule` | `DestructiveHint: false` (was unset → default `true`) |
| `unblock_job` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `retry_job` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `cancel_build` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `update_pipeline` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `update_pipeline_schedule` | `DestructiveHint: true` (was unset → default `true`; now explicit) |
| `update_cluster` | `DestructiveHint: true` (was `false`) |
| `update_cluster_queue` | `DestructiveHint: true` (was `false`) |
| `resume_cluster_queue_dispatch` | `DestructiveHint: true` (was `false`) |
