### PR TITLE
fix: reduce list jobs response payload

### DIFF
--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -36,17 +36,104 @@ type ListJobsArgs struct {
 	State              string `json:"state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g.\\, 'passed\\,failed\\,running')"`
 	StepKey            string `json:"step_key,omitempty" jsonschema:"Filter jobs by step key. Includes all parallel jobs for the step"`
 	GroupKey           string `json:"group_key,omitempty" jsonschema:"Filter jobs by group key. Includes all jobs in the group"`
+	DetailLevel        string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default)\\, 'detailed'\\, or 'full'"`
 	IncludeRetriedJobs *bool  `json:"include_retried_jobs,omitempty" jsonschema:"Include retried jobs in the response. Defaults to true on the server when omitted"`
 	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1\\, max 100\\, default 30)"`
 	After              string `json:"after,omitempty" jsonschema:"Cursor for the next page. Take this from the 'links.next' URL of a previous response. Mutually exclusive with 'before'"`
 	Before             string `json:"before,omitempty" jsonschema:"Cursor for the previous page. Take this from a previous response. Mutually exclusive with 'after'"`
-	IncludeAgent       bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default)\\, only agent.id is included"`
+	IncludeAgent       bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details at the detailed and full levels. When false (default)\\, detailed and full responses include only agent.id"`
+}
+
+// JobSummary contains the fields normally needed to identify a build failure.
+type JobSummary struct {
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	Command    string `json:"command"`
+	ExitStatus *int   `json:"exit_status"`
+}
+
+// JobDetail adds actionable job metadata while excluding repeated build,
+// cluster, queue, and log URLs from the SDK response.
+type JobDetail struct {
+	JobSummary
+	ID                 string                    `json:"id"`
+	Type               string                    `json:"type,omitempty"`
+	Label              string                    `json:"label,omitempty"`
+	StepKey            string                    `json:"step_key,omitempty"`
+	GroupKey           string                    `json:"group_key,omitempty"`
+	Signal             *int                      `json:"signal,omitempty"`
+	SignalReason       string                    `json:"signal_reason,omitempty"`
+	CreatedAt          *buildkite.Timestamp      `json:"created_at,omitempty"`
+	StartedAt          *buildkite.Timestamp      `json:"started_at,omitempty"`
+	FinishedAt         *buildkite.Timestamp      `json:"finished_at,omitempty"`
+	Agent              *buildkite.Agent          `json:"agent,omitempty"`
+	Retried            bool                      `json:"retried,omitempty"`
+	RetriedInJobID     string                    `json:"retried_in_job_id,omitempty"`
+	RetriesCount       int                       `json:"retries_count,omitempty"`
+	RetrySource        *buildkite.JobRetrySource `json:"retry_source,omitempty"`
+	SoftFailed         bool                      `json:"soft_failed,omitempty"`
+	Unblockable        bool                      `json:"unblockable,omitempty"`
+	ParallelGroupIndex *int                      `json:"parallel_group_index,omitempty"`
+	ParallelGroupTotal *int                      `json:"parallel_group_total,omitempty"`
+}
+
+type JobListResult[T any] struct {
+	Items []T                     `json:"items"`
+	Links buildkite.JobsListLinks `json:"links"`
+}
+
+func summarizeJob(job buildkite.Job) JobSummary {
+	return JobSummary{
+		Name:       job.Name,
+		State:      job.State,
+		Command:    job.Command,
+		ExitStatus: job.ExitStatus,
+	}
+}
+
+func detailJob(job buildkite.Job) JobDetail {
+	var agent *buildkite.Agent
+	if job.Agent.ID != "" {
+		agent = &job.Agent
+	}
+
+	return JobDetail{
+		JobSummary:         summarizeJob(job),
+		ID:                 job.ID,
+		Type:               job.Type,
+		Label:              job.Label,
+		StepKey:            job.StepKey,
+		GroupKey:           job.GroupKey,
+		Signal:             job.Signal,
+		SignalReason:       job.SignalReason,
+		CreatedAt:          job.CreatedAt,
+		StartedAt:          job.StartedAt,
+		FinishedAt:         job.FinishedAt,
+		Agent:              agent,
+		Retried:            job.Retried,
+		RetriedInJobID:     job.RetriedInJobID,
+		RetriesCount:       job.RetriesCount,
+		RetrySource:        job.RetrySource,
+		SoftFailed:         job.SoftFailed,
+		Unblockable:        job.Unblockable,
+		ParallelGroupIndex: job.ParallelGroupIndex,
+		ParallelGroupTotal: job.ParallelGroupTotal,
+	}
+}
+
+func createJobListResult[T any](jobs buildkite.JobsList, converter func(buildkite.Job) T) JobListResult[T] {
+	items := make([]T, len(jobs.Items))
+	for i, job := range jobs.Items {
+		items[i] = converter(job)
+	}
+
+	return JobListResult[T]{Items: items, Links: jobs.Links}
 }
 
 func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_jobs",
-			Description: "List jobs for a Buildkite build, with optional state filtering and cursor-based pagination. Returns an object with 'items' (the jobs) and 'links' containing 'next'/'self' URLs; pass the cursor from 'links.next' back as 'after' to fetch the next page",
+			Description: "List jobs for a Buildkite build, returning a lightweight summary by default. For CI failure diagnosis, use state='failed,broken' to avoid returning successful jobs. Use detail_level='detailed' for job IDs and execution metadata or 'full' for the SDK response. Returns 'items' and cursor pagination 'links'",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Jobs",
 				ReadOnlyHint: true,
@@ -56,6 +143,15 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 			ctx, span := trace.Start(ctx, "buildkite.ListJobs")
 			defer span.End()
 
+			if args.DetailLevel == "" {
+				args.DetailLevel = "summary"
+			}
+			switch args.DetailLevel {
+			case "summary", "detailed", "full":
+			default:
+				return utils.NewToolResultError("detail_level must be 'summary', 'detailed', or 'full'"), nil, nil
+			}
+
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("pipeline_slug", args.PipelineSlug),
@@ -63,6 +159,7 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				attribute.String("state", args.State),
 				attribute.String("step_key", args.StepKey),
 				attribute.String("group_key", args.GroupKey),
+				attribute.String("detail_level", args.DetailLevel),
 				attribute.Int("per_page", args.PerPage),
 			)
 
@@ -94,10 +191,6 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
-			for i := range jobs.Items {
-				redactUnusedJobFields(&jobs.Items[i])
-			}
-
 			if !args.IncludeAgent && len(jobs.Items) > 0 {
 				for i := range jobs.Items {
 					jobs.Items[i].Agent = buildkite.Agent{
@@ -106,7 +199,22 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				}
 			}
 
-			return mcpTextResult(span, &jobs)
+			var result any
+			switch args.DetailLevel {
+			case "summary":
+				result = createJobListResult(jobs, summarizeJob)
+			case "detailed":
+				result = createJobListResult(jobs, detailJob)
+			default: // full
+				for i := range jobs.Items {
+					redactUnusedJobFields(&jobs.Items[i])
+				}
+				result = jobs
+			}
+
+			span.SetAttributes(attribute.Int("item_count", len(jobs.Items)))
+
+			return mcpTextResult(span, &result)
 		}, []string{"read_builds"}
 }
 

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -46,11 +46,14 @@ type ListJobsArgs struct {
 
 // JobSummary contains the fields normally needed to identify a build failure.
 type JobSummary struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	State      string `json:"state"`
-	Command    string `json:"command"`
-	ExitStatus *int   `json:"exit_status"`
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	State        string `json:"state"`
+	Command      string `json:"command"`
+	ExitStatus   *int   `json:"exit_status"`
+	SoftFailed   bool   `json:"soft_failed,omitempty"`
+	SignalReason string `json:"signal_reason,omitempty"`
+	StepKey      string `json:"step_key,omitempty"`
 }
 
 // JobDetail adds actionable job metadata while excluding repeated build,
@@ -59,10 +62,8 @@ type JobDetail struct {
 	JobSummary
 	Type               string                    `json:"type,omitempty"`
 	Label              string                    `json:"label,omitempty"`
-	StepKey            string                    `json:"step_key,omitempty"`
 	GroupKey           string                    `json:"group_key,omitempty"`
 	Signal             *int                      `json:"signal,omitempty"`
-	SignalReason       string                    `json:"signal_reason,omitempty"`
 	CreatedAt          *buildkite.Timestamp      `json:"created_at,omitempty"`
 	StartedAt          *buildkite.Timestamp      `json:"started_at,omitempty"`
 	FinishedAt         *buildkite.Timestamp      `json:"finished_at,omitempty"`
@@ -71,7 +72,6 @@ type JobDetail struct {
 	RetriedInJobID     string                    `json:"retried_in_job_id,omitempty"`
 	RetriesCount       int                       `json:"retries_count,omitempty"`
 	RetrySource        *buildkite.JobRetrySource `json:"retry_source,omitempty"`
-	SoftFailed         bool                      `json:"soft_failed,omitempty"`
 	Unblockable        bool                      `json:"unblockable,omitempty"`
 	ParallelGroupIndex *int                      `json:"parallel_group_index,omitempty"`
 	ParallelGroupTotal *int                      `json:"parallel_group_total,omitempty"`
@@ -84,11 +84,14 @@ type JobListResult[T any] struct {
 
 func summarizeJob(job buildkite.Job) JobSummary {
 	return JobSummary{
-		ID:         job.ID,
-		Name:       job.Name,
-		State:      job.State,
-		Command:    job.Command,
-		ExitStatus: job.ExitStatus,
+		ID:           job.ID,
+		Name:         job.Name,
+		State:        job.State,
+		Command:      job.Command,
+		ExitStatus:   job.ExitStatus,
+		SoftFailed:   job.SoftFailed,
+		SignalReason: job.SignalReason,
+		StepKey:      job.StepKey,
 	}
 }
 
@@ -102,10 +105,8 @@ func detailJob(job buildkite.Job) JobDetail {
 		JobSummary:         summarizeJob(job),
 		Type:               job.Type,
 		Label:              job.Label,
-		StepKey:            job.StepKey,
 		GroupKey:           job.GroupKey,
 		Signal:             job.Signal,
-		SignalReason:       job.SignalReason,
 		CreatedAt:          job.CreatedAt,
 		StartedAt:          job.StartedAt,
 		FinishedAt:         job.FinishedAt,
@@ -114,7 +115,6 @@ func detailJob(job buildkite.Job) JobDetail {
 		RetriedInJobID:     job.RetriedInJobID,
 		RetriesCount:       job.RetriesCount,
 		RetrySource:        job.RetrySource,
-		SoftFailed:         job.SoftFailed,
 		Unblockable:        job.Unblockable,
 		ParallelGroupIndex: job.ParallelGroupIndex,
 		ParallelGroupTotal: job.ParallelGroupTotal,

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -46,6 +46,7 @@ type ListJobsArgs struct {
 
 // JobSummary contains the fields normally needed to identify a build failure.
 type JobSummary struct {
+	ID         string `json:"id"`
 	Name       string `json:"name"`
 	State      string `json:"state"`
 	Command    string `json:"command"`
@@ -56,7 +57,6 @@ type JobSummary struct {
 // cluster, queue, and log URLs from the SDK response.
 type JobDetail struct {
 	JobSummary
-	ID                 string                    `json:"id"`
 	Type               string                    `json:"type,omitempty"`
 	Label              string                    `json:"label,omitempty"`
 	StepKey            string                    `json:"step_key,omitempty"`
@@ -84,6 +84,7 @@ type JobListResult[T any] struct {
 
 func summarizeJob(job buildkite.Job) JobSummary {
 	return JobSummary{
+		ID:         job.ID,
 		Name:       job.Name,
 		State:      job.State,
 		Command:    job.Command,
@@ -99,7 +100,6 @@ func detailJob(job buildkite.Job) JobDetail {
 
 	return JobDetail{
 		JobSummary:         summarizeJob(job),
-		ID:                 job.ID,
 		Type:               job.Type,
 		Label:              job.Label,
 		StepKey:            job.StepKey,
@@ -133,7 +133,7 @@ func createJobListResult[T any](jobs buildkite.JobsList, converter func(buildkit
 func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_jobs",
-			Description: "List jobs for a Buildkite build, returning a lightweight summary by default. For CI failure diagnosis, use state='failed,broken' to avoid returning successful jobs. Use detail_level='detailed' for job IDs and execution metadata or 'full' for the SDK response. Returns 'items' and cursor pagination 'links'",
+			Description: "List jobs for a Buildkite build, returning an actionable summary by default. For CI failure diagnosis, use state='failed,broken' to avoid returning successful jobs. Use detail_level='detailed' for execution metadata or 'full' for the existing full MCP job response. Returns 'items' and cursor pagination 'links'",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Jobs",
 				ReadOnlyHint: true,
@@ -191,7 +191,7 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
-			if !args.IncludeAgent && len(jobs.Items) > 0 {
+			if args.DetailLevel != "summary" && !args.IncludeAgent && len(jobs.Items) > 0 {
 				for i := range jobs.Items {
 					jobs.Items[i].Agent = buildkite.Agent{
 						ID: jobs.Items[i].Agent.ID,

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -46,35 +46,35 @@ type ListJobsArgs struct {
 
 // JobSummary contains the fields normally needed to identify a build failure.
 type JobSummary struct {
-	ID           string `json:"id"`
-	Name         string `json:"name"`
-	State        string `json:"state"`
-	Command      string `json:"command"`
-	ExitStatus   *int   `json:"exit_status"`
-	SoftFailed   bool   `json:"soft_failed,omitempty"`
-	SignalReason string `json:"signal_reason,omitempty"`
-	StepKey      string `json:"step_key,omitempty"`
+	ID           string                    `json:"id"`
+	Name         string                    `json:"name"`
+	State        string                    `json:"state"`
+	Command      string                    `json:"command"`
+	ExitStatus   *int                      `json:"exit_status"`
+	SoftFailed   bool                      `json:"soft_failed,omitempty"`
+	SignalReason string                    `json:"signal_reason,omitempty"`
+	StepKey      string                    `json:"step_key,omitempty"`
+	RetriesCount int                       `json:"retries_count,omitempty"`
+	RetrySource  *buildkite.JobRetrySource `json:"retry_source,omitempty"`
 }
 
 // JobDetail adds actionable job metadata while excluding repeated build,
 // cluster, queue, and log URLs from the SDK response.
 type JobDetail struct {
 	JobSummary
-	Type               string                    `json:"type,omitempty"`
-	Label              string                    `json:"label,omitempty"`
-	GroupKey           string                    `json:"group_key,omitempty"`
-	Signal             *int                      `json:"signal,omitempty"`
-	CreatedAt          *buildkite.Timestamp      `json:"created_at,omitempty"`
-	StartedAt          *buildkite.Timestamp      `json:"started_at,omitempty"`
-	FinishedAt         *buildkite.Timestamp      `json:"finished_at,omitempty"`
-	Agent              *buildkite.Agent          `json:"agent,omitempty"`
-	Retried            bool                      `json:"retried,omitempty"`
-	RetriedInJobID     string                    `json:"retried_in_job_id,omitempty"`
-	RetriesCount       int                       `json:"retries_count,omitempty"`
-	RetrySource        *buildkite.JobRetrySource `json:"retry_source,omitempty"`
-	Unblockable        bool                      `json:"unblockable,omitempty"`
-	ParallelGroupIndex *int                      `json:"parallel_group_index,omitempty"`
-	ParallelGroupTotal *int                      `json:"parallel_group_total,omitempty"`
+	Type               string               `json:"type,omitempty"`
+	Label              string               `json:"label,omitempty"`
+	GroupKey           string               `json:"group_key,omitempty"`
+	Signal             *int                 `json:"signal,omitempty"`
+	CreatedAt          *buildkite.Timestamp `json:"created_at,omitempty"`
+	StartedAt          *buildkite.Timestamp `json:"started_at,omitempty"`
+	FinishedAt         *buildkite.Timestamp `json:"finished_at,omitempty"`
+	Agent              *buildkite.Agent     `json:"agent,omitempty"`
+	Retried            bool                 `json:"retried,omitempty"`
+	RetriedInJobID     string               `json:"retried_in_job_id,omitempty"`
+	Unblockable        bool                 `json:"unblockable,omitempty"`
+	ParallelGroupIndex *int                 `json:"parallel_group_index,omitempty"`
+	ParallelGroupTotal *int                 `json:"parallel_group_total,omitempty"`
 }
 
 type JobListResult[T any] struct {
@@ -92,6 +92,8 @@ func summarizeJob(job buildkite.Job) JobSummary {
 		SoftFailed:   job.SoftFailed,
 		SignalReason: job.SignalReason,
 		StepKey:      job.StepKey,
+		RetriesCount: job.RetriesCount,
+		RetrySource:  job.RetrySource,
 	}
 }
 
@@ -113,8 +115,6 @@ func detailJob(job buildkite.Job) JobDetail {
 		Agent:              agent,
 		Retried:            job.Retried,
 		RetriedInJobID:     job.RetriedInJobID,
-		RetriesCount:       job.RetriesCount,
-		RetrySource:        job.RetrySource,
 		Unblockable:        job.Unblockable,
 		ParallelGroupIndex: job.ParallelGroupIndex,
 		ParallelGroupTotal: job.ParallelGroupTotal,

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -76,6 +76,10 @@ func testJobAgent() buildkite.Agent {
 	}
 }
 
+func intPtr(value int) *int {
+	return &value
+}
+
 func TestUnblockJob(t *testing.T) {
 	// Test tool definition
 	t.Run("ToolDefinition", func(t *testing.T) {
@@ -330,7 +334,7 @@ func TestListJobs(t *testing.T) {
 				assert.Equal(t, "test-pipeline", pipeline)
 				assert.Equal(t, "123", buildNumber)
 				return buildkite.JobsList{
-					Items: []buildkite.Job{{ID: "job-1", State: "passed"}},
+					Items: []buildkite.Job{{ID: "job-1", Name: "test", State: "passed", Command: "go test ./...", ExitStatus: intPtr(0)}},
 					Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/v2/...?after=cursor2"},
 				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
 			},
@@ -354,7 +358,9 @@ func TestListJobs(t *testing.T) {
 
 		text := getTextResult(t, result).Text
 		assert.Contains(t, text, `"items":[`)
-		assert.Contains(t, text, `"id":"job-1"`)
+		assert.Contains(t, text, `"name":"test"`)
+		assert.Contains(t, text, `"command":"go test ./..."`)
+		assert.NotContains(t, text, `"id":"job-1"`)
 		assert.Contains(t, text, `"next":"https://api.buildkite.com`)
 
 		require.NotNil(t, captured)
@@ -365,6 +371,65 @@ func TestListJobs(t *testing.T) {
 		assert.False(t, *captured.IncludeRetriedJobs)
 		assert.Equal(t, 50, captured.PerPage)
 		assert.Equal(t, "cursor1", captured.After)
+	})
+
+	t.Run("SummaryContainsOnlyDiagnosticFields", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{Items: []buildkite.Job{{
+					ID:              "job-1",
+					Name:            "test",
+					State:           "failed",
+					Command:         "go test ./...",
+					ExitStatus:      intPtr(1),
+					BuildURL:        "https://api.buildkite.com/v2/builds/123",
+					ClusterID:       "cluster-1",
+					ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1",
+				}}}, &buildkite.Response{}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug: "test-org", PipelineSlug: "test-pipeline", BuildNumber: "123",
+		})
+		require.NoError(t, err)
+
+		var response struct {
+			Items []map[string]any `json:"items"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &response))
+		require.Len(t, response.Items, 1)
+		assert.Equal(t, map[string]any{
+			"name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
+		}, response.Items[0])
+	})
+
+	t.Run("DetailedExcludesRepeatedInfrastructureFields", func(t *testing.T) {
+		mockJobs := &MockJobsClient{
+			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{Items: []buildkite.Job{{
+					ID: "job-1", Name: "test", State: "failed", Command: "go test ./...",
+					BuildURL: "https://api.buildkite.com/v2/builds/123", ClusterID: "cluster-1",
+					ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1", AgentQueryRules: []string{"queue=test"},
+				}}}, &buildkite.Response{}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+		_, handler, _ := ListJobs()
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug: "test-org", PipelineSlug: "test-pipeline", BuildNumber: "123", DetailLevel: "detailed",
+		})
+		require.NoError(t, err)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(t, text, `"id":"job-1"`)
+		assert.NotContains(t, text, "build_url")
+		assert.NotContains(t, text, "cluster_id")
+		assert.NotContains(t, text, "cluster_queue_url")
+		assert.NotContains(t, text, "agent_query_rules")
 	})
 
 	t.Run("RedactsUnusedJobFields", func(t *testing.T) {
@@ -392,6 +457,7 @@ func TestListJobs(t *testing.T) {
 			OrgSlug:      "test-org",
 			PipelineSlug: "test-pipeline",
 			BuildNumber:  "123",
+			DetailLevel:  "full",
 		})
 		require.NoError(t, err)
 
@@ -428,6 +494,7 @@ func TestListJobs(t *testing.T) {
 			OrgSlug:      "test-org",
 			PipelineSlug: "test-pipeline",
 			BuildNumber:  "123",
+			DetailLevel:  "full",
 		})
 		require.NoError(t, err)
 
@@ -460,6 +527,7 @@ func TestListJobs(t *testing.T) {
 			OrgSlug:      "test-org",
 			PipelineSlug: "test-pipeline",
 			BuildNumber:  "123",
+			DetailLevel:  "full",
 			IncludeAgent: true,
 		})
 		require.NoError(t, err)
@@ -468,6 +536,17 @@ func TestListJobs(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
 		require.Len(t, jobs.Items, 1)
 		assert.Equal(t, testJobAgent(), jobs.Items[0].Agent)
+	})
+
+	t.Run("InvalidDetailLevel", func(t *testing.T) {
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: &MockJobsClient{}})
+		_, handler, _ := ListJobs()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+			OrgSlug: "test-org", PipelineSlug: "test-pipeline", BuildNumber: "123", DetailLevel: "verbose",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, getTextResult(t, result).Text, "detail_level must be 'summary', 'detailed', or 'full'")
 	})
 
 	t.Run("AfterAndBeforeMutuallyExclusive", func(t *testing.T) {

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -360,7 +361,7 @@ func TestListJobs(t *testing.T) {
 		assert.Contains(t, text, `"items":[`)
 		assert.Contains(t, text, `"name":"test"`)
 		assert.Contains(t, text, `"command":"go test ./..."`)
-		assert.NotContains(t, text, `"id":"job-1"`)
+		assert.Contains(t, text, `"id":"job-1"`)
 		assert.Contains(t, text, `"next":"https://api.buildkite.com`)
 
 		require.NotNil(t, captured)
@@ -402,18 +403,29 @@ func TestListJobs(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &response))
 		require.Len(t, response.Items, 1)
 		assert.Equal(t, map[string]any{
-			"name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
+			"id": "job-1", "name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
 		}, response.Items[0])
 	})
 
 	t.Run("DetailedExcludesRepeatedInfrastructureFields", func(t *testing.T) {
+		timestamp := buildkite.NewTimestamp(time.Date(2026, 7, 17, 6, 46, 58, 0, time.UTC))
 		mockJobs := &MockJobsClient{
 			ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
-				return buildkite.JobsList{Items: []buildkite.Job{{
-					ID: "job-1", Name: "test", State: "failed", Command: "go test ./...",
-					BuildURL: "https://api.buildkite.com/v2/builds/123", ClusterID: "cluster-1",
-					ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1", AgentQueryRules: []string{"queue=test"},
-				}}}, &buildkite.Response{}, nil
+				return buildkite.JobsList{
+					Items: []buildkite.Job{{
+						ID: "job-1", Name: "test", State: "failed", Command: "go test ./...",
+						CreatedAt: timestamp, StartedAt: timestamp, FinishedAt: timestamp,
+						Signal: intPtr(9), SignalReason: "agent_stop", Retried: true,
+						RetriedInJobID: "job-2", RetriesCount: 1,
+						RetrySource:        &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"},
+						SoftFailed:         true,
+						Unblockable:        true,
+						ParallelGroupIndex: intPtr(1), ParallelGroupTotal: intPtr(3),
+						BuildURL: "https://api.buildkite.com/v2/builds/123", ClusterID: "cluster-1",
+						ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1", AgentQueryRules: []string{"queue=test"},
+					}},
+					Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/v2/jobs?after=next"},
+				}, &buildkite.Response{}, nil
 			},
 		}
 
@@ -425,11 +437,62 @@ func TestListJobs(t *testing.T) {
 		require.NoError(t, err)
 
 		text := getTextResult(t, result).Text
-		assert.Contains(t, text, `"id":"job-1"`)
+		var jobs JobListResult[JobDetail]
+		require.NoError(t, json.Unmarshal([]byte(text), &jobs))
+		require.Len(t, jobs.Items, 1)
+		job := jobs.Items[0]
+		assert.Equal(t, "job-1", job.ID)
+		assert.Equal(t, timestamp, job.CreatedAt)
+		assert.Equal(t, timestamp, job.StartedAt)
+		assert.Equal(t, timestamp, job.FinishedAt)
+		assert.Equal(t, intPtr(9), job.Signal)
+		assert.Equal(t, "agent_stop", job.SignalReason)
+		assert.True(t, job.Retried)
+		assert.Equal(t, "job-2", job.RetriedInJobID)
+		assert.Equal(t, 1, job.RetriesCount)
+		assert.Equal(t, &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"}, job.RetrySource)
+		assert.True(t, job.SoftFailed)
+		assert.True(t, job.Unblockable)
+		assert.Equal(t, intPtr(1), job.ParallelGroupIndex)
+		assert.Equal(t, intPtr(3), job.ParallelGroupTotal)
+		assert.Equal(t, buildkite.JobsListLink("https://api.buildkite.com/v2/jobs?after=next"), jobs.Links.Next)
 		assert.NotContains(t, text, "build_url")
 		assert.NotContains(t, text, "cluster_id")
 		assert.NotContains(t, text, "cluster_queue_url")
 		assert.NotContains(t, text, "agent_query_rules")
+	})
+
+	t.Run("DetailedAgentFields", func(t *testing.T) {
+		for _, test := range []struct {
+			name         string
+			includeAgent bool
+			want         buildkite.Agent
+		}{
+			{name: "IDOnlyByDefault", want: buildkite.Agent{ID: "agent-1"}},
+			{name: "FullDetailsWhenRequested", includeAgent: true, want: testJobAgent()},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				mockJobs := &MockJobsClient{
+					ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+						return buildkite.JobsList{Items: []buildkite.Job{{ID: "job-1", Agent: testJobAgent()}}}, &buildkite.Response{}, nil
+					},
+				}
+
+				ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+				_, handler, _ := ListJobs()
+				result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+					OrgSlug: "test-org", PipelineSlug: "test-pipeline", BuildNumber: "123",
+					DetailLevel: "detailed", IncludeAgent: test.includeAgent,
+				})
+				require.NoError(t, err)
+
+				var jobs JobListResult[JobDetail]
+				require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
+				require.Len(t, jobs.Items, 1)
+				require.NotNil(t, jobs.Items[0].Agent)
+				assert.Equal(t, test.want, *jobs.Items[0].Agent)
+			})
+		}
 	})
 
 	t.Run("RedactsUnusedJobFields", func(t *testing.T) {

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -383,6 +383,9 @@ func TestListJobs(t *testing.T) {
 					State:           "failed",
 					Command:         "go test ./...",
 					ExitStatus:      intPtr(1),
+					SoftFailed:      true,
+					SignalReason:    "agent_stop",
+					StepKey:         "test",
 					BuildURL:        "https://api.buildkite.com/v2/builds/123",
 					ClusterID:       "cluster-1",
 					ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1",
@@ -404,6 +407,7 @@ func TestListJobs(t *testing.T) {
 		require.Len(t, response.Items, 1)
 		assert.Equal(t, map[string]any{
 			"id": "job-1", "name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
+			"soft_failed": true, "signal_reason": "agent_stop", "step_key": "test",
 		}, response.Items[0])
 	})
 

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -386,6 +386,8 @@ func TestListJobs(t *testing.T) {
 					SoftFailed:      true,
 					SignalReason:    "agent_stop",
 					StepKey:         "test",
+					RetriesCount:    1,
+					RetrySource:     &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"},
 					BuildURL:        "https://api.buildkite.com/v2/builds/123",
 					ClusterID:       "cluster-1",
 					ClusterQueueURL: "https://api.buildkite.com/v2/queues/queue-1",
@@ -408,6 +410,7 @@ func TestListJobs(t *testing.T) {
 		assert.Equal(t, map[string]any{
 			"id": "job-1", "name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
 			"soft_failed": true, "signal_reason": "agent_stop", "step_key": "test",
+			"retries_count": float64(1), "retry_source": map[string]any{"job_id": "job-0", "retry_type": "manual"},
 		}, response.Items[0])
 	})
 

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -230,7 +230,7 @@ func TestListPipelinesArgsSchema(t *testing.T) {
 	}
 }
 
-func TestListJobsArgsSchema(t *testing.T) {
+func TestListJobsArgsSchemaFilters(t *testing.T) {
 	s := schemaFor[ListJobsArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[ListJobsArgs](t))
 
@@ -250,6 +250,17 @@ func TestUnblockJobArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"fields"} {
+		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
+	}
+}
+
+func TestListJobsArgsSchemaOptionalFields(t *testing.T) {
+	s := schemaFor[ListJobsArgs](t)
+	req := slices.Clone(s.Required)
+	slices.Sort(req)
+	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
+
+	for _, opt := range []string{"state", "detail_level", "include_retried_jobs", "per_page", "after", "before", "include_agent"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
 }


### PR DESCRIPTION
- add summary, detailed, and full response levels
- default to four-field job summaries for lower token usage
- omit repeated infrastructure metadata from detailed responses
- recommend failed and broken state filters for CI triage
- cover response shapes, validation, and full-mode compatibility
