### PR TITLE
feat(feedback): add a feedback prompt tool

### DIFF
--- a/pkg/buildkite/feedback.go
+++ b/pkg/buildkite/feedback.go
@@ -1,0 +1,83 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+const reportIssuePromptName = "report_issue"
+
+const reportIssuePromptDescription = "Generate a structured, copy-pasteable report of a problem with this MCP server (failed tool calls, unexpected results, or missing capabilities) that the user can submit as a GitHub issue"
+
+const reportIssuePromptTemplate = `You are helping the user report a problem with the Buildkite MCP server (buildkite-mcp-server).
+
+Known environment (include these values in the report verbatim):
+- buildkite-mcp-server version: %s
+- MCP client: %s
+
+Review this conversation for Buildkite MCP tool calls that failed, returned errors, or behaved differently than the user expected, then produce an issue report the user can copy and paste.
+
+Rules:
+- Redact all secrets before including anything in the report: API tokens, credentials, environment variable values, and signed or private URLs. Replace each with [REDACTED].
+- Do not include full log output. Quote only short excerpts (a few lines) directly relevant to the problem.
+- Only include information visible in this conversation. Do not guess or invent details; write "unknown" where information is missing.
+
+Output the report inside a single fenced markdown code block using this template:
+
+## Summary
+One sentence describing what went wrong.
+
+## Environment
+- buildkite-mcp-server version:
+- MCP client:
+
+## Tool calls
+For each problematic tool call:
+- Tool: the tool name
+- Arguments: the arguments as JSON, redacted per the rules above
+- Actual behavior: the error message or unexpected result
+- Expected behavior: what should have happened
+
+## What I was trying to do
+The user's goal, in one or two sentences.
+
+## Additional context
+Anything else relevant, or "none".
+
+After the report, tell the user they can submit it by opening an issue at https://github.com/buildkite/buildkite-mcp-server/issues/new and pasting the report into the body, or by sharing it with Buildkite support.`
+
+// NewReportIssuePrompt returns the report_issue prompt and its handler. The
+// handler embeds the server version and, when available, the connected MCP
+// client's name and version so reports carry environment details the model
+// cannot reliably know itself.
+func NewReportIssuePrompt(version string) (*mcp.Prompt, mcp.PromptHandler) {
+	prompt := &mcp.Prompt{
+		Name:        reportIssuePromptName,
+		Description: reportIssuePromptDescription,
+	}
+
+	handler := func(ctx context.Context, request *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		client := "unknown"
+		if request != nil && request.Session != nil {
+			if ip := request.Session.InitializeParams(); ip != nil && ip.ClientInfo != nil && ip.ClientInfo.Name != "" {
+				client = fmt.Sprintf("%s %s", ip.ClientInfo.Name, ip.ClientInfo.Version)
+			}
+		}
+
+		text := fmt.Sprintf(reportIssuePromptTemplate, version, client)
+
+		return &mcp.GetPromptResult{
+			Description: reportIssuePromptDescription,
+			Messages: []*mcp.PromptMessage{
+				{
+					Role:    mcp.Role("user"),
+					Content: &mcp.TextContent{Text: text},
+				},
+			},
+		}, nil
+	}
+
+	return prompt, handler
+}

--- a/pkg/buildkite/feedback.go
+++ b/pkg/buildkite/feedback.go
@@ -13,10 +13,6 @@ const reportIssuePromptDescription = "Generate a structured, copy-pasteable repo
 
 const reportIssuePromptTemplate = `You are helping the user report a problem with the Buildkite MCP server (buildkite-mcp-server).
 
-Known environment (include these values in the report verbatim):
-- buildkite-mcp-server version: %s
-- MCP client: %s
-
 Review this conversation for Buildkite MCP tool calls that failed, returned errors, or behaved differently than the user expected, then produce an issue report the user can copy and paste.
 
 Rules:
@@ -30,8 +26,8 @@ Output the report inside a single fenced markdown code block using this template
 One sentence describing what went wrong.
 
 ## Environment
-- buildkite-mcp-server version:
-- MCP client:
+- buildkite-mcp-server version: %s
+- MCP client: %s
 
 ## Tool calls
 For each problematic tool call:

--- a/pkg/buildkite/feedback.go
+++ b/pkg/buildkite/feedback.go
@@ -58,7 +58,11 @@ func NewReportIssuePrompt(version string) (*mcp.Prompt, mcp.PromptHandler) {
 		client := "unknown"
 		if request != nil && request.Session != nil {
 			if ip := request.Session.InitializeParams(); ip != nil && ip.ClientInfo != nil && ip.ClientInfo.Name != "" {
-				client = fmt.Sprintf("%s %s", ip.ClientInfo.Name, ip.ClientInfo.Version)
+				if ip.ClientInfo.Version != "" {
+					client = fmt.Sprintf("%s %s", ip.ClientInfo.Name, ip.ClientInfo.Version)
+				} else {
+					client = ip.ClientInfo.Name
+				}
 			}
 		}
 

--- a/pkg/buildkite/feedback_test.go
+++ b/pkg/buildkite/feedback_test.go
@@ -1,0 +1,31 @@
+package buildkite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReportIssuePrompt(t *testing.T) {
+	require := require.New(t)
+
+	prompt, handler := NewReportIssuePrompt("1.2.3")
+
+	require.Equal("report_issue", prompt.Name)
+	require.NotEmpty(prompt.Description)
+
+	result, err := handler(context.Background(), &mcp.GetPromptRequest{
+		Params: &mcp.GetPromptParams{Name: "report_issue"},
+	})
+	require.NoError(err)
+	require.Len(result.Messages, 1)
+
+	text, ok := result.Messages[0].Content.(*mcp.TextContent)
+	require.True(ok)
+	require.Contains(text.Text, "buildkite-mcp-server version: 1.2.3")
+	require.Contains(text.Text, "MCP client: unknown")
+	require.Contains(text.Text, "[REDACTED]")
+	require.Contains(text.Text, "https://github.com/buildkite/buildkite-mcp-server/issues/new")
+}

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -109,11 +109,14 @@ func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...Tools
 	// Register tools
 	RegisterTools(s, cfg)
 
-	// Register prompt
+	// Register prompts
 	s.AddPrompt(&mcp.Prompt{
 		Name:        "user_token_organization_prompt",
 		Description: "When asked for detail of a user's pipelines start by looking up the user's token organization",
 	}, buildkite.HandleUserTokenOrganizationPrompt)
+
+	reportIssuePrompt, reportIssueHandler := buildkite.NewReportIssuePrompt(version)
+	s.AddPrompt(reportIssuePrompt, reportIssueHandler)
 
 	// Register resource
 	s.AddResource(&mcp.Resource{


### PR DESCRIPTION
## Description

Implements a simple means for users/LLMs to generate feedback for tool use issues.

## Changes

- adds a `feedback` tool set which includes a `report_issue` prompt, usable for LLMs and humans
    -   generates output which the user can then pass to folks via GH issue, email, Slack, etc
- adds testing for the feedback tool

## Docs

Documentation is centralised in buildkite.com/docs, so a PR will be opened there.
