### PR TITLE
fix: strengthen skill discovery instructions and export them

### DIFF
--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -65,9 +65,12 @@ func unauthorizedMiddleware(cb func()) mcp.Middleware {
 
 // instructionSection is one paragraph of the server instructions, optionally
 // gated on a toolset being enabled. An empty toolset means always included.
+// writeOnly marks a paragraph that describes a write-only operation, excluded
+// whenever read-only mode is active regardless of toolset.
 type instructionSection struct {
-	toolset string
-	text    string
+	toolset   string
+	writeOnly bool
+	text      string
 }
 
 var instructionSections = []instructionSection{
@@ -91,19 +94,23 @@ var instructionSections = []instructionSection{
 		text:    "Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.",
 	},
 	{
-		toolset: toolsets.ToolsetAnnotations,
-		text:    "Annotation scope: when creating an annotation with scope \"job\", job_id is required. If job_id is provided but scope is left as the default \"build\", the job_id is silently ignored.",
+		toolset:   toolsets.ToolsetAnnotations,
+		writeOnly: true,
+		text:      "Annotation scope: when creating an annotation with scope \"job\", job_id is required. If job_id is provided but scope is left as the default \"build\", the job_id is silently ignored.",
 	},
 }
 
 // BuildkiteServerInstructions builds the instructions sent to MCP clients
 // describing how to use this server's tools, including only the paragraphs
-// relevant to enabledToolsets. Exported so other services embedding or
-// re-implementing Buildkite MCP tools (e.g. custom/internal MCP servers) can
-// reuse the same guidance instead of maintaining their own copy.
-func BuildkiteServerInstructions(enabledToolsets []string) string {
+// relevant to enabledToolsets and readOnly mode. Exported so other services
+// embedding or re-implementing Buildkite MCP tools (e.g. custom/internal MCP
+// servers) can reuse the same guidance instead of maintaining their own copy.
+func BuildkiteServerInstructions(enabledToolsets []string, readOnly bool) string {
 	parts := make([]string, 0, len(instructionSections))
 	for _, s := range instructionSections {
+		if s.writeOnly && readOnly {
+			continue
+		}
 		if s.toolset == "" || toolsets.IsToolsetEnabled(enabledToolsets, s.toolset) {
 			parts = append(parts, s.text)
 		}
@@ -126,7 +133,7 @@ func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...Tools
 		Name:    "buildkite-mcp-server",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: BuildkiteServerInstructions(cfg.EnabledToolsets),
+		Instructions: BuildkiteServerInstructions(cfg.EnabledToolsets, cfg.ReadOnly),
 	})
 
 	log.Info().Str("version", version).Msg("Starting Buildkite MCP server")

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
 	"github.com/buildkite/buildkite-mcp-server/pkg/toolsets"
@@ -62,27 +63,53 @@ func unauthorizedMiddleware(cb func()) mcp.Middleware {
 	}
 }
 
-// BuildkiteServerInstructions are the instructions sent to MCP clients describing
-// how to use this server's tools. Exported so other services embedding or
+// instructionSection is one paragraph of the server instructions, optionally
+// gated on a toolset being enabled. An empty toolset means always included.
+type instructionSection struct {
+	toolset string
+	text    string
+}
+
+var instructionSections = []instructionSection{
+	{text: "This is the Buildkite MCP Server. It provides access to the Buildkite CI/CD API, enabling you to manage and inspect pipelines, builds, jobs, logs, clusters, tests, artifacts, and annotations."},
+	{
+		toolset: toolsets.ToolsetUser,
+		text:    "Start here: Before using most tools, call user_token_organization to retrieve the organization slug. Nearly every other tool requires the org_slug parameter, and this call is the fastest way to discover it.",
+	},
+	{
+		toolset: toolsets.ToolsetSkills,
+		text:    "Skill discovery: Always call list_skills early in a session — it's cheap (names and one-line descriptions only) and surfaces guidance not visible in any tool's name or schema. When a task matches a listed skill (e.g. debugging a build failure, tuning search_logs), call load_skill for that guide — it covers parameter tuning, caching behavior, and details beyond the summaries below.",
+	},
+	{text: "Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation."},
+	{text: "Common pitfalls:\n\nbuild_number is a sequential integer string (e.g. \"42\"), not a UUID. Build, job, artifact, and log tools all require this identifier — do not use the build's UUID id field."},
+	{
+		toolset: toolsets.ToolsetBuilds,
+		text:    "Job state \"broken\" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.",
+	},
+	{
+		toolset: toolsets.ToolsetLogs,
+		text:    "Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.",
+	},
+	{
+		toolset: toolsets.ToolsetAnnotations,
+		text:    "Annotation scope: when creating an annotation with scope \"job\", job_id is required. If job_id is provided but scope is left as the default \"build\", the job_id is silently ignored.",
+	},
+}
+
+// BuildkiteServerInstructions builds the instructions sent to MCP clients
+// describing how to use this server's tools, including only the paragraphs
+// relevant to enabledToolsets. Exported so other services embedding or
 // re-implementing Buildkite MCP tools (e.g. custom/internal MCP servers) can
 // reuse the same guidance instead of maintaining their own copy.
-const BuildkiteServerInstructions = `This is the Buildkite MCP Server. It provides access to the Buildkite CI/CD API, enabling you to manage and inspect pipelines, builds, jobs, logs, clusters, tests, artifacts, and annotations.
-
-Start here: Before using most tools, call user_token_organization to retrieve the organization slug. Nearly every other tool requires the org_slug parameter, and this call is the fastest way to discover it.
-
-Skill discovery: Always call list_skills early in a session — it's cheap (names and one-line descriptions only) and surfaces guidance not visible in any tool's name or schema. When a task matches a listed skill (e.g. debugging a build failure, tuning search_logs), call load_skill for that guide — it covers parameter tuning, caching behavior, and details beyond the summaries below.
-
-Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation.
-
-Common pitfalls:
-
-build_number is a sequential integer string (e.g. "42"), not a UUID. Build, job, artifact, and log tools all require this identifier — do not use the build's UUID id field.
-
-Job state "broken" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.
-
-Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.
-
-Annotation scope: when creating an annotation with scope "job", job_id is required. If job_id is provided but scope is left as the default "build", the job_id is silently ignored.`
+func BuildkiteServerInstructions(enabledToolsets []string) string {
+	parts := make([]string, 0, len(instructionSections))
+	for _, s := range instructionSections {
+		if s.toolset == "" || toolsets.IsToolsetEnabled(enabledToolsets, s.toolset) {
+			parts = append(parts, s.text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
 
 // NewMCPServer creates a new MCP server with the given configuration
 func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...ToolsetOption) *mcp.Server {
@@ -99,7 +126,7 @@ func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...Tools
 		Name:    "buildkite-mcp-server",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: BuildkiteServerInstructions,
+		Instructions: BuildkiteServerInstructions(cfg.EnabledToolsets),
 	})
 
 	log.Info().Str("version", version).Msg("Starting Buildkite MCP server")

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -62,13 +62,17 @@ func unauthorizedMiddleware(cb func()) mcp.Middleware {
 	}
 }
 
-const buildkiteServerInstructions = `This is the Buildkite MCP Server. It provides access to the Buildkite CI/CD API, enabling you to manage and inspect pipelines, builds, jobs, logs, clusters, tests, artifacts, and annotations.
+// BuildkiteServerInstructions are the instructions sent to MCP clients describing
+// how to use this server's tools. Exported so other services embedding or
+// re-implementing Buildkite MCP tools (e.g. custom/internal MCP servers) can
+// reuse the same guidance instead of maintaining their own copy.
+const BuildkiteServerInstructions = `This is the Buildkite MCP Server. It provides access to the Buildkite CI/CD API, enabling you to manage and inspect pipelines, builds, jobs, logs, clusters, tests, artifacts, and annotations.
 
 Start here: Before using most tools, call user_token_organization to retrieve the organization slug. Nearly every other tool requires the org_slug parameter, and this call is the fastest way to discover it.
 
-Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation.
+Skill discovery: Always call list_skills early in a session — it's cheap (names and one-line descriptions only) and surfaces guidance not visible in any tool's name or schema. When a task matches a listed skill (e.g. debugging a build failure, tuning search_logs), call load_skill for that guide — it covers parameter tuning, caching behavior, and details beyond the summaries below.
 
-For task-specific guidance beyond these pitfalls, call list_skills to see available guides, then load_skill to read one.
+Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation.
 
 Common pitfalls:
 
@@ -95,7 +99,7 @@ func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...Tools
 		Name:    "buildkite-mcp-server",
 		Version: version,
 	}, &mcp.ServerOptions{
-		Instructions: buildkiteServerInstructions,
+		Instructions: BuildkiteServerInstructions,
 	})
 
 	log.Info().Str("version", version).Msg("Starting Buildkite MCP server")

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -24,10 +24,11 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 	always := []string{authorization, buildNumber}
 
 	tests := []struct {
-		name    string
-		enabled []string
-		want    []string
-		notWant []string
+		name     string
+		enabled  []string
+		readOnly bool
+		want     []string
+		notWant  []string
 	}{
 		{
 			name:    "all toolsets includes every section",
@@ -52,12 +53,26 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 			want:    append(append([]string{}, always...), startHere),
 			notWant: []string{skillDiscovery, jobStateBroken, logInvestigation, annotationScope},
 		},
+		{
+			name:     "all toolsets, read-only, omits annotation scope",
+			enabled:  []string{"all"},
+			readOnly: true,
+			want:     append(append([]string{}, always...), startHere, skillDiscovery, jobStateBroken, logInvestigation),
+			notWant:  []string{annotationScope},
+		},
+		{
+			name:     "annotations toolset, read-only, omits annotation scope",
+			enabled:  []string{"annotations"},
+			readOnly: true,
+			want:     append([]string{}, always...),
+			notWant:  []string{annotationScope},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := require.New(t)
-			got := BuildkiteServerInstructions(tt.enabled)
+			got := BuildkiteServerInstructions(tt.enabled, tt.readOnly)
 
 			for _, w := range tt.want {
 				assert.Contains(got, w)

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -10,6 +10,65 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBuildkiteServerInstructions(t *testing.T) {
+	const (
+		startHere        = "Start here:"
+		skillDiscovery   = "Skill discovery:"
+		authorization    = "Authorization:"
+		buildNumber      = "build_number is a sequential"
+		jobStateBroken   = `Job state "broken"`
+		logInvestigation = "Log investigation order:"
+		annotationScope  = "Annotation scope:"
+	)
+
+	always := []string{authorization, buildNumber}
+
+	tests := []struct {
+		name    string
+		enabled []string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "all toolsets includes every section",
+			enabled: []string{"all"},
+			want:    append(append([]string{}, always...), startHere, skillDiscovery, jobStateBroken, logInvestigation, annotationScope),
+		},
+		{
+			name:    "builds alone",
+			enabled: []string{"builds"},
+			want:    append(append([]string{}, always...), jobStateBroken),
+			notWant: []string{startHere, skillDiscovery, logInvestigation, annotationScope},
+		},
+		{
+			name:    "skills alone",
+			enabled: []string{"skills"},
+			want:    append(append([]string{}, always...), skillDiscovery),
+			notWant: []string{startHere, jobStateBroken, logInvestigation, annotationScope},
+		},
+		{
+			name:    "user alone",
+			enabled: []string{"user"},
+			want:    append(append([]string{}, always...), startHere),
+			notWant: []string{skillDiscovery, jobStateBroken, logInvestigation, annotationScope},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+			got := BuildkiteServerInstructions(tt.enabled)
+
+			for _, w := range tt.want {
+				assert.Contains(got, w)
+			}
+			for _, nw := range tt.notWant {
+				assert.NotContains(got, nw)
+			}
+		})
+	}
+}
+
 func TestUnauthorizedMiddleware_CallsCallbackOnUnauthorized(t *testing.T) {
 	called := false
 	middleware := unauthorizedMiddleware(func() { called = true })

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -122,14 +122,20 @@ func (tr *ToolsetRegistry) List() []string {
 	return names
 }
 
+// expandAllToolsets replaces the "all" sentinel with the full list of
+// registered toolset names; otherwise returns enabled unchanged.
+func (tr *ToolsetRegistry) expandAllToolsets(enabled []string) []string {
+	if slices.Contains(enabled, ToolsetAll) {
+		return tr.List()
+	}
+	return enabled
+}
+
 // GetEnabledTools returns tools from enabled toolsets, optionally filtering for read-only
 func (tr *ToolsetRegistry) GetEnabledTools(enabledToolsets []string, readOnlyMode bool) []ToolDefinition {
 	var tools []ToolDefinition
 
-	// If "all" is specified, enable all toolsets
-	if slices.Contains(enabledToolsets, "all") {
-		enabledToolsets = tr.List()
-	}
+	enabledToolsets = tr.expandAllToolsets(enabledToolsets)
 
 	for _, toolsetName := range enabledToolsets {
 		if toolset, exists := tr.toolsets[toolsetName]; exists {
@@ -192,10 +198,7 @@ func (tr *ToolsetRegistry) GetMetadata() []ToolsetMetadata {
 func (tr *ToolsetRegistry) GetRequiredScopes(enabledToolsets []string, readOnlyMode bool) []string {
 	scopeMap := make(map[string]bool)
 
-	// If "all" is specified, enable all toolsets
-	if slices.Contains(enabledToolsets, "all") {
-		enabledToolsets = tr.List()
-	}
+	enabledToolsets = tr.expandAllToolsets(enabledToolsets)
 
 	for _, toolsetName := range enabledToolsets {
 		if toolset, exists := tr.toolsets[toolsetName]; exists {
@@ -262,6 +265,12 @@ var ValidToolsets = []string{
 // IsValidToolset checks if a toolset name is valid
 func IsValidToolset(name string) bool {
 	return slices.Contains(ValidToolsets, name)
+}
+
+// IsToolsetEnabled reports whether name is enabled, treating ToolsetAll as a
+// wildcard that enables every toolset.
+func IsToolsetEnabled(enabled []string, name string) bool {
+	return slices.Contains(enabled, ToolsetAll) || slices.Contains(enabled, name)
 }
 
 // ValidateToolsets checks if all toolset names are valid

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -598,6 +598,30 @@ func TestIsValidToolset(t *testing.T) {
 	}
 }
 
+func TestIsToolsetEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  []string
+		toolset  string
+		expected bool
+	}{
+		{"all enables any toolset", []string{"all"}, "skills", true},
+		{"all enables an unrelated toolset", []string{"all"}, "logs", true},
+		{"exact match", []string{"builds"}, "builds", true},
+		{"not in list", []string{"builds"}, "logs", false},
+		{"present among several", []string{"builds", "logs", "annotations"}, "logs", true},
+		{"empty enabled list", []string{}, "builds", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+			result := IsToolsetEnabled(tt.enabled, tt.toolset)
+			assert.Equal(tt.expected, result)
+		})
+	}
+}
+
 func TestValidateToolsets(t *testing.T) {
 	t.Run("all valid toolsets", func(t *testing.T) {
 		assert := require.New(t)


### PR DESCRIPTION
- Rewords the skill discovery instruction to be a directive, not a hedge. Evals showed agents rarely called `list_skills` under the old "For task-specific guidance beyond these pitfalls..." phrasing.
- Exports `BuildkiteServerInstructions` so other services building custom/internal MCP servers can reuse this guidance.
- Converts `BuildkiteServerInstructions` into a function of `EnabledToolsets`, so the text only includes paragraphs relevant to tools actually registered on a given server instance.
- Fixes two cases where the old static text was misleading when a toolset was disabled: "Start here" told the agent to call `user_token_organization` even without the `user` toolset enabled, and "Skill discovery" appeared even without `skills` enabled.
- Adds `toolsets.IsToolsetEnabled` and extracts `expandAllToolsets` to dedupe the identical `"all"` expansion logic already duplicated in `GetEnabledTools`/`GetRequiredScopes`.
