### PR TITLE
Exclude jobs when discovering Test Engine runs

### DIFF
--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -224,6 +224,10 @@ func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRu
 
 			deps := DepsFromContext(ctx)
 			build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
+				BuildsListOptions: buildkite.BuildsListOptions{
+					ExcludeJobs:     true,
+					ExcludePipeline: true,
+				},
 				IncludeTestEngine: true,
 			})
 			if err != nil {

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -305,8 +305,10 @@ func TestListBuilds(t *testing.T) {
 func TestGetBuildTestEngineRuns(t *testing.T) {
 	assert := require.New(t)
 
+	var capturedOptions *buildkite.BuildGetOptions
 	client := &MockBuildsClient{
 		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			capturedOptions = opt
 			// Return build with test engine data
 			return buildkite.Build{
 					ID:     "123",
@@ -361,6 +363,11 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 	assert.Contains(textContent.Text, "run-2")
 	assert.Contains(textContent.Text, "my-test-suite")
 	assert.Contains(textContent.Text, "another-test-suite")
+
+	require.NotNil(t, capturedOptions)
+	assert.True(capturedOptions.ExcludeJobs)
+	assert.True(capturedOptions.ExcludePipeline)
+	assert.True(capturedOptions.IncludeTestEngine)
 }
 
 func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {


### PR DESCRIPTION
## Problem and approach

`get_build_test_engine_runs` currently asks the Builds API to include Test Engine data without excluding unrelated jobs and pipeline details. Request all three options together so the tool still returns the same Test Engine run references while avoiding unnecessary build payload data.

## Compatibility and deployment risk

Low risk: the tool schema and response shape are unchanged. Only upstream payload expansion changes, so this can deploy normally.

## Rollback

Revert this PR to restore the previous Builds API request options.
