### PR TITLE
feat: add list_skills/load_skill tools for discoverable usage guides

### DIFF
--- a/pkg/buildkite/agents.go
+++ b/pkg/buildkite/agents.go
@@ -21,14 +21,14 @@ type ListAgentsArgs struct {
 	Hostname    string `json:"hostname,omitempty"`
 	Version     string `json:"version,omitempty"`
 	Page        int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage     int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
-	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default)\\, 'detailed'\\, or 'full'"`
+	PerPage     int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default), 'detailed', or 'full'"`
 }
 
 type GetAgentArgs struct {
 	OrgSlug     string `json:"org_slug"`
 	AgentID     string `json:"agent_id"`
-	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary'\\, 'detailed'\\, or 'full' (default)"`
+	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary', 'detailed', or 'full' (default)"`
 }
 
 type AgentJobSummary struct {

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -31,7 +31,7 @@ type ListAnnotationsArgs struct {
 	Scope        string `json:"scope,omitempty" jsonschema:"Annotation scope: 'build' (default) or 'job'. When 'job', job_id is required."`
 	JobID        string `json:"job_id,omitempty" jsonschema:"Job ID required when scope is job"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type CreateAnnotationArgs struct {

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -237,7 +237,7 @@ type ListArtifactsForBuildArgs struct {
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type ListArtifactsForJobArgs struct {
@@ -246,7 +246,7 @@ type ListArtifactsForJobArgs struct {
 	BuildNumber  string `json:"build_number"`
 	JobID        string `json:"job_id"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type GetArtifactArgs struct {

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -66,13 +66,13 @@ type BuildDetail struct {
 // ListBuildsArgs struct with enhanced filtering
 type ListBuildsArgs struct {
 	OrgSlug      string `json:"org_slug"`
-	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Filter builds by pipeline. When omitted\\, lists builds across all pipelines in the organization"`
+	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Filter builds by pipeline. When omitted, lists builds across all pipelines in the organization"`
 	Branch       string `json:"branch,omitempty" jsonschema:"Filter builds by git branch name"`
-	State        string `json:"state,omitempty" jsonschema:"Filter builds by state (scheduled\\, running\\, passed\\, failed\\, canceled\\, skipped)"`
+	State        string `json:"state,omitempty" jsonschema:"Filter builds by state (scheduled, running, passed, failed, canceled, skipped)"`
 	Commit       string `json:"commit,omitempty" jsonschema:"Filter builds by specific commit SHA"`
 	Creator      string `json:"creator,omitempty" jsonschema:"Filter builds by build creator"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 // GetBuildArgs struct

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -22,7 +22,7 @@ type ListClusterQueuesArgs struct {
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage   int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage   int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type GetClusterQueueArgs struct {

--- a/pkg/buildkite/clusters.go
+++ b/pkg/buildkite/clusters.go
@@ -19,7 +19,7 @@ type ClustersClient interface {
 type ListClustersArgs struct {
 	OrgSlug string `json:"org_slug"`
 	Page    int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type GetClusterArgs struct {

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -33,15 +33,15 @@ type ListJobsArgs struct {
 	OrgSlug            string `json:"org_slug"`
 	PipelineSlug       string `json:"pipeline_slug"`
 	BuildNumber        string `json:"build_number"`
-	State              string `json:"state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g.\\, 'passed\\,failed\\,running')"`
+	State              string `json:"state,omitempty" jsonschema:"Filter jobs by state. Comma-separated for multiple states (e.g., 'passed,failed,running')"`
 	StepKey            string `json:"step_key,omitempty" jsonschema:"Filter jobs by step key. Includes all parallel jobs for the step"`
 	GroupKey           string `json:"group_key,omitempty" jsonschema:"Filter jobs by group key. Includes all jobs in the group"`
-	DetailLevel        string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default)\\, 'detailed'\\, or 'full'"`
+	DetailLevel        string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default), 'detailed', or 'full'"`
 	IncludeRetriedJobs *bool  `json:"include_retried_jobs,omitempty" jsonschema:"Include retried jobs in the response. Defaults to true on the server when omitted"`
-	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1\\, max 100\\, default 30)"`
+	PerPage            int    `json:"per_page,omitempty" jsonschema:"Results per page for cursor pagination (min 1, max 100, default 30)"`
 	After              string `json:"after,omitempty" jsonschema:"Cursor for the next page. Take this from the 'links.next' URL of a previous response. Mutually exclusive with 'before'"`
 	Before             string `json:"before,omitempty" jsonschema:"Cursor for the previous page. Take this from a previous response. Mutually exclusive with 'after'"`
-	IncludeAgent       bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details at the detailed and full levels. When false (default)\\, detailed and full responses include only agent.id"`
+	IncludeAgent       bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details at the detailed and full levels. When false (default), detailed and full responses include only agent.id"`
 }
 
 // JobSummary contains the fields normally needed to identify a build failure.
@@ -224,7 +224,7 @@ type GetJobArgs struct {
 	JobID        string `json:"job_id"`
 	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Pipeline slug. Provide together with 'build_number' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
 	BuildNumber  string `json:"build_number,omitempty" jsonschema:"Build number. Provide together with 'pipeline_slug' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
-	IncludeAgent bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default)\\, only agent.id is included"`
+	IncludeAgent bool   `json:"include_agent,omitempty" jsonschema:"Include full agent details in job objects. When false (default), only agent.id is included"`
 }
 
 func GetJob() (mcp.Tool, mcp.ToolHandlerFor[GetJobArgs, any], []string) {

--- a/pkg/buildkite/pipeline_schedules.go
+++ b/pkg/buildkite/pipeline_schedules.go
@@ -20,7 +20,7 @@ type ListPipelineSchedulesArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 func ListPipelineSchedules() (mcp.Tool, mcp.ToolHandlerFor[ListPipelineSchedulesArgs, any], []string) {
@@ -104,7 +104,7 @@ func GetPipelineSchedule() (mcp.Tool, mcp.ToolHandlerFor[GetPipelineScheduleArgs
 type CreatePipelineScheduleArgs struct {
 	OrgSlug      string            `json:"org_slug"`
 	PipelineSlug string            `json:"pipeline_slug"`
-	Cronline     string            `json:"cronline" jsonschema:"Schedule interval as a crontab expression (e.g. '0 0 * * *') or predefined value (e.g. '@daily'\\, '@hourly'\\, '@weekly'\\, '@monthly'\\, '@yearly')"`
+	Cronline     string            `json:"cronline" jsonschema:"Schedule interval as a crontab expression (e.g. '0 0 * * *') or predefined value (e.g. '@daily', '@hourly', '@weekly', '@monthly', '@yearly')"`
 	Label        string            `json:"label,omitempty" jsonschema:"Descriptive label for the schedule"`
 	Message      string            `json:"message,omitempty" jsonschema:"Message attached to triggered builds"`
 	Commit       string            `json:"commit,omitempty" jsonschema:"Commit reference (defaults to HEAD)"`

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -22,8 +22,8 @@ type ListPipelinesArgs struct {
 	Name        string `json:"name,omitempty" jsonschema:"Filter pipelines by name"`
 	Repository  string `json:"repository,omitempty" jsonschema:"Filter pipelines by repository URL"`
 	Page        int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage     int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
-	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default)\\, 'detailed'\\, or 'full'"`
+	PerPage     int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default), 'detailed', or 'full'"`
 }
 
 type CreatePipelineResult struct {
@@ -105,7 +105,7 @@ func ListPipelines() (mcp.Tool, mcp.ToolHandlerFor[ListPipelinesArgs, any], []st
 type GetPipelineArgs struct {
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
-	DetailLevel  string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary'\\, 'detailed'\\, or 'full' (default)"`
+	DetailLevel  string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary', 'detailed', or 'full' (default)"`
 }
 
 func GetPipeline() (mcp.Tool, mcp.ToolHandlerFor[GetPipelineArgs, any], []string) {

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -320,3 +320,14 @@ func TestGetBuildTestEngineRunsArgsSchema(t *testing.T) {
 	req := sortedRequired[GetBuildTestEngineRunsArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 }
+
+func TestListSkillsArgsSchema(t *testing.T) {
+	s := schemaFor[ListSkillsArgs](t)
+	require.Empty(t, s.Required)
+	require.Contains(t, s.Properties, "query")
+}
+
+func TestLoadSkillArgsSchema(t *testing.T) {
+	req := sortedRequired[LoadSkillArgs](t)
+	require.Equal(t, []string{"skill_name"}, req)
+}

--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -58,7 +58,7 @@ func ListSkills() (mcp.Tool, mcp.ToolHandlerFor[ListSkillsArgs, any], []string) 
 }
 
 type LoadSkillArgs struct {
-	SkillName string `json:"skill_name" jsonschema:"Name of the skill to load\\, as returned by list_skills"`
+	SkillName string `json:"skill_name" jsonschema:"Name of the skill to load, as returned by list_skills"`
 }
 
 func LoadSkill() (mcp.Tool, mcp.ToolHandlerFor[LoadSkillArgs, any], []string) {
@@ -74,15 +74,18 @@ func LoadSkill() (mcp.Tool, mcp.ToolHandlerFor[LoadSkillArgs, any], []string) {
 			defer span.End()
 
 			var match *skill
-			names := make([]string, 0, len(skillRegistry))
 			for i := range skillRegistry {
-				names = append(names, skillRegistry[i].Name)
 				if skillRegistry[i].Name == args.SkillName {
 					match = &skillRegistry[i]
+					break
 				}
 			}
 
 			if match == nil {
+				names := make([]string, len(skillRegistry))
+				for i := range skillRegistry {
+					names[i] = skillRegistry[i].Name
+				}
 				return utils.NewToolResultError(fmt.Sprintf("unknown skill %q, valid skills are: %s", args.SkillName, strings.Join(names, ", "))), nil, nil
 			}
 

--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -1,0 +1,96 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type skill struct {
+	Name        string
+	Description string
+	Path        string // path within resourcesFS
+}
+
+var skillRegistry = []skill{
+	{
+		Name:        "debug-logs-guide",
+		Description: "How to debug Buildkite build failures using tail_logs, search_logs, and read_logs — including failed vs broken job semantics and token-efficient investigation workflow.",
+		Path:        "resources/debug-logs-guide.md",
+	},
+}
+
+type skillSummary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type ListSkillsArgs struct {
+	Query string `json:"query,omitempty" jsonschema:"Optional case-insensitive filter over skill name and description"`
+}
+
+func ListSkills() (mcp.Tool, mcp.ToolHandlerFor[ListSkillsArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_skills",
+			Description: "List available skill guides that document usage patterns, pitfalls, and workflows for Buildkite MCP tools",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Skill Guides",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListSkillsArgs) (*mcp.CallToolResult, any, error) {
+			_, span := trace.Start(ctx, "buildkite.ListSkills")
+			defer span.End()
+
+			results := []skillSummary{}
+			query := strings.ToLower(args.Query)
+			for _, s := range skillRegistry {
+				if query == "" || strings.Contains(strings.ToLower(s.Name), query) || strings.Contains(strings.ToLower(s.Description), query) {
+					results = append(results, skillSummary{Name: s.Name, Description: s.Description})
+				}
+			}
+
+			return mcpTextResult(span, results)
+		}, []string{}
+}
+
+type LoadSkillArgs struct {
+	SkillName string `json:"skill_name" jsonschema:"Name of the skill to load\\, as returned by list_skills"`
+}
+
+func LoadSkill() (mcp.Tool, mcp.ToolHandlerFor[LoadSkillArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "load_skill",
+			Description: "Load the full content of a skill guide by name",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Load Skill Guide",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args LoadSkillArgs) (*mcp.CallToolResult, any, error) {
+			_, span := trace.Start(ctx, "buildkite.LoadSkill")
+			defer span.End()
+
+			var match *skill
+			names := make([]string, 0, len(skillRegistry))
+			for i := range skillRegistry {
+				names = append(names, skillRegistry[i].Name)
+				if skillRegistry[i].Name == args.SkillName {
+					match = &skillRegistry[i]
+				}
+			}
+
+			if match == nil {
+				return utils.NewToolResultError(fmt.Sprintf("unknown skill %q, valid skills are: %s", args.SkillName, strings.Join(names, ", "))), nil, nil
+			}
+
+			content, err := resourcesFS.ReadFile(match.Path)
+			if err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to read skill %q: %v", args.SkillName, err)), nil, nil
+			}
+
+			return utils.NewToolResultText(string(content)), nil, nil
+		}, []string{}
+}

--- a/pkg/buildkite/skills_test.go
+++ b/pkg/buildkite/skills_test.go
@@ -1,0 +1,84 @@
+package buildkite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListSkills(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no query returns all skills", func(t *testing.T) {
+		assert := require.New(t)
+
+		tool, handler, _ := ListSkills()
+		assert.NotNil(tool)
+		assert.NotNil(handler)
+
+		request := createMCPRequest(t, map[string]any{})
+		result, _, err := handler(ctx, request, ListSkillsArgs{})
+		assert.NoError(err)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(textContent.Text, "debug-logs-guide")
+	})
+
+	t.Run("query filters by substring case-insensitively", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, handler, _ := ListSkills()
+		request := createMCPRequest(t, map[string]any{"query": "DEBUG"})
+		result, _, err := handler(ctx, request, ListSkillsArgs{Query: "DEBUG"})
+		assert.NoError(err)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(textContent.Text, "debug-logs-guide")
+	})
+
+	t.Run("query matching nothing returns empty list", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, handler, _ := ListSkills()
+		request := createMCPRequest(t, map[string]any{"query": "nonexistent-skill-xyz"})
+		result, _, err := handler(ctx, request, ListSkillsArgs{Query: "nonexistent-skill-xyz"})
+		assert.NoError(err)
+
+		textContent := getTextResult(t, result)
+		assert.JSONEq(`[]`, textContent.Text)
+	})
+}
+
+func TestLoadSkill(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("known name returns file content", func(t *testing.T) {
+		assert := require.New(t)
+
+		tool, handler, _ := LoadSkill()
+		assert.NotNil(tool)
+		assert.NotNil(handler)
+
+		request := createMCPRequest(t, map[string]any{"skill_name": "debug-logs-guide"})
+		result, _, err := handler(ctx, request, LoadSkillArgs{SkillName: "debug-logs-guide"})
+		assert.NoError(err)
+		assert.False(result.IsError)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(textContent.Text, "broken")
+	})
+
+	t.Run("unknown name returns error mentioning valid names", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, handler, _ := LoadSkill()
+		request := createMCPRequest(t, map[string]any{"skill_name": "nonexistent-skill"})
+		result, _, err := handler(ctx, request, LoadSkillArgs{SkillName: "nonexistent-skill"})
+		assert.NoError(err)
+		assert.True(result.IsError)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(textContent.Text, "debug-logs-guide")
+	})
+}

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -19,7 +19,7 @@ type GetFailedTestExecutionsArgs struct {
 	RunID                  string `json:"run_id"`
 	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded failure details such as full error messages and stack traces"`
 	Page                   int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage                int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage                int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 func GetFailedTestExecutions() (mcp.Tool, mcp.ToolHandlerFor[GetFailedTestExecutionsArgs, any], []string) {

--- a/pkg/buildkite/test_runs.go
+++ b/pkg/buildkite/test_runs.go
@@ -23,7 +23,7 @@ type ListTestRunsArgs struct {
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	Page          int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage       int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1\\, max 100)"`
+	PerPage       int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type GetTestRunArgs struct {

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -68,6 +68,8 @@ Start here: Before using most tools, call user_token_organization to retrieve th
 
 Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation.
 
+For task-specific guidance beyond these pitfalls, call list_skills to see available guides, then load_skill to read one.
+
 Common pitfalls:
 
 build_number is a sequential integer string (e.g. "42"), not a UUID. Build, job, artifact, and log tools all require this identifier — do not use the build's UUID id field.
@@ -75,8 +77,6 @@ build_number is a sequential integer string (e.g. "42"), not a UUID. Build, job,
 Job state "broken" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.
 
 Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.
-
-Before debugging logs or investigating build failures, call list_skills to discover usage guides, then load_skill to read one.
 
 Annotation scope: when creating an annotation with scope "job", job_id is required. If job_id is provided but scope is left as the default "build", the job_id is silently ignored.`
 

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -76,6 +76,8 @@ Job state "broken" means the job did not run because something inside the build 
 
 Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.
 
+Before debugging logs or investigating build failures, call list_skills to discover usage guides, then load_skill to read one.
+
 Annotation scope: when creating an annotation with scope "job", job_id is required. If job_id is provided but scope is left as the default "build", the job_id is silently ignored.`
 
 // NewMCPServer creates a new MCP server with the given configuration

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -242,6 +242,7 @@ const (
 	ToolsetTests       = "tests"
 	ToolsetAnnotations = "annotations"
 	ToolsetUser        = "user"
+	ToolsetSkills      = "skills"
 )
 
 var ValidToolsets = []string{
@@ -255,6 +256,7 @@ var ValidToolsets = []string{
 	ToolsetTests,
 	ToolsetAnnotations,
 	ToolsetUser,
+	ToolsetSkills,
 }
 
 // IsValidToolset checks if a toolset name is valid
@@ -392,6 +394,14 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.CurrentUser),
 				newToolDef(buildkite.UserTokenOrganization),
 				newToolDef(buildkite.AccessToken),
+			},
+		},
+		ToolsetSkills: {
+			Name:        "Skill Guides",
+			Description: "Discover and load usage guides for Buildkite MCP tools",
+			Tools: []ToolDefinition{
+				newToolDef(buildkite.ListSkills),
+				newToolDef(buildkite.LoadSkill),
 			},
 		},
 	}

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -584,6 +584,7 @@ func TestIsValidToolset(t *testing.T) {
 		{"valid toolset - tests", "tests", true},
 		{"valid toolset - annotations", "annotations", true},
 		{"valid toolset - user", "user", true},
+		{"valid toolset - skills", "skills", true},
 		{"invalid toolset", "invalid", false},
 		{"empty string", "", false},
 	}
@@ -629,7 +630,7 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	registry.RegisterToolsets(builtin)
 
 	// Check that expected toolsets are registered
-	expectedToolsets := []string{"clusters", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "user"}
+	expectedToolsets := []string{"clusters", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "user", "skills"}
 	for _, name := range expectedToolsets {
 		_, exists := registry.Get(name)
 		assert.True(exists, "expected toolset %s to be registered", name)


### PR DESCRIPTION
This PR adds two new tools: `list_skills` and `load_skill`.

The tools help an agent find and read usage guides for the Buildkite MCP tools.

Many MCP clients do not read passive resources on their own. A guide is easier to find as a tool call.

The first skill uses the existing debug-logs-guide. This guide already existed as an MCP resource. The guide explains how to debug a build failure with the log tools. This PR does not change the text of the guide. This PR only adds a new way to find and load it.

## Changes

- Add a new toolset named `skills`. The `all` toolset includes this new toolset.
- Add `list_skills`. This tool lists all skills. A user can filter the list with a query string.
- Add `load_skill`. This tool returns the full text of one skill.
- Add one line to the server instructions. The line tells an agent to call `list_skills` before it debugs a build failure.
- Remove an old pattern from the tool descriptions. The old pattern put a backslash before a comma. This pattern did not work as planned. It left a stray backslash in the text shown to the agent. Remove this pattern from every tool argument in the code base.