### PR TITLE
Move Test Engine expansion out of get_build

### DIFF
--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -204,7 +204,7 @@ func ListBuilds() (mcp.Tool, mcp.ToolHandlerFor[ListBuildsArgs, any], []string) 
 func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRunsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build_test_engine_runs",
-			Description: "Get test engine runs data for a specific build in Buildkite. This can be used to look up Test Runs.",
+			Description: "Get test engine runs data for a specific build. Returns run references, [] when the build has no runs, or null when the build has no Test Engine data.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build Test Engine Runs",
 				ReadOnlyHint: true,
@@ -232,7 +232,8 @@ func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRu
 				return handleBuildkiteError(err)
 			}
 
-			// Extract just the test engine runs data
+			// Preserve null when no Test Engine data exists so callers can
+			// distinguish it from a build with no runs ([]).
 			var testEngineRuns []buildkite.TestEngineRun
 			if build.TestEngine != nil {
 				testEngineRuns = build.TestEngine.Runs
@@ -245,7 +246,7 @@ func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRu
 func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build",
-			Description: "Get metadata for a single build. Jobs are not included — use list_jobs or get_job for job detail. Use get_build_test_engine_runs for Test Engine run references",
+			Description: "Get metadata for a single build. Jobs are not included — use list_jobs or get_job for job detail. This response does not indicate whether Test Engine data exists; call get_build_test_engine_runs to check.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build",
 				ReadOnlyHint: true,

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -34,18 +34,17 @@ type BuildSummary struct {
 // pipeline configuration from the raw Buildkite SDK response.
 type BuildDetail struct {
 	BuildSummary
-	Blocked       bool                          `json:"blocked"`
-	Author        buildkite.Author              `json:"author"`
-	ScheduledAt   *buildkite.Timestamp          `json:"scheduled_at,omitempty"`
-	StartedAt     *buildkite.Timestamp          `json:"started_at,omitempty"`
-	FinishedAt    *buildkite.Timestamp          `json:"finished_at,omitempty"`
-	MetaData      map[string]string             `json:"meta_data,omitempty"`
-	Creator       buildkite.Creator             `json:"creator"`
-	Source        string                        `json:"source,omitempty"`
-	RebuiltFrom   *buildkite.RebuiltFrom        `json:"rebuilt_from,omitempty"`
-	PullRequest   *buildkite.PullRequest        `json:"pull_request,omitempty"`
-	TriggeredFrom *buildkite.TriggeredFrom      `json:"triggered_from,omitempty"`
-	TestEngine    *buildkite.TestEngineProperty `json:"test_engine,omitempty"`
+	Blocked       bool                     `json:"blocked"`
+	Author        buildkite.Author         `json:"author"`
+	ScheduledAt   *buildkite.Timestamp     `json:"scheduled_at,omitempty"`
+	StartedAt     *buildkite.Timestamp     `json:"started_at,omitempty"`
+	FinishedAt    *buildkite.Timestamp     `json:"finished_at,omitempty"`
+	MetaData      map[string]string        `json:"meta_data,omitempty"`
+	Creator       buildkite.Creator        `json:"creator"`
+	Source        string                   `json:"source,omitempty"`
+	RebuiltFrom   *buildkite.RebuiltFrom   `json:"rebuilt_from,omitempty"`
+	PullRequest   *buildkite.PullRequest   `json:"pull_request,omitempty"`
+	TriggeredFrom *buildkite.TriggeredFrom `json:"triggered_from,omitempty"`
 }
 
 // ListBuildsArgs struct with enhanced filtering
@@ -104,7 +103,6 @@ func detailBuild(build buildkite.Build) BuildDetail {
 		RebuiltFrom:   build.RebuiltFrom,
 		PullRequest:   build.PullRequest,
 		TriggeredFrom: build.TriggeredFrom,
-		TestEngine:    build.TestEngine,
 	}
 }
 
@@ -247,7 +245,7 @@ func GetBuildTestEngineRuns() (mcp.Tool, mcp.ToolHandlerFor[GetBuildTestEngineRu
 func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build",
-			Description: "Get a single build. Jobs are not included — use list_jobs or get_job for job detail",
+			Description: "Get metadata for a single build. Jobs are not included — use list_jobs or get_job for job detail. Use get_build_test_engine_runs for Test Engine run references",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build",
 				ReadOnlyHint: true,
@@ -269,7 +267,6 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 					ExcludeJobs:     true,
 					ExcludePipeline: true,
 				},
-				IncludeTestEngine: true,
 			}
 
 			deps := DepsFromContext(ctx)

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -68,6 +68,7 @@ func TestGetBuild(t *testing.T) {
 		tool, handler, scopes := GetBuild()
 		require.Equal(t, "get_build", tool.Name)
 		require.Contains(t, tool.Description, "metadata")
+		require.Contains(t, tool.Description, "does not indicate whether Test Engine data exists")
 		require.Contains(t, tool.Description, "get_build_test_engine_runs")
 		require.True(t, tool.Annotations.ReadOnlyHint)
 		require.Equal(t, []string{"read_builds"}, scopes)
@@ -355,6 +356,8 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 	// Test tool properties
 	assert.Equal("get_build_test_engine_runs", tool.Name)
 	assert.Contains(tool.Description, "test engine runs")
+	assert.Contains(tool.Description, "[] when")
+	assert.Contains(tool.Description, "null when")
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{})
@@ -375,6 +378,33 @@ func TestGetBuildTestEngineRuns(t *testing.T) {
 	assert.True(capturedOptions.ExcludeJobs)
 	assert.True(capturedOptions.ExcludePipeline)
 	assert.True(capturedOptions.IncludeTestEngine)
+}
+
+func TestGetBuildTestEngineRunsNoRuns(t *testing.T) {
+	assert := require.New(t)
+
+	client := &MockBuildsClient{
+		GetFunc: func(ctx context.Context, org string, pipeline string, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+					ID:         "123",
+					Number:     1,
+					TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{}},
+				}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: client})
+	_, handler, _ := GetBuildTestEngineRuns()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildTestEngineRunsArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+	})
+	assert.NoError(err)
+	assert.Equal("[]", getTextResult(t, result).Text)
 }
 
 func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {
@@ -408,7 +438,7 @@ func TestGetBuildTestEngineRunsNoBuildTestEngine(t *testing.T) {
 	assert.NoError(err)
 
 	textContent := getTextResult(t, result)
-	// Should return empty array when no test engine data
+	// Preserve the distinction between no Test Engine data and no runs.
 	assert.Equal("null", textContent.Text)
 }
 

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -67,6 +67,8 @@ func TestGetBuild(t *testing.T) {
 	t.Run("ToolDefinition", func(t *testing.T) {
 		tool, handler, scopes := GetBuild()
 		require.Equal(t, "get_build", tool.Name)
+		require.Contains(t, tool.Description, "metadata")
+		require.Contains(t, tool.Description, "get_build_test_engine_runs")
 		require.True(t, tool.Annotations.ReadOnlyHint)
 		require.Equal(t, []string{"read_builds"}, scopes)
 		require.NotNil(t, handler)
@@ -98,6 +100,9 @@ func TestGetBuild(t *testing.T) {
 							Configuration: "steps:\n  - command: echo secret",
 							Env:           map[string]any{"PIPELINE_SECRET": "redacted"},
 						},
+						TestEngine: &buildkite.TestEngineProperty{
+							Runs: []buildkite.TestEngineRun{{ID: "run-1"}},
+						},
 						CreatedAt: &buildkite.Timestamp{},
 					}, &buildkite.Response{
 						Response: &http.Response{StatusCode: 200},
@@ -127,12 +132,14 @@ func TestGetBuild(t *testing.T) {
 		assert.NotContains(text, "SECRET_TOKEN")
 		assert.NotContains(text, "PIPELINE_SECRET")
 		assert.NotContains(text, "steps:")
+		assert.NotContains(text, `"test_engine":`)
+		assert.NotContains(text, "run-1")
 
 		// The handler must exclude jobs and pipeline detail from the API request.
 		require.NotNil(t, capturedOptions)
 		assert.True(capturedOptions.ExcludeJobs)
 		assert.True(capturedOptions.ExcludePipeline)
-		assert.True(capturedOptions.IncludeTestEngine)
+		assert.False(capturedOptions.IncludeTestEngine)
 	})
 
 	t.Run("APIError", func(t *testing.T) {


### PR DESCRIPTION
## Problem and approach

`get_build` currently expands Test Engine data and exposes `test_engine` despite being the build metadata tool. Stop requesting that expansion, remove it from `BuildDetail`, and direct Test Engine workflows to `get_build_test_engine_runs`.

Depends on #304, which keeps the dedicated lookup lightweight while preserving its run-reference response.

## Compatibility and migration

This intentionally removes `test_engine` from the observed `get_build` response contract. Clients that need Test Engine run identifiers must call `get_build_test_engine_runs` with the same organization, pipeline, and build number.

The repository is currently at v1.9.0. Because the project is post-1.0 and this is a response-contract break, target v2.0.0. GoReleaser generates the changelog from commits, so the v2.0.0 release notes must be manually curated to include this migration; no changelog-fragment mechanism exists in the repository.

## Deployment risk

Do not include this in a v1.x release. Deploy it with v2.0.0 after #304; clients parsing `get_build.test_engine` must migrate first.

## Rollback

Revert this PR to restore Test Engine expansion and the `test_engine` response field. #304 can remain deployed because it does not change its tool contract.
