### PR TITLE
fix: tokenize list_skills query matching

### DIFF
--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -29,6 +29,17 @@ type skillSummary struct {
 	Description string `json:"description"`
 }
 
+// matchesAllTokens reports whether every token is a substring of haystack.
+// An empty token list matches everything.
+func matchesAllTokens(haystack string, tokens []string) bool {
+	for _, t := range tokens {
+		if !strings.Contains(haystack, t) {
+			return false
+		}
+	}
+	return true
+}
+
 type ListSkillsArgs struct {
 	Query string `json:"query,omitempty" jsonschema:"Optional case-insensitive filter over skill name and description"`
 }
@@ -46,9 +57,10 @@ func ListSkills() (mcp.Tool, mcp.ToolHandlerFor[ListSkillsArgs, any], []string) 
 			defer span.End()
 
 			results := []skillSummary{}
-			query := strings.ToLower(args.Query)
+			tokens := strings.Fields(strings.ToLower(args.Query))
 			for _, s := range skillRegistry {
-				if query == "" || strings.Contains(strings.ToLower(s.Name), query) || strings.Contains(strings.ToLower(s.Description), query) {
+				haystack := strings.ToLower(s.Name + " " + s.Description)
+				if matchesAllTokens(haystack, tokens) {
 					results = append(results, skillSummary{Name: s.Name, Description: s.Description})
 				}
 			}

--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -96,6 +96,11 @@ func LoadSkill() (mcp.Tool, mcp.ToolHandlerFor[LoadSkillArgs, any], []string) {
 				}
 			}
 
+			span.SetAttributes(
+				attribute.String("skill_name", args.SkillName),
+				attribute.Bool("matched", match != nil),
+			)
+
 			if match == nil {
 				names := make([]string, len(skillRegistry))
 				for i := range skillRegistry {

--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type skill struct {
@@ -55,6 +56,8 @@ func ListSkills() (mcp.Tool, mcp.ToolHandlerFor[ListSkillsArgs, any], []string) 
 		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListSkillsArgs) (*mcp.CallToolResult, any, error) {
 			_, span := trace.Start(ctx, "buildkite.ListSkills")
 			defer span.End()
+
+			span.SetAttributes(attribute.String("query", args.Query))
 
 			results := []skillSummary{}
 			tokens := strings.Fields(strings.ToLower(args.Query))

--- a/pkg/buildkite/skills_test.go
+++ b/pkg/buildkite/skills_test.go
@@ -48,6 +48,30 @@ func TestListSkills(t *testing.T) {
 		textContent := getTextResult(t, result)
 		assert.JSONEq(`[]`, textContent.Text)
 	})
+
+	t.Run("multi-word query matches when all tokens appear out of order", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, handler, _ := ListSkills()
+		request := createMCPRequest(t, map[string]any{"query": "debug build failure"})
+		result, _, err := handler(ctx, request, ListSkillsArgs{Query: "debug build failure"})
+		assert.NoError(err)
+
+		textContent := getTextResult(t, result)
+		assert.Contains(textContent.Text, "debug-logs-guide")
+	})
+
+	t.Run("multi-word query with one non-matching token returns empty list", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, handler, _ := ListSkills()
+		request := createMCPRequest(t, map[string]any{"query": "debug nonexistent"})
+		result, _, err := handler(ctx, request, ListSkillsArgs{Query: "debug nonexistent"})
+		assert.NoError(err)
+
+		textContent := getTextResult(t, result)
+		assert.JSONEq(`[]`, textContent.Text)
+	})
 }
 
 func TestLoadSkill(t *testing.T) {


### PR DESCRIPTION
- list_skills previously required the whole query to appear as one literal substring in a skill's name+description
- natural multi-word queries (e.g. "debug build failure") silently returned zero results even when a relevant skill existed
- split the query into whitespace-separated tokens and require every token to be a substring somewhere in name+description (order- independent), instead of the whole phrase matching contiguously
- add regression tests for the out-of-order multi-word match and the one-non-matching-token empty-result case
- record the query on ListSkills' trace span, and skill_name + matched (whether it resolved) on LoadSkill's trace span, for observability into what's being searched/loaded
