### PR TITLE
Add job step and group key filters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609
+	github.com/buildkite/go-buildkite/v5 v5.7.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.22
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.6.0
+	github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.22
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609 h1:iJSBeqygwpKKCuQwYHbAP89kahfpUqlDFsirhV7Q6vA=
-github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.7.0 h1:UY2vlF5AceV7zqWUN+uU7bjEXgEFdKrwayvZ8bZgcj0=
+github.com/buildkite/go-buildkite/v5 v5.7.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.6.0 h1:tC+zcKNeGBbsR1JBUSCuwXzxMtsQ/Q/GKW5f7C2eUAY=
-github.com/buildkite/go-buildkite/v5 v5.6.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609 h1:iJSBeqygwpKKCuQwYHbAP89kahfpUqlDFsirhV7Q6vA=
+github.com/buildkite/go-buildkite/v5 v5.6.1-0.20260717055231-9b999e28d609/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -34,6 +34,8 @@ type ListJobsArgs struct {
 	PipelineSlug       string `json:"pipeline_slug"`
 	BuildNumber        string `json:"build_number"`
 	State              string `json:"state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g.\\, 'passed\\,failed\\,running')"`
+	StepKey            string `json:"step_key,omitempty" jsonschema:"Filter jobs by step key. Includes all parallel jobs for the step"`
+	GroupKey           string `json:"group_key,omitempty" jsonschema:"Filter jobs by group key. Includes all jobs in the group"`
 	IncludeRetriedJobs *bool  `json:"include_retried_jobs,omitempty" jsonschema:"Include retried jobs in the response. Defaults to true on the server when omitted"`
 	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1\\, max 100\\, default 30)"`
 	After              string `json:"after,omitempty" jsonschema:"Cursor for the next page. Take this from the 'links.next' URL of a previous response. Mutually exclusive with 'before'"`
@@ -59,6 +61,8 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				attribute.String("pipeline_slug", args.PipelineSlug),
 				attribute.String("build_number", args.BuildNumber),
 				attribute.String("state", args.State),
+				attribute.String("step_key", args.StepKey),
+				attribute.String("group_key", args.GroupKey),
 				attribute.Int("per_page", args.PerPage),
 			)
 
@@ -68,6 +72,8 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 
 			options := &buildkite.JobsListOptions{
 				IncludeRetriedJobs: args.IncludeRetriedJobs,
+				StepKey:            args.StepKey,
+				GroupKey:           args.GroupKey,
 				PerPage:            args.PerPage,
 				After:              args.After,
 				Before:             args.Before,

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -344,6 +344,8 @@ func TestListJobs(t *testing.T) {
 			PipelineSlug:       "test-pipeline",
 			BuildNumber:        "123",
 			State:              "passed, failed",
+			StepKey:            "test-step",
+			GroupKey:           "test-group",
 			IncludeRetriedJobs: boolPtr(false),
 			PerPage:            50,
 			After:              "cursor1",
@@ -357,6 +359,8 @@ func TestListJobs(t *testing.T) {
 
 		require.NotNil(t, captured)
 		assert.Equal(t, []string{"passed", "failed"}, captured.State)
+		assert.Equal(t, "test-step", captured.StepKey)
+		assert.Equal(t, "test-group", captured.GroupKey)
 		require.NotNil(t, captured.IncludeRetriedJobs)
 		assert.False(t, *captured.IncludeRetriedJobs)
 		assert.Equal(t, 50, captured.PerPage)

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -230,6 +230,19 @@ func TestListPipelinesArgsSchema(t *testing.T) {
 	}
 }
 
+func TestListJobsArgsSchema(t *testing.T) {
+	s := schemaFor[ListJobsArgs](t)
+	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[ListJobsArgs](t))
+
+	for _, opt := range []string{"step_key", "group_key"} {
+		require.Contains(t, s.Properties, opt)
+		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
+	}
+
+	require.Equal(t, "Filter jobs by step key. Includes all parallel jobs for the step", s.Properties["step_key"].Description)
+	require.Equal(t, "Filter jobs by group key. Includes all jobs in the group", s.Properties["group_key"].Description)
+}
+
 func TestUnblockJobArgsSchema(t *testing.T) {
 	s := schemaFor[UnblockJobArgs](t)
 	req := slices.Clone(s.Required)


### PR DESCRIPTION
## Description

Adds optional `step_key` and `group_key` inputs to `list_jobs`. A step-key filter includes every parallel job for that step; a group-key filter includes every job in that group. Both filters are passed through with cursor pagination.

This PR uses the support from [go-buildkite #347](https://github.com/buildkite/go-buildkite/pull/347), released in [v5.7.0](https://github.com/buildkite/go-buildkite/releases/tag/v5.7.0).

## Deployment

1. Confirm the server-side filters are deployed.
2. Merge and deploy this MCP server change.

## Rollback

Revert this PR. The new inputs are optional, so removing them restores the previous tool contract without data migration.
