### PR TITLE
feat(tool): add build failure summary

### DIFF
--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -42,19 +43,206 @@ func boolPtr(b bool) *bool {
 }
 
 func mcpTextResult(span trace.Span, result any) (*mcp.CallToolResult, any, error) {
+	sanitized, err := marshalSanitizedJSON(result)
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+
+	return mcpSanitizedTextResult(span, sanitized)
+}
+
+func mcpTextResultWithByteLimit(span trace.Span, result any, limit int) (*mcp.CallToolResult, any, error) {
+	sanitized, err := marshalSanitizedJSON(result)
+	if err != nil {
+		return utils.NewToolResultError(err.Error()), nil, nil
+	}
+
+	sanitized, err = limitSanitizedJSONPayload(sanitized, limit)
+	if err != nil {
+		return utils.NewToolResultError(fmt.Sprintf("failed to limit result: %v", err)), nil, nil
+	}
+
+	return mcpSanitizedTextResult(span, sanitized)
+}
+
+func marshalSanitizedJSON(result any) ([]byte, error) {
 	r, err := json.Marshal(result)
 	if err != nil {
-		return utils.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err)), nil, nil
+		return nil, fmt.Errorf("failed to marshal result: %v", err)
 	}
 
 	sanitized, err := sanitize.SanitizeJSONBytes(r)
 	if err != nil {
-		return utils.NewToolResultError(fmt.Sprintf("failed to sanitize result: %v", err)), nil, nil
+		return nil, fmt.Errorf("failed to sanitize result: %v", err)
 	}
+	return sanitized, nil
+}
 
+func mcpSanitizedTextResult(span trace.Span, sanitized []byte) (*mcp.CallToolResult, any, error) {
 	span.SetAttributes(
 		attribute.Int("estimated_tokens", tokens.EstimateTokens(string(sanitized))),
 	)
 
 	return utils.NewToolResultText(string(sanitized)), nil, nil
+}
+
+func limitSanitizedJSONPayload(payload []byte, limit int) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, fmt.Errorf("decode sanitized JSON: %w", err)
+	}
+
+	root, ok := value.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+	if _, ok := root["content_limit_bytes"]; ok {
+		root["content_limit_bytes"] = limit
+	}
+
+	// content_bytes is part of the payload, so stabilize it before checking the
+	// serialized size.
+	bounded, err := marshalJSONWithContentBytes(root)
+	if err != nil {
+		return nil, err
+	}
+	if len(bounded) <= limit {
+		return bounded, nil
+	}
+
+	root["content_truncated"] = true
+	// Array items carry collection-specific semantics and truncation metadata.
+	// The generic limiter must preserve them; callers must reduce semantic
+	// collections before serialization.
+	if candidate, candidateErr := marshalLimitedJSON(root, 0); candidateErr != nil {
+		return nil, candidateErr
+	} else if len(candidate) > limit {
+		return nil, fmt.Errorf("JSON structure exceeds %d byte limit", limit)
+	}
+
+	// Search using the actual encoded size so quotes, backslashes, newlines, and
+	// other JSON escaping are included in the final budget.
+	low, high := 0, maxJSONStringBytes(root)
+	var best []byte
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate, candidateErr := marshalLimitedJSON(root, mid)
+		if candidateErr != nil {
+			return nil, candidateErr
+		}
+		if len(candidate) <= limit {
+			best = candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if best == nil {
+		return nil, fmt.Errorf("JSON structure exceeds %d byte limit", limit)
+	}
+	return best, nil
+}
+
+func marshalLimitedJSON(value map[string]any, stringLimit int) ([]byte, error) {
+	limitedValue, _ := limitJSONValue(value, stringLimit, "")
+	limited, ok := limitedValue.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+	return marshalJSONWithContentBytes(limited)
+}
+
+func limitJSONValue(value any, stringLimit int, context string) (any, bool) {
+	switch value := value.(type) {
+	case string:
+		limited, truncated := truncateUTF8Bytes(value, stringLimit)
+		return limited, truncated
+	case []any:
+		limited := make([]any, len(value))
+		truncated := false
+		for i := range limited {
+			var itemTruncated bool
+			limited[i], itemTruncated = limitJSONValue(value[i], stringLimit, context)
+			truncated = truncated || itemTruncated
+		}
+		return limited, truncated
+	case map[string]any:
+		limited := make(map[string]any, len(value))
+		truncated := false
+		bodyTruncated := false
+		logContentTruncated := false
+		contentTruncated := false
+		for key, item := range value {
+			var itemTruncated bool
+			limited[key], itemTruncated = limitJSONValue(item, stringLimit, key)
+			truncated = truncated || itemTruncated
+			if !itemTruncated {
+				continue
+			}
+			switch {
+			case context == "annotations" && key == "body_html":
+				bodyTruncated = true
+			case context == "jobs" && (key == "log_tail" || key == "log_error"):
+				logContentTruncated = true
+			case context == "test_runs" && (key == "failed_executions" || key == "error"):
+				contentTruncated = true
+			}
+		}
+		if bodyTruncated {
+			limited["body_truncated"] = true
+		}
+		if logContentTruncated {
+			limited["log_content_truncated"] = true
+		}
+		if truncated && (context == "failed_executions" || context == "log_tail") {
+			contentTruncated = true
+		}
+		if contentTruncated {
+			limited["content_truncated"] = true
+		}
+		return limited, truncated
+	default:
+		return value, false
+	}
+}
+
+func maxJSONStringBytes(value any) int {
+	switch value := value.(type) {
+	case string:
+		return len(value)
+	case []any:
+		maximum := 0
+		for _, item := range value {
+			maximum = max(maximum, maxJSONStringBytes(item))
+		}
+		return maximum
+	case map[string]any:
+		maximum := 0
+		for _, item := range value {
+			maximum = max(maximum, maxJSONStringBytes(item))
+		}
+		return maximum
+	default:
+		return 0
+	}
+}
+
+func marshalJSONWithContentBytes(value map[string]any) ([]byte, error) {
+	if _, ok := value["content_bytes"]; !ok {
+		return json.Marshal(value)
+	}
+
+	value["content_bytes"] = 0
+	for {
+		payload, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshal limited JSON: %w", err)
+		}
+		if value["content_bytes"] == len(payload) {
+			return payload, nil
+		}
+		value["content_bytes"] = len(payload)
+	}
 }

--- a/pkg/buildkite/buildkite_test.go
+++ b/pkg/buildkite/buildkite_test.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -78,4 +79,88 @@ func getTextResult(t *testing.T, result *mcp.CallToolResult) *mcp.TextContent {
 
 func testPtr[T any](value T) *T {
 	return &value
+}
+
+func TestLimitSanitizedJSONPayloadPreservesArrayItems(t *testing.T) {
+	items := make([]map[string]any, 8)
+	for i := range items {
+		items[i] = map[string]any{"index": i, "content": strings.Repeat("x", 100)}
+	}
+	payload, err := json.Marshal(map[string]any{
+		"content_bytes":       0,
+		"content_limit_bytes": 400,
+		"items":               items,
+	})
+	require.NoError(t, err)
+
+	limited, err := limitSanitizedJSONPayload(payload, 400)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(limited), 400)
+
+	var result struct {
+		Items            []map[string]any `json:"items"`
+		ContentTruncated bool             `json:"content_truncated"`
+	}
+	require.NoError(t, json.Unmarshal(limited, &result))
+	require.Len(t, result.Items, len(items))
+	require.True(t, result.ContentTruncated)
+}
+
+func TestLimitSanitizedJSONPayloadRejectsOversizedArrayStructure(t *testing.T) {
+	items := make([]int, 1_000)
+	payload, err := json.Marshal(map[string]any{"items": items})
+	require.NoError(t, err)
+
+	_, err = limitSanitizedJSONPayload(payload, 100)
+	require.ErrorContains(t, err, "JSON structure exceeds 100 byte limit")
+}
+
+func TestLimitSanitizedJSONPayloadUpdatesNestedTruncationMetadata(t *testing.T) {
+	content := strings.Repeat("<", 1_000)
+	payload, err := json.Marshal(map[string]any{
+		"content_bytes":       0,
+		"content_limit_bytes": 512,
+		"annotations": []any{map[string]any{
+			"body_html": content,
+		}},
+		"jobs": []any{map[string]any{
+			"log_tail": []any{map[string]any{"c": content, "rn": 1}},
+		}},
+		"test_runs": []any{map[string]any{
+			"failed_executions": []any{map[string]any{"failure_reason": content}},
+		}},
+	})
+	require.NoError(t, err)
+
+	limited, err := limitSanitizedJSONPayload(payload, 512)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(limited), 512)
+
+	var result struct {
+		ContentTruncated bool `json:"content_truncated"`
+		Annotations      []struct {
+			BodyHTML      string `json:"body_html"`
+			BodyTruncated bool   `json:"body_truncated"`
+		} `json:"annotations"`
+		Jobs []struct {
+			LogContentTruncated bool `json:"log_content_truncated"`
+			LogTail             []struct {
+				ContentTruncated bool `json:"content_truncated"`
+			} `json:"log_tail"`
+		} `json:"jobs"`
+		TestRuns []struct {
+			ContentTruncated bool `json:"content_truncated"`
+			FailedExecutions []struct {
+				ContentTruncated bool `json:"content_truncated"`
+			} `json:"failed_executions"`
+		} `json:"test_runs"`
+	}
+	require.NoError(t, json.Unmarshal(limited, &result))
+	require.True(t, result.ContentTruncated)
+	require.True(t, result.Annotations[0].BodyTruncated)
+	require.Less(t, len(result.Annotations[0].BodyHTML), len(content))
+	require.True(t, result.Jobs[0].LogContentTruncated)
+	require.True(t, result.Jobs[0].LogTail[0].ContentTruncated)
+	require.True(t, result.TestRuns[0].ContentTruncated)
+	require.True(t, result.TestRuns[0].FailedExecutions[0].ContentTruncated)
 }

--- a/pkg/buildkite/errors.go
+++ b/pkg/buildkite/errors.go
@@ -26,17 +26,27 @@ var ErrUnauthorized = &jsonrpc.Error{
 	Message: "buildkite: unauthorized",
 }
 
+func isBuildkiteUnauthorized(err error) bool {
+	if errors.Is(err, ErrUnauthorized) {
+		return true
+	}
+
+	var errResp *buildkite.ErrorResponse
+	return errors.As(err, &errResp) && errResp.Response != nil && errResp.Response.StatusCode == http.StatusUnauthorized
+}
+
 // handleBuildkiteError converts a Buildkite API error into tool handler return values.
 // On a 401 it returns (nil, nil, ErrUnauthorized) so the error propagates as a
 // JSON-RPC error and can be intercepted by middleware. On other errors it returns
 // a tool result error so the tool call succeeds at the JSON-RPC level but with an
 // error body.
 func handleBuildkiteError(err error) (*mcp.CallToolResult, any, error) {
+	if isBuildkiteUnauthorized(err) {
+		return nil, nil, ErrUnauthorized
+	}
+
 	var errResp *buildkite.ErrorResponse
 	if errors.As(err, &errResp) {
-		if errResp.Response != nil && errResp.Response.StatusCode == http.StatusUnauthorized {
-			return nil, nil, ErrUnauthorized
-		}
 		if errResp.RawBody != nil {
 			return utils.NewToolResultError(string(errResp.RawBody)), nil, nil
 		}

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -45,13 +45,13 @@ type GetBuildFailureSummaryArgs struct {
 	OrgSlug                string `json:"org_slug"`
 	PipelineSlug           string `json:"pipeline_slug"`
 	BuildNumber            string `json:"build_number"`
-	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed or promised-failing job (default 50, max 200)"`
-	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum failed, broken, or promised-failing jobs to return (default 10, max 50)"`
+	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
+	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, max 50)"`
 	MaxAnnotations         int    `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
 	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to inspect (default 5, max 20)"`
 	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed test executions to return across all Test Engine runs (default 100, max 200)"`
 	MaxFailedTestsPerRun   int    `json:"max_failed_tests_per_run,omitempty" jsonschema:"Maximum failed test executions to return per Test Engine run (default 20, max 100)"`
-	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed and promised-failing jobs (default true)"`
+	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
 	IncludeAnnotations     *bool  `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
 	IncludeFailedTests     *bool  `json:"include_failed_tests,omitempty" jsonschema:"Include failed Test Engine executions when the build has Test Engine runs (default true)"`
 	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded test failure details such as stack traces within the summary's bounded test-content budget"`
@@ -74,6 +74,7 @@ type FailureSummaryJob struct {
 	JobSummary
 	PromisedExitStatus   *int                     `json:"promised_exit_status,omitempty"`
 	PromisedExitStatusAt *buildkite.Timestamp     `json:"promised_exit_status_at,omitempty"`
+	ExpiredAt            *buildkite.Timestamp     `json:"expired_at,omitempty"`
 	LogTail              []FailureSummaryLogEntry `json:"log_tail,omitempty"`
 	LogTotalRows         int64                    `json:"log_total_rows,omitempty"`
 	LogTruncated         bool                     `json:"log_truncated,omitempty"`
@@ -139,18 +140,31 @@ func failureSummaryBuild(build buildkite.Build) BuildFailureSummaryBuild {
 }
 
 func isPrimaryFailureSummaryJob(job buildkite.Job) bool {
-	if job.State == "failed" || job.State == "timed_out" {
+	switch job.State {
+	case "failed", "timed_out", "expired":
 		return true
+	case "running":
+		return job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0
+	default:
+		return false
 	}
-	return job.State == "running" && job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0
+}
+
+func isSecondaryFailureSummaryJob(job buildkite.Job) bool {
+	switch job.State {
+	case "canceled", "broken", "waiting_failed", "blocked_failed", "unblocked_failed":
+		return true
+	default:
+		return false
+	}
 }
 
 func isFailureSummaryJob(job buildkite.Job) bool {
-	return isPrimaryFailureSummaryJob(job) || job.State == "broken"
+	return isPrimaryFailureSummaryJob(job) || isSecondaryFailureSummaryJob(job)
 }
 
 func shouldReadFailureLog(job buildkite.Job) bool {
-	return isPrimaryFailureSummaryJob(job)
+	return job.State == "canceled" || (job.State != "expired" && isPrimaryFailureSummaryJob(job))
 }
 
 func failureSummaryJob(job buildkite.Job) FailureSummaryJob {
@@ -158,6 +172,7 @@ func failureSummaryJob(job buildkite.Job) FailureSummaryJob {
 		JobSummary:           summarizeJob(job),
 		PromisedExitStatus:   job.PromisedExitStatus,
 		PromisedExitStatusAt: job.PromisedExitStatusAt,
+		ExpiredAt:            job.ExpiredAt,
 	}
 }
 
@@ -692,7 +707,7 @@ func limitFailureSummaryLogCollections(result *BuildFailureSummary, limit int) e
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build_failure_summary",
-			Description: "Diagnose a Buildkite build failure in one call. Returns build state, failed and broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Start with this tool before calling individual job, log, annotation, or test tools.",
+			Description: "Diagnose a Buildkite build failure in one call. Returns build state, terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Start with this tool before calling individual job, log, annotation, or test tools.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build Failure Summary",
 				ReadOnlyHint: true,
@@ -740,7 +755,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				// The API's failed filter includes running jobs with a hard promised
 				// failure. Querying running separately can include promises covered by
 				// soft-fail or retry rules that do not put the build into failing.
-				State:              []string{"failed", "timed_out"},
+				State:              []string{"failed", "timed_out", "expired"},
 				IncludeRetriedJobs: &includeRetriedJobs,
 				PerPage:            maxJobs + 1,
 			})
@@ -762,17 +777,17 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 
 			remainingJobs := maxJobs - len(sourceJobs)
-			brokenJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"broken"},
+			secondaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"},
 				IncludeRetriedJobs: &includeRetriedJobs,
 				PerPage:            remainingJobs + 1,
 			})
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
-			jobsTruncated = jobsTruncated || brokenJobsList.Links.Next != ""
-			for _, job := range brokenJobsList.Items {
-				if !isFailureSummaryJob(job) || job.State != "broken" {
+			jobsTruncated = jobsTruncated || secondaryJobsList.Links.Next != ""
+			for _, job := range secondaryJobsList.Items {
+				if !isSecondaryFailureSummaryJob(job) {
 					continue
 				}
 				if len(sourceJobs) < maxJobs {

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -150,21 +150,21 @@ func isPrimaryFailureSummaryJob(job buildkite.Job) bool {
 	}
 }
 
-func isSecondaryFailureSummaryJob(job buildkite.Job) bool {
+func isCanceledFailureSummaryJob(job buildkite.Job) bool {
+	return job.State == "canceled"
+}
+
+func isDownstreamFailureSummaryJob(job buildkite.Job) bool {
 	switch job.State {
-	case "canceled", "broken", "waiting_failed", "blocked_failed", "unblocked_failed":
+	case "broken", "waiting_failed", "blocked_failed", "unblocked_failed":
 		return true
 	default:
 		return false
 	}
 }
 
-func isFailureSummaryJob(job buildkite.Job) bool {
-	return isPrimaryFailureSummaryJob(job) || isSecondaryFailureSummaryJob(job)
-}
-
 func shouldReadFailureLog(job buildkite.Job) bool {
-	return job.State == "canceled" || (job.State != "expired" && isPrimaryFailureSummaryJob(job))
+	return isCanceledFailureSummaryJob(job) || (job.State != "expired" && isPrimaryFailureSummaryJob(job))
 }
 
 func failureSummaryJob(job buildkite.Job) FailureSummaryJob {
@@ -777,17 +777,38 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 
 			remainingJobs := maxJobs - len(sourceJobs)
-			secondaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"},
+			canceledJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"canceled"},
 				IncludeRetriedJobs: &includeRetriedJobs,
 				PerPage:            remainingJobs + 1,
 			})
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
-			jobsTruncated = jobsTruncated || secondaryJobsList.Links.Next != ""
-			for _, job := range secondaryJobsList.Items {
-				if !isSecondaryFailureSummaryJob(job) {
+			jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
+			for _, job := range canceledJobsList.Items {
+				if !isCanceledFailureSummaryJob(job) {
+					continue
+				}
+				if len(sourceJobs) < maxJobs {
+					sourceJobs = append(sourceJobs, job)
+				} else {
+					jobsTruncated = true
+				}
+			}
+
+			remainingJobs = maxJobs - len(sourceJobs)
+			downstreamJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
+				IncludeRetriedJobs: &includeRetriedJobs,
+				PerPage:            remainingJobs + 1,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+			jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
+			for _, job := range downstreamJobsList.Items {
+				if !isDownstreamFailureSummaryJob(job) {
 					continue
 				}
 				if len(sourceJobs) < maxJobs {

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -1,0 +1,808 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"unicode/utf8"
+
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	defaultFailureSummaryLogTail         = 50
+	maxFailureSummaryLogTail             = 200
+	defaultFailureSummaryJobs            = 10
+	maxFailureSummaryJobs                = 50
+	defaultFailureSummaryAnnotations     = 20
+	maxFailureSummaryAnnotations         = 100
+	failureSummaryAnnotationPageSize     = 100
+	failureSummaryAnnotationScanPages    = 5
+	defaultFailureSummaryTestRuns        = 5
+	maxFailureSummaryTestRuns            = 20
+	defaultFailureSummaryTestsPerRun     = 20
+	maxFailureSummaryTestsPerRun         = 100
+	defaultFailureSummaryFailedTests     = 100
+	maxFailureSummaryFailedTests         = 200
+	failureSummaryEntryContentByteLimit  = 4 * 1024
+	failureSummaryExecutionByteLimit     = 16 * 1024
+	failureSummaryLogJobContentByteLimit = 64 * 1024
+	failureSummaryLogContentByteLimit    = 128 * 1024
+	failureSummaryAnnotationContentLimit = 64 * 1024
+	failureSummaryTestContentByteLimit   = 64 * 1024
+	failureSummaryContentByteLimit       = failureSummaryLogContentByteLimit + failureSummaryAnnotationContentLimit + failureSummaryTestContentByteLimit
+	failureSummaryConcurrency            = 4
+)
+
+// GetBuildFailureSummaryArgs controls the amount of diagnostic context returned
+// by get_build_failure_summary. Pointer booleans let omitted values default to
+// true while still allowing callers to disable an optional section.
+type GetBuildFailureSummaryArgs struct {
+	OrgSlug                string `json:"org_slug"`
+	PipelineSlug           string `json:"pipeline_slug"`
+	BuildNumber            string `json:"build_number"`
+	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed or promised-failing job (default 50, max 200)"`
+	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum failed, broken, or promised-failing jobs to return (default 10, max 50)"`
+	MaxAnnotations         int    `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
+	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to inspect (default 5, max 20)"`
+	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed test executions to return across all Test Engine runs (default 100, max 200)"`
+	MaxFailedTestsPerRun   int    `json:"max_failed_tests_per_run,omitempty" jsonschema:"Maximum failed test executions to return per Test Engine run (default 20, max 100)"`
+	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed and promised-failing jobs (default true)"`
+	IncludeAnnotations     *bool  `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
+	IncludeFailedTests     *bool  `json:"include_failed_tests,omitempty" jsonschema:"Include failed Test Engine executions when the build has Test Engine runs (default true)"`
+	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded test failure details such as stack traces within the summary's bounded test-content budget"`
+}
+
+type BuildFailureSummaryBuild struct {
+	BuildSummary
+	Blocked     bool                 `json:"blocked"`
+	ScheduledAt *buildkite.Timestamp `json:"scheduled_at,omitempty"`
+	StartedAt   *buildkite.Timestamp `json:"started_at,omitempty"`
+	FinishedAt  *buildkite.Timestamp `json:"finished_at,omitempty"`
+}
+
+type FailureSummaryLogEntry struct {
+	TerseLogEntry
+	ContentTruncated bool `json:"content_truncated,omitempty"`
+}
+
+type FailureSummaryJob struct {
+	JobSummary
+	PromisedExitStatus   *int                     `json:"promised_exit_status,omitempty"`
+	PromisedExitStatusAt *buildkite.Timestamp     `json:"promised_exit_status_at,omitempty"`
+	LogTail              []FailureSummaryLogEntry `json:"log_tail,omitempty"`
+	LogTotalRows         int64                    `json:"log_total_rows,omitempty"`
+	LogTruncated         bool                     `json:"log_truncated,omitempty"`
+	LogContentTruncated  bool                     `json:"log_content_truncated,omitempty"`
+	LogEntriesOmitted    int                      `json:"log_entries_omitted,omitempty"`
+	LogError             string                   `json:"log_error,omitempty"`
+}
+
+type FailureSummaryAnnotation struct {
+	AnnotationSummary
+	BodyHTML      string `json:"body_html"`
+	BodyTruncated bool   `json:"body_truncated,omitempty"`
+}
+
+type FailureSummaryFailedExecution struct {
+	buildkite.FailedExecution
+	ContentTruncated bool `json:"content_truncated,omitempty"`
+}
+
+type FailureSummaryTestRun struct {
+	RunID            string                          `json:"run_id"`
+	TestSuiteSlug    string                          `json:"test_suite_slug"`
+	FailedExecutions []FailureSummaryFailedExecution `json:"failed_executions,omitempty"`
+	Truncated        bool                            `json:"truncated,omitempty"`
+	ContentTruncated bool                            `json:"content_truncated,omitempty"`
+	Error            string                          `json:"error,omitempty"`
+}
+
+type BuildFailureSummary struct {
+	Build                BuildFailureSummaryBuild   `json:"build"`
+	Jobs                 []FailureSummaryJob        `json:"jobs"`
+	JobsTruncated        bool                       `json:"jobs_truncated,omitempty"`
+	Annotations          []FailureSummaryAnnotation `json:"annotations,omitempty"`
+	AnnotationsTruncated bool                       `json:"annotations_truncated,omitempty"`
+	TestRuns             []FailureSummaryTestRun    `json:"test_runs,omitempty"`
+	TestRunsTruncated    bool                       `json:"test_runs_truncated,omitempty"`
+	FailedTestsTruncated bool                       `json:"failed_tests_truncated,omitempty"`
+	ContentBytes         int                        `json:"content_bytes"`
+	ContentLimitBytes    int                        `json:"content_limit_bytes"`
+	ContentTruncated     bool                       `json:"content_truncated,omitempty"`
+	Warnings             []string                   `json:"warnings,omitempty"`
+}
+
+func defaultTrue(value *bool) bool {
+	return value == nil || *value
+}
+
+func boundedValue(value, defaultValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	return min(value, maxValue)
+}
+
+func failureSummaryBuild(build buildkite.Build) BuildFailureSummaryBuild {
+	return BuildFailureSummaryBuild{
+		BuildSummary: summarizeBuild(build),
+		Blocked:      build.Blocked,
+		ScheduledAt:  build.ScheduledAt,
+		StartedAt:    build.StartedAt,
+		FinishedAt:   build.FinishedAt,
+	}
+}
+
+func isFailureSummaryJob(job buildkite.Job) bool {
+	if job.State == "failed" || job.State == "broken" {
+		return true
+	}
+	return job.State == "running" && job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0
+}
+
+func shouldReadFailureLog(job buildkite.Job) bool {
+	return job.State == "failed" || (job.State == "running" && job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0)
+}
+
+func failureSummaryJob(job buildkite.Job) FailureSummaryJob {
+	return FailureSummaryJob{
+		JobSummary:           summarizeJob(job),
+		PromisedExitStatus:   job.PromisedExitStatus,
+		PromisedExitStatusAt: job.PromisedExitStatusAt,
+	}
+}
+
+func truncateUTF8Bytes(value string, limit int) (string, bool) {
+	if len(value) <= limit {
+		return value, false
+	}
+	if limit <= 0 {
+		return "", true
+	}
+
+	const ellipsis = "…"
+	prefixLimit := limit
+	if limit >= len(ellipsis) {
+		prefixLimit -= len(ellipsis)
+	} else {
+		return utf8Prefix(value, limit), true
+	}
+	return utf8Prefix(value, prefixLimit) + ellipsis, true
+}
+
+func utf8Prefix(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	for limit > 0 && !utf8.RuneStart(value[limit]) {
+		limit--
+	}
+	return value[:limit]
+}
+
+func failureSummaryAnnotations(annotations []buildkite.Annotation, limit int) ([]FailureSummaryAnnotation, bool) {
+	results := make([]FailureSummaryAnnotation, 0, min(len(annotations), limit))
+	truncated := false
+	for _, annotation := range annotations {
+		if annotation.Style != "error" && annotation.Style != "warning" {
+			continue
+		}
+		if len(results) >= limit {
+			truncated = true
+			continue
+		}
+		body, bodyTruncated := truncateUTF8Bytes(annotation.BodyHTML, failureSummaryEntryContentByteLimit)
+		results = append(results, FailureSummaryAnnotation{
+			AnnotationSummary: summarizeAnnotations([]buildkite.Annotation{annotation})[0],
+			BodyHTML:          body,
+			BodyTruncated:     bodyTruncated,
+		})
+	}
+	return results, truncated
+}
+
+func loadFailureAnnotations(ctx context.Context, client AnnotationsClient, args GetBuildFailureSummaryArgs, limit int) ([]FailureSummaryAnnotation, bool, error) {
+	results := make([]FailureSummaryAnnotation, 0, limit)
+	page := 1
+
+	for pagesScanned := 0; pagesScanned < failureSummaryAnnotationScanPages; pagesScanned++ {
+		annotations, response, err := client.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.AnnotationListOptions{
+			ListOptions: buildkite.ListOptions{Page: page, PerPage: failureSummaryAnnotationPageSize},
+			Scope:       "all",
+		})
+		if err != nil {
+			if isBuildkiteUnauthorized(err) {
+				return nil, false, ErrUnauthorized
+			}
+			return results, true, err
+		}
+
+		remaining := limit - len(results)
+		pageResults, pageTruncated := failureSummaryAnnotations(annotations, remaining)
+		results = append(results, pageResults...)
+
+		hasNextPage := response != nil && response.NextPage > 0
+		if pageTruncated {
+			return results, true, nil
+		}
+		if len(results) >= limit {
+			return results, hasNextPage, nil
+		}
+		if !hasNextPage {
+			return results, false, nil
+		}
+		if pagesScanned+1 >= failureSummaryAnnotationScanPages {
+			return results, true, nil
+		}
+		page = response.NextPage
+	}
+
+	return results, true, nil
+}
+
+func readFailureLogTail(ctx context.Context, client BuildkiteLogsClient, args GetBuildFailureSummaryArgs, job buildkite.Job, tail int) ([]FailureSummaryLogEntry, int64, bool, bool, int, error) {
+	reader, err := newParquetReader(ctx, client, JobLogsBaseParams{
+		OrgSlug:      args.OrgSlug,
+		PipelineSlug: args.PipelineSlug,
+		BuildNumber:  args.BuildNumber,
+		JobID:        job.ID,
+	})
+	if err != nil {
+		return nil, 0, false, false, 0, err
+	}
+	defer reader.Close()
+
+	fileInfo, err := reader.GetFileInfo()
+	if err != nil {
+		return nil, 0, false, false, 0, fmt.Errorf("get log file info: %w", err)
+	}
+
+	startRow := max(fileInfo.RowCount-int64(tail), 0)
+	entries := make([]FailureSummaryLogEntry, 0, min(int(fileInfo.RowCount-startRow), tail))
+	contentTruncated := false
+	for entry, readErr := range reader.SeekToRow(ctx, startRow) {
+		if readErr != nil {
+			return nil, fileInfo.RowCount, startRow > 0, contentTruncated, 0, fmt.Errorf("read log tail: %w", readErr)
+		}
+		terse := toTerseEntry(entry)
+		var entryContentTruncated bool
+		terse.C, entryContentTruncated = truncateUTF8Bytes(terse.C, failureSummaryEntryContentByteLimit)
+		entries = append(entries, FailureSummaryLogEntry{TerseLogEntry: terse, ContentTruncated: entryContentTruncated})
+		contentTruncated = contentTruncated || entryContentTruncated
+	}
+
+	entries, omitted, jobTruncated := boundFailureLogEntries(entries, failureSummaryLogJobContentByteLimit)
+	return entries, fileInfo.RowCount, startRow > 0, contentTruncated || jobTruncated, omitted, nil
+}
+
+func boundFailureLogEntries(entries []FailureSummaryLogEntry, limit int) ([]FailureSummaryLogEntry, int, bool) {
+	remaining := limit
+	first := len(entries)
+	contentTruncated := false
+	for first > 0 {
+		contentLength := len(entries[first-1].C)
+		if contentLength > remaining {
+			if remaining > 0 {
+				entries[first-1].C, _ = truncateUTF8Bytes(entries[first-1].C, remaining)
+				entries[first-1].ContentTruncated = true
+				contentTruncated = true
+				first--
+			}
+			break
+		}
+		remaining -= contentLength
+		first--
+	}
+
+	if first == 0 {
+		return entries, 0, contentTruncated
+	}
+	result := append([]FailureSummaryLogEntry(nil), entries[first:]...)
+	return result, first, true
+}
+
+func loadFailureLogs(ctx context.Context, client BuildkiteLogsClient, args GetBuildFailureSummaryArgs, sourceJobs []buildkite.Job, jobs []FailureSummaryJob, tail int) error {
+	semaphore := make(chan struct{}, failureSummaryConcurrency)
+	unauthorized := make(chan error, len(sourceJobs))
+	var waitGroup sync.WaitGroup
+
+	for i := range sourceJobs {
+		if !shouldReadFailureLog(sourceJobs[i]) {
+			continue
+		}
+
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			entries, totalRows, truncated, contentTruncated, omitted, err := readFailureLogTail(ctx, client, args, sourceJobs[index], tail)
+			if err != nil {
+				if isBuildkiteUnauthorized(err) {
+					unauthorized <- ErrUnauthorized
+					return
+				}
+				jobs[index].LogError = err.Error()
+				return
+			}
+			jobs[index].LogTail = entries
+			jobs[index].LogTotalRows = totalRows
+			jobs[index].LogTruncated = truncated
+			jobs[index].LogContentTruncated = contentTruncated
+			jobs[index].LogEntriesOmitted = omitted
+		}(i)
+	}
+
+	waitGroup.Wait()
+	select {
+	case err := <-unauthorized:
+		return err
+	default:
+		return nil
+	}
+}
+
+func loadFailureTestRuns(ctx context.Context, client TestExecutionsClient, args GetBuildFailureSummaryArgs, runs []buildkite.TestEngineRun, maxRuns, maxPerRun, maxTotal int) ([]FailureSummaryTestRun, bool, bool, error) {
+	selectedRunCount := min(len(runs), maxRuns)
+	runsTruncated := selectedRunCount < len(runs)
+	perRunLimit := min(maxPerRun, maxTotal)
+	results := make([]FailureSummaryTestRun, selectedRunCount)
+	semaphore := make(chan struct{}, failureSummaryConcurrency)
+	unauthorized := make(chan error, selectedRunCount)
+	var waitGroup sync.WaitGroup
+
+	for i := range results {
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			run := runs[index]
+			result := FailureSummaryTestRun{RunID: run.ID, TestSuiteSlug: run.Suite.Slug}
+			executions, response, err := client.GetFailedExecutions(ctx, args.OrgSlug, run.Suite.Slug, run.ID, &buildkite.FailedExecutionsOptions{
+				IncludeFailureExpanded: args.IncludeFailureExpanded,
+				Page:                   1,
+				PerPage:                perRunLimit,
+			})
+			if err != nil {
+				if isBuildkiteUnauthorized(err) {
+					unauthorized <- ErrUnauthorized
+					return
+				}
+				result.Error = err.Error()
+				result.Truncated = true
+			} else {
+				if len(executions) > perRunLimit {
+					executions = executions[:perRunLimit]
+					result.Truncated = true
+				}
+				result.FailedExecutions = make([]FailureSummaryFailedExecution, len(executions))
+				for i, execution := range executions {
+					result.FailedExecutions[i].FailedExecution = execution
+				}
+				result.Truncated = result.Truncated || (response != nil && response.NextPage > 0)
+			}
+			results[index] = result
+		}(i)
+	}
+
+	waitGroup.Wait()
+	select {
+	case err := <-unauthorized:
+		return nil, false, false, err
+	default:
+	}
+
+	remaining := maxTotal
+	for i := range results {
+		if len(results[i].FailedExecutions) > remaining {
+			results[i].FailedExecutions = results[i].FailedExecutions[:remaining]
+			results[i].Truncated = true
+		}
+		remaining -= len(results[i].FailedExecutions)
+	}
+
+	failedTestsTruncated := runsTruncated
+	for _, result := range results {
+		if result.Truncated {
+			failedTestsTruncated = true
+			break
+		}
+	}
+
+	return results, runsTruncated, failedTestsTruncated, nil
+}
+
+func limitFailureSummaryString(value string, fieldLimit int, entryRemaining, sectionRemaining *int) (string, bool) {
+	limit := min(fieldLimit, *entryRemaining, *sectionRemaining)
+	result, truncated := truncateUTF8Bytes(value, limit)
+	used := len(result)
+	*entryRemaining -= used
+	*sectionRemaining -= used
+	return result, truncated
+}
+
+func failureSummaryLogContentBytes(entries []FailureSummaryLogEntry) int {
+	total := 0
+	for _, entry := range entries {
+		total += len(entry.C)
+	}
+	return total
+}
+
+func consumeFailureSummaryBytes(size int, entryRemaining, sectionRemaining *int) bool {
+	if size > *entryRemaining || size > *sectionRemaining {
+		return false
+	}
+	*entryRemaining -= size
+	*sectionRemaining -= size
+	return true
+}
+
+func limitFailureExpanded(values []buildkite.FailureExpanded, entryRemaining, sectionRemaining *int) ([]buildkite.FailureExpanded, bool) {
+	result := make([]buildkite.FailureExpanded, 0, len(values))
+	truncated := false
+	if len(values) > 0 && !consumeFailureSummaryBytes(len(`"failure_expanded":[]`), entryRemaining, sectionRemaining) {
+		return result, true
+	}
+	for _, value := range values {
+		objectBytes := len(`{}`)
+		if len(result) > 0 {
+			objectBytes++ // comma between failure_expanded items
+		}
+		if !consumeFailureSummaryBytes(objectBytes, entryRemaining, sectionRemaining) {
+			truncated = true
+			break
+		}
+
+		bounded := buildkite.FailureExpanded{}
+		for _, backtrace := range value.Backtrace {
+			structureBytes := len(`""`)
+			if len(bounded.Backtrace) == 0 {
+				structureBytes += len(`"backtrace":[]`)
+			} else {
+				structureBytes++ // comma between backtrace items
+			}
+			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
+				truncated = true
+				break
+			}
+			line, lineTruncated := limitFailureSummaryString(backtrace, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
+			bounded.Backtrace = append(bounded.Backtrace, line)
+			truncated = truncated || lineTruncated
+		}
+		if len(bounded.Backtrace) < len(value.Backtrace) {
+			truncated = true
+		}
+		for _, expanded := range value.Expanded {
+			structureBytes := len(`""`)
+			if len(bounded.Expanded) == 0 {
+				structureBytes += len(`"expanded":[]`)
+				if len(bounded.Backtrace) > 0 {
+					structureBytes++ // comma between object fields
+				}
+			} else {
+				structureBytes++ // comma between expanded items
+			}
+			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
+				truncated = true
+				break
+			}
+			line, lineTruncated := limitFailureSummaryString(expanded, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
+			bounded.Expanded = append(bounded.Expanded, line)
+			truncated = truncated || lineTruncated
+		}
+		if len(bounded.Expanded) < len(value.Expanded) {
+			truncated = true
+		}
+		result = append(result, bounded)
+		if *entryRemaining <= 0 || *sectionRemaining <= 0 {
+			if len(result) < len(values) {
+				truncated = true
+			}
+			break
+		}
+	}
+	return result, truncated
+}
+
+func limitFailureExecution(execution *FailureSummaryFailedExecution, limit int, sectionRemaining *int) bool {
+	entryRemaining := limit
+	truncated := execution.ContentTruncated
+	fields := []*string{
+		&execution.FailureReason,
+		&execution.TestName,
+		&execution.Location,
+		&execution.RunName,
+		&execution.Branch,
+	}
+	for _, field := range fields {
+		var fieldTruncated bool
+		*field, fieldTruncated = limitFailureSummaryString(*field, failureSummaryEntryContentByteLimit, &entryRemaining, sectionRemaining)
+		truncated = truncated || fieldTruncated
+	}
+
+	var expandedTruncated bool
+	execution.FailureExpanded, expandedTruncated = limitFailureExpanded(execution.FailureExpanded, &entryRemaining, sectionRemaining)
+	truncated = truncated || expandedTruncated
+	execution.ContentTruncated = truncated
+	return truncated
+}
+
+func applyFailureSummaryContentLimits(result *BuildFailureSummary) {
+	result.ContentLimitBytes = failureSummaryContentByteLimit
+
+	logRemaining := failureSummaryLogContentByteLimit
+	logItemsRemaining := 0
+	for _, job := range result.Jobs {
+		if len(job.LogTail) > 0 || job.LogError != "" {
+			logItemsRemaining++
+		}
+	}
+	for i := range result.Jobs {
+		job := &result.Jobs[i]
+		if len(job.LogTail) == 0 && job.LogError == "" {
+			continue
+		}
+		itemLimit := min(failureSummaryLogJobContentByteLimit, logRemaining/logItemsRemaining)
+		itemRemaining := itemLimit
+		if job.LogError != "" {
+			var truncated bool
+			job.LogError, truncated = limitFailureSummaryString(job.LogError, failureSummaryEntryContentByteLimit, &itemRemaining, &logRemaining)
+			job.LogContentTruncated = job.LogContentTruncated || truncated
+		}
+		entries, omitted, truncated := boundFailureLogEntries(job.LogTail, min(itemRemaining, logRemaining))
+		used := failureSummaryLogContentBytes(entries)
+		itemRemaining -= used
+		logRemaining -= used
+		job.LogTail = entries
+		job.LogEntriesOmitted += omitted
+		job.LogTruncated = job.LogTruncated || omitted > 0
+		job.LogContentTruncated = job.LogContentTruncated || truncated
+		result.ContentTruncated = result.ContentTruncated || job.LogContentTruncated
+		logItemsRemaining--
+	}
+
+	annotationRemaining := failureSummaryAnnotationContentLimit
+	for i := range result.Warnings {
+		entryRemaining := failureSummaryEntryContentByteLimit
+		var truncated bool
+		result.Warnings[i], truncated = limitFailureSummaryString(result.Warnings[i], failureSummaryEntryContentByteLimit, &entryRemaining, &annotationRemaining)
+		result.ContentTruncated = result.ContentTruncated || truncated
+	}
+	for i := range result.Annotations {
+		annotation := &result.Annotations[i]
+		entryRemaining := failureSummaryEntryContentByteLimit
+		var truncated bool
+		annotation.BodyHTML, truncated = limitFailureSummaryString(annotation.BodyHTML, failureSummaryEntryContentByteLimit, &entryRemaining, &annotationRemaining)
+		annotation.BodyTruncated = annotation.BodyTruncated || truncated
+		result.ContentTruncated = result.ContentTruncated || annotation.BodyTruncated
+	}
+
+	testRemaining := failureSummaryTestContentByteLimit
+	testItemsRemaining := 0
+	for _, run := range result.TestRuns {
+		testItemsRemaining += len(run.FailedExecutions)
+		if run.Error != "" {
+			testItemsRemaining++
+		}
+	}
+	for i := range result.TestRuns {
+		run := &result.TestRuns[i]
+		if run.Error != "" {
+			itemLimit := min(failureSummaryExecutionByteLimit, testRemaining/testItemsRemaining)
+			entryRemaining := itemLimit
+			var truncated bool
+			run.Error, truncated = limitFailureSummaryString(run.Error, failureSummaryEntryContentByteLimit, &entryRemaining, &testRemaining)
+			run.ContentTruncated = run.ContentTruncated || truncated
+			testItemsRemaining--
+		}
+		for j := range run.FailedExecutions {
+			itemLimit := min(failureSummaryExecutionByteLimit, testRemaining/testItemsRemaining)
+			truncated := limitFailureExecution(&run.FailedExecutions[j], itemLimit, &testRemaining)
+			run.ContentTruncated = run.ContentTruncated || truncated
+			testItemsRemaining--
+		}
+		result.ContentTruncated = result.ContentTruncated || run.ContentTruncated
+	}
+}
+
+func failureSummaryWithLogEntryLimit(result *BuildFailureSummary, perJobLimit int) BuildFailureSummary {
+	limited := *result
+	limited.Jobs = append([]FailureSummaryJob(nil), result.Jobs...)
+	for i := range limited.Jobs {
+		entries := result.Jobs[i].LogTail
+		if len(entries) <= perJobLimit {
+			continue
+		}
+
+		omitted := len(entries) - perJobLimit
+		limited.Jobs[i].LogTail = entries[omitted:]
+		limited.Jobs[i].LogEntriesOmitted += omitted
+		limited.Jobs[i].LogTruncated = true
+		limited.Jobs[i].LogContentTruncated = true
+		limited.ContentTruncated = true
+	}
+	return limited
+}
+
+func marshalFailureSummaryWithContentBytes(result *BuildFailureSummary) ([]byte, error) {
+	result.ContentBytes = 0
+	for {
+		payload, err := marshalSanitizedJSON(result)
+		if err != nil {
+			return nil, err
+		}
+		if result.ContentBytes == len(payload) {
+			return payload, nil
+		}
+		result.ContentBytes = len(payload)
+	}
+}
+
+func limitFailureSummaryLogCollections(result *BuildFailureSummary, limit int) error {
+	payload, err := marshalFailureSummaryWithContentBytes(result)
+	if err != nil {
+		return err
+	}
+	if len(payload) <= limit {
+		return nil
+	}
+
+	maxEntries := 0
+	for _, job := range result.Jobs {
+		maxEntries = max(maxEntries, len(job.LogTail))
+	}
+	if maxEntries == 0 {
+		return nil
+	}
+
+	best := failureSummaryWithLogEntryLimit(result, 0)
+	low, high := 0, maxEntries
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate := failureSummaryWithLogEntryLimit(result, mid)
+		candidatePayload, candidateErr := marshalFailureSummaryWithContentBytes(&candidate)
+		if candidateErr != nil {
+			return candidateErr
+		}
+		if len(candidatePayload) <= limit {
+			best = candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+
+	*result = best
+	return nil
+}
+
+func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "get_build_failure_summary",
+			Description: "Diagnose a Buildkite build failure in one call. Returns build state, failed and broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Start with this tool before calling individual job, log, annotation, or test tools.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Build Failure Summary",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args GetBuildFailureSummaryArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
+			defer span.End()
+
+			logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
+			maxJobs := boundedValue(args.MaxJobs, defaultFailureSummaryJobs, maxFailureSummaryJobs)
+			maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
+			maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
+			maxFailedTestsPerRun := boundedValue(args.MaxFailedTestsPerRun, defaultFailureSummaryTestsPerRun, maxFailureSummaryTestsPerRun)
+			maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.Int("log_tail", logTail),
+				attribute.Int("max_jobs", maxJobs),
+				attribute.Int("max_test_runs", maxTestRuns),
+				attribute.Int("max_failed_tests", maxFailedTests),
+				attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
+				attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
+				attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
+			)
+
+			deps := DepsFromContext(ctx)
+			build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
+				BuildsListOptions: buildkite.BuildsListOptions{
+					ExcludeJobs:     true,
+					ExcludePipeline: true,
+				},
+				IncludeTestEngine: true,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			result := BuildFailureSummary{Build: failureSummaryBuild(build)}
+
+			includeRetriedJobs := false
+			jobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				// The API's failed filter includes running jobs with a hard promised
+				// failure. Querying running separately can include promises covered by
+				// soft-fail or retry rules that do not put the build into failing.
+				State:              []string{"failed", "broken"},
+				IncludeRetriedJobs: &includeRetriedJobs,
+				PerPage:            100,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			sourceJobs := make([]buildkite.Job, 0, min(len(jobsList.Items), maxJobs))
+			failureJobCount := 0
+			for _, job := range jobsList.Items {
+				if !isFailureSummaryJob(job) {
+					continue
+				}
+				failureJobCount++
+				if len(sourceJobs) < maxJobs {
+					sourceJobs = append(sourceJobs, job)
+				}
+			}
+			result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
+			for i, job := range sourceJobs {
+				result.Jobs[i] = failureSummaryJob(job)
+			}
+			result.JobsTruncated = failureJobCount > maxJobs || jobsList.Links.Next != ""
+
+			if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
+				if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {
+					return nil, nil, err
+				}
+			}
+
+			if defaultTrue(args.IncludeAnnotations) && deps.AnnotationsClient != nil {
+				result.Annotations, result.AnnotationsTruncated, err = loadFailureAnnotations(ctx, deps.AnnotationsClient, args, maxAnnotations)
+				if err != nil {
+					if isBuildkiteUnauthorized(err) {
+						return nil, nil, ErrUnauthorized
+					}
+					result.Warnings = append(result.Warnings, fmt.Sprintf("annotations unavailable after partial scan: %v", err))
+				}
+			}
+
+			if defaultTrue(args.IncludeFailedTests) && deps.TestExecutionsClient != nil && build.TestEngine != nil {
+				result.TestRuns, result.TestRunsTruncated, result.FailedTestsTruncated, err = loadFailureTestRuns(
+					ctx,
+					deps.TestExecutionsClient,
+					args,
+					build.TestEngine.Runs,
+					maxTestRuns,
+					maxFailedTestsPerRun,
+					maxFailedTests,
+				)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+
+			applyFailureSummaryContentLimits(&result)
+			if err := limitFailureSummaryLogCollections(&result, failureSummaryContentByteLimit); err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
+			}
+
+			span.SetAttributes(
+				attribute.Int("failure_job_count", len(result.Jobs)),
+				attribute.Int("annotation_count", len(result.Annotations)),
+				attribute.Int("test_run_count", len(result.TestRuns)),
+			)
+
+			return mcpTextResultWithByteLimit(span, &result, failureSummaryContentByteLimit)
+		}, []string{"read_builds", "read_build_logs", "read_suites"}
+}

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -138,15 +138,19 @@ func failureSummaryBuild(build buildkite.Build) BuildFailureSummaryBuild {
 	}
 }
 
-func isFailureSummaryJob(job buildkite.Job) bool {
-	if job.State == "failed" || job.State == "broken" {
+func isPrimaryFailureSummaryJob(job buildkite.Job) bool {
+	if job.State == "failed" || job.State == "timed_out" {
 		return true
 	}
 	return job.State == "running" && job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0
 }
 
+func isFailureSummaryJob(job buildkite.Job) bool {
+	return isPrimaryFailureSummaryJob(job) || job.State == "broken"
+}
+
 func shouldReadFailureLog(job buildkite.Job) bool {
-	return job.State == "failed" || (job.State == "running" && job.PromisedExitStatus != nil && *job.PromisedExitStatus != 0)
+	return isPrimaryFailureSummaryJob(job)
 }
 
 func failureSummaryJob(job buildkite.Job) FailureSummaryJob {
@@ -732,34 +736,56 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			result := BuildFailureSummary{Build: failureSummaryBuild(build)}
 
 			includeRetriedJobs := false
-			jobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+			primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
 				// The API's failed filter includes running jobs with a hard promised
 				// failure. Querying running separately can include promises covered by
 				// soft-fail or retry rules that do not put the build into failing.
-				State:              []string{"failed", "broken"},
+				State:              []string{"failed", "timed_out"},
 				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            100,
+				PerPage:            maxJobs + 1,
 			})
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
 
-			sourceJobs := make([]buildkite.Job, 0, min(len(jobsList.Items), maxJobs))
-			failureJobCount := 0
-			for _, job := range jobsList.Items {
-				if !isFailureSummaryJob(job) {
+			sourceJobs := make([]buildkite.Job, 0, maxJobs)
+			jobsTruncated := primaryJobsList.Links.Next != ""
+			for _, job := range primaryJobsList.Items {
+				if !isPrimaryFailureSummaryJob(job) {
 					continue
 				}
-				failureJobCount++
 				if len(sourceJobs) < maxJobs {
 					sourceJobs = append(sourceJobs, job)
+				} else {
+					jobsTruncated = true
+				}
+			}
+
+			remainingJobs := maxJobs - len(sourceJobs)
+			brokenJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"broken"},
+				IncludeRetriedJobs: &includeRetriedJobs,
+				PerPage:            remainingJobs + 1,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+			jobsTruncated = jobsTruncated || brokenJobsList.Links.Next != ""
+			for _, job := range brokenJobsList.Items {
+				if !isFailureSummaryJob(job) || job.State != "broken" {
+					continue
+				}
+				if len(sourceJobs) < maxJobs {
+					sourceJobs = append(sourceJobs, job)
+				} else {
+					jobsTruncated = true
 				}
 			}
 			result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
 			for i, job := range sourceJobs {
 				result.Jobs[i] = failureSummaryJob(job)
 			}
-			result.JobsTruncated = failureJobCount > maxJobs || jobsList.Links.Next != ""
+			result.JobsTruncated = jobsTruncated
 
 			if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
 				if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -64,7 +64,7 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 			require.False(t, *options.IncludeRetriedJobs)
 			switch options.State[0] {
 			case "failed":
-				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
 				require.Equal(t, defaultFailureSummaryJobs+1, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "job-failed", Name: "compile", State: "failed", Command: "make build", ExitStatus: testPtr(1)},
@@ -72,7 +72,7 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 					{ID: "job-running", Name: "unrelated", State: "running"},
 				}}, &buildkite.Response{}, nil
 			case "broken":
-				require.Equal(t, []string{"broken"}, options.State)
+				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
 				require.Equal(t, defaultFailureSummaryJobs-1, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "job-broken", Name: "deploy", State: "broken"},
@@ -222,13 +222,14 @@ func TestGetBuildFailureSummaryPrioritizesFailuresBeforeBrokenJobs(t *testing.T)
 		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
 			switch options.State[0] {
 			case "failed":
-				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
 				require.Equal(t, 3, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "failed", State: "failed"},
 					{ID: "promised", State: "running", PromisedExitStatus: &promisedExitStatus},
 				}}, &buildkite.Response{}, nil
 			case "broken":
+				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
 				require.Equal(t, 1, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "broken-1", State: "broken"},
@@ -267,7 +268,7 @@ func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
 		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
 			switch options.State[0] {
 			case "failed":
-				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
 				return buildkite.JobsList{Items: []buildkite.Job{{ID: "timed-out", State: "timed_out"}}}, &buildkite.Response{}, nil
 			case "broken":
 				return buildkite.JobsList{}, &buildkite.Response{}, nil
@@ -299,6 +300,86 @@ func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
 	require.Len(t, summary.Jobs, 1)
 	require.Equal(t, "timed_out", summary.Jobs[0].State)
 	require.Equal(t, []string{"running", "job timed out"}, []string{summary.Jobs[0].LogTail[0].C, summary.Jobs[0].LogTail[1].C})
+}
+
+func TestGetBuildFailureSummaryIncludesExpiredAndDownstreamFailedJobsWithoutLogs(t *testing.T) {
+	expiredAt := buildkite.NewTimestamp(time.Date(2026, time.July, 24, 1, 2, 3, 0, time.UTC))
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "failed"}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			switch options.State[0] {
+			case "failed":
+				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "expired", State: "expired", ExpiredAt: expiredAt}}}, &buildkite.Response{}, nil
+			case "broken":
+				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "waiting", State: "waiting_failed"}}}, &buildkite.Response{}, nil
+			default:
+				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
+			}
+		},
+	}
+	logCalls := 0
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+			logCalls++
+			return nil, errors.New("unexpected log request")
+		},
+	}
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient: buildsClient, JobsClient: jobsClient, BuildkiteLogsClient: logsClient,
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		IncludeAnnotations: &include, IncludeFailedTests: &include,
+	})
+	require.NoError(t, err)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Equal(t, []string{"expired", "waiting"}, []string{summary.Jobs[0].ID, summary.Jobs[1].ID})
+	require.NotNil(t, summary.Jobs[0].ExpiredAt)
+	require.Empty(t, summary.Jobs[0].LogTail)
+	require.Empty(t, summary.Jobs[1].LogTail)
+	require.Zero(t, logCalls)
+}
+
+func TestFailureSummaryJobClassification(t *testing.T) {
+	promisedExitStatus := 1
+	tests := []struct {
+		name      string
+		job       buildkite.Job
+		primary   bool
+		secondary bool
+		readLog   bool
+	}{
+		{name: "failed", job: buildkite.Job{State: "failed"}, primary: true, readLog: true},
+		{name: "timed out", job: buildkite.Job{State: "timed_out"}, primary: true, readLog: true},
+		{name: "expired", job: buildkite.Job{State: "expired"}, primary: true},
+		{name: "canceled", job: buildkite.Job{State: "canceled"}, secondary: true, readLog: true},
+		{name: "promised failure", job: buildkite.Job{State: "running", PromisedExitStatus: &promisedExitStatus}, primary: true, readLog: true},
+		{name: "broken", job: buildkite.Job{State: "broken"}, secondary: true},
+		{name: "waiting failed", job: buildkite.Job{State: "waiting_failed"}, secondary: true},
+		{name: "blocked failed", job: buildkite.Job{State: "blocked_failed"}, secondary: true},
+		{name: "unblocked failed", job: buildkite.Job{State: "unblocked_failed"}, secondary: true},
+		{name: "passed", job: buildkite.Job{State: "passed"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.primary, isPrimaryFailureSummaryJob(test.job))
+			require.Equal(t, test.secondary, isSecondaryFailureSummaryJob(test.job))
+			require.Equal(t, test.primary || test.secondary, isFailureSummaryJob(test.job))
+			require.Equal(t, test.readLog, shouldReadFailureLog(test.job))
+		})
+	}
 }
 
 func TestGetBuildFailureSummaryCanDisableOptionalSections(t *testing.T) {

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -1,0 +1,685 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	buildkitelogs "github.com/buildkite/buildkite-logs"
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBuildFailureSummaryToolDefinition(t *testing.T) {
+	tool, handler, scopes := GetBuildFailureSummary()
+
+	require.Equal(t, "get_build_failure_summary", tool.Name)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Contains(t, tool.Description, "one call")
+	require.Equal(t, []string{"read_builds", "read_build_logs", "read_suites"}, scopes)
+	require.NotNil(t, handler)
+}
+
+func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
+	failedLog := t.TempDir() + "/failed.parquet"
+	promisedLog := t.TempDir() + "/promised.parquet"
+	writeTestParquetFile(t, failedLog, []string{"setup", "compile error", "build failed"})
+	writeTestParquetFile(t, promisedLog, []string{"tests running", "test failure promised"})
+
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(_ context.Context, org, pipeline, number string, options *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "pipeline", pipeline)
+			require.Equal(t, "42", number)
+			require.True(t, options.ExcludeJobs)
+			require.True(t, options.ExcludePipeline)
+			require.True(t, options.IncludeTestEngine)
+			return buildkite.Build{
+				ID:      "build-id",
+				Number:  42,
+				State:   "failing",
+				Branch:  "main",
+				Commit:  "abc123",
+				Message: "Fix tests",
+				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
+					ID:    "run-1",
+					Suite: buildkite.TestEngineSuite{Slug: "suite-1"},
+				}}},
+			}, &buildkite.Response{Response: &http.Response{StatusCode: http.StatusOK}}, nil
+		},
+	}
+
+	promisedExitStatus := 1
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, org, pipeline, number string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			require.Equal(t, []string{"failed", "broken"}, options.State)
+			require.Equal(t, 100, options.PerPage)
+			require.NotNil(t, options.IncludeRetriedJobs)
+			require.False(t, *options.IncludeRetriedJobs)
+			return buildkite.JobsList{Items: []buildkite.Job{
+				{ID: "job-failed", Name: "compile", State: "failed", Command: "make build", ExitStatus: testPtr(1)},
+				{ID: "job-broken", Name: "deploy", State: "broken"},
+				{ID: "job-promised", Name: "tests", State: "running", PromisedExitStatus: &promisedExitStatus},
+				{ID: "job-running", Name: "unrelated", State: "running"},
+			}}, &buildkite.Response{}, nil
+		},
+	}
+
+	annotationsClient := &MockAnnotationsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			require.Equal(t, "all", options.Scope)
+			require.Equal(t, failureSummaryAnnotationPageSize, options.PerPage)
+			switch options.Page {
+			case 1:
+				return []buildkite.Annotation{{ID: "annotation-success", Context: "coverage", Style: "success", BodyHTML: "coverage passed"}}, &buildkite.Response{NextPage: 2}, nil
+			case 2:
+				return []buildkite.Annotation{
+					{ID: "annotation-error", Context: "tests", Style: "error", BodyHTML: "<p>2 tests failed</p>"},
+					{ID: "annotation-warning", Context: "lint", Style: "warning", JobID: "job-failed", BodyHTML: "lint warning"},
+				}, &buildkite.Response{}, nil
+			default:
+				return nil, nil, errors.New("unexpected annotation page")
+			}
+		},
+	}
+
+	type testExecutionCall struct {
+		org, suite, runID string
+		options           buildkite.FailedExecutionsOptions
+	}
+	var testExecutionCallsMu sync.Mutex
+	var testExecutionCalls []testExecutionCall
+	testExecutionsClient := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(_ context.Context, org, suite, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			testExecutionCallsMu.Lock()
+			testExecutionCalls = append(testExecutionCalls, testExecutionCall{org: org, suite: suite, runID: runID, options: *options})
+			testExecutionCallsMu.Unlock()
+			return []buildkite.FailedExecution{{
+				ExecutionID:   "execution-1",
+				TestName:      "TestWidgets",
+				FailureReason: "expected 2, got 3",
+			}}, &buildkite.Response{NextPage: 2}, nil
+		},
+	}
+
+	type logCall struct {
+		ttl          time.Duration
+		forceRefresh bool
+	}
+	var logCallsMu sync.Mutex
+	logCalls := map[string][]logCall{}
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(_ context.Context, _, _, _, job string, ttl time.Duration, forceRefresh bool) (*buildkitelogs.ParquetReader, error) {
+			logCallsMu.Lock()
+			logCalls[job] = append(logCalls[job], logCall{ttl: ttl, forceRefresh: forceRefresh})
+			logCallsMu.Unlock()
+			switch job {
+			case "job-failed":
+				return buildkitelogs.NewParquetReader(failedLog), nil
+			case "job-promised":
+				return buildkitelogs.NewParquetReader(promisedLog), nil
+			default:
+				return nil, errors.New("unexpected log request")
+			}
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:         buildsClient,
+		JobsClient:           jobsClient,
+		AnnotationsClient:    annotationsClient,
+		TestExecutionsClient: testExecutionsClient,
+		BuildkiteLogsClient:  logsClient,
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug:              "org",
+		PipelineSlug:         "pipeline",
+		BuildNumber:          "42",
+		LogTail:              2,
+		MaxFailedTestsPerRun: 7,
+	})
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+
+	text := getTextResult(t, callResult).Text
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(text), &summary))
+	require.LessOrEqual(t, len(text), failureSummaryContentByteLimit)
+	require.Equal(t, len(text), summary.ContentBytes)
+	require.Equal(t, "failing", summary.Build.State)
+	require.Equal(t, 42, summary.Build.Number)
+	require.Len(t, summary.Jobs, 3)
+	require.False(t, summary.JobsTruncated)
+
+	require.Equal(t, "job-failed", summary.Jobs[0].ID)
+	require.Equal(t, int64(3), summary.Jobs[0].LogTotalRows)
+	require.True(t, summary.Jobs[0].LogTruncated)
+	require.Equal(t, []string{"compile error", "build failed"}, []string{summary.Jobs[0].LogTail[0].C, summary.Jobs[0].LogTail[1].C})
+
+	require.Equal(t, "job-broken", summary.Jobs[1].ID)
+	require.Empty(t, summary.Jobs[1].LogTail)
+	require.Empty(t, summary.Jobs[1].LogError)
+
+	require.Equal(t, "job-promised", summary.Jobs[2].ID)
+	require.Equal(t, 1, *summary.Jobs[2].PromisedExitStatus)
+	require.Len(t, summary.Jobs[2].LogTail, 2)
+
+	require.Len(t, summary.Annotations, 2)
+	require.False(t, summary.AnnotationsTruncated)
+	require.Equal(t, "annotation-error", summary.Annotations[0].ID)
+	require.NotContains(t, getTextResult(t, callResult).Text, "coverage passed")
+
+	require.Len(t, summary.TestRuns, 1)
+	require.Equal(t, "suite-1", summary.TestRuns[0].TestSuiteSlug)
+	require.True(t, summary.TestRuns[0].Truncated)
+	require.Equal(t, "TestWidgets", summary.TestRuns[0].FailedExecutions[0].TestName)
+	require.False(t, summary.TestRunsTruncated)
+	require.True(t, summary.FailedTestsTruncated)
+
+	testExecutionCallsMu.Lock()
+	require.Equal(t, []testExecutionCall{{
+		org: "org", suite: "suite-1", runID: "run-1",
+		options: buildkite.FailedExecutionsOptions{Page: 1, PerPage: 7},
+	}}, testExecutionCalls)
+	testExecutionCallsMu.Unlock()
+
+	logCallsMu.Lock()
+	require.Equal(t, map[string][]logCall{
+		"job-failed":   {{ttl: 30 * time.Second}},
+		"job-promised": {{ttl: 30 * time.Second}},
+	}, logCalls)
+	logCallsMu.Unlock()
+}
+
+func TestGetBuildFailureSummaryCanDisableOptionalSections(t *testing.T) {
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "passed"}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: buildsClient, JobsClient: jobsClient})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug:            "org",
+		PipelineSlug:       "pipeline",
+		BuildNumber:        "1",
+		IncludeLogs:        &include,
+		IncludeAnnotations: &include,
+		IncludeFailedTests: &include,
+	})
+
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Equal(t, "passed", summary.Build.State)
+	require.Empty(t, summary.Jobs)
+	require.Empty(t, summary.Annotations)
+	require.Empty(t, summary.TestRuns)
+}
+
+func TestGetBuildFailureSummaryLimitsFinalEscapedJSONPayload(t *testing.T) {
+	escapeHeavy := strings.Repeat("\"\\\n", failureSummaryContentByteLimit)
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+				ID:      "build-id",
+				Number:  1,
+				State:   "failed",
+				Message: escapeHeavy,
+			}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{Items: []buildkite.Job{{
+				ID:      "job-id",
+				Name:    "escaped command",
+				State:   "failed",
+				Command: escapeHeavy,
+			}}}, &buildkite.Response{}, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient: buildsClient,
+		JobsClient:   jobsClient,
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
+	})
+
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+	text := getTextResult(t, callResult).Text
+	require.LessOrEqual(t, len(text), failureSummaryContentByteLimit)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(text), &summary))
+	require.Equal(t, len(text), summary.ContentBytes)
+	require.Equal(t, failureSummaryContentByteLimit, summary.ContentLimitBytes)
+	require.True(t, summary.ContentTruncated)
+	require.Less(t, len(summary.Build.Message), len(escapeHeavy))
+	require.Less(t, len(summary.Jobs[0].Command), len(escapeHeavy))
+}
+
+func TestGetBuildFailureSummaryBoundsTestEngineWork(t *testing.T) {
+	runs := make([]buildkite.TestEngineRun, 4)
+	for i := range runs {
+		runs[i] = buildkite.TestEngineRun{
+			ID:    fmt.Sprintf("run-%d", i+1),
+			Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
+		}
+	}
+
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "failed", TestEngine: &buildkite.TestEngineProperty{Runs: runs}}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+
+	var callsMu sync.Mutex
+	calls := map[string]int{}
+	testExecutionsClient := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			callsMu.Lock()
+			calls[runID] = options.PerPage
+			callsMu.Unlock()
+
+			executions := make([]buildkite.FailedExecution, options.PerPage)
+			for i := range executions {
+				executions[i] = buildkite.FailedExecution{ExecutionID: fmt.Sprintf("%s-execution-%d", runID, i+1)}
+			}
+			response := &buildkite.Response{}
+			if runID == "run-1" {
+				response.NextPage = 2
+			}
+			return executions, response, nil
+		},
+	}
+
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:         buildsClient,
+		JobsClient:           jobsClient,
+		TestExecutionsClient: testExecutionsClient,
+	})
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug:              "org",
+		PipelineSlug:         "pipeline",
+		BuildNumber:          "1",
+		IncludeLogs:          &include,
+		IncludeAnnotations:   &include,
+		MaxTestRuns:          2,
+		MaxFailedTests:       3,
+		MaxFailedTestsPerRun: 2,
+	})
+	require.NoError(t, err)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Len(t, summary.TestRuns, 2)
+	require.True(t, summary.TestRunsTruncated)
+	require.True(t, summary.FailedTestsTruncated)
+	require.Len(t, summary.TestRuns[0].FailedExecutions, 2)
+	require.Len(t, summary.TestRuns[1].FailedExecutions, 1)
+
+	callsMu.Lock()
+	require.Equal(t, map[string]int{"run-1": 2, "run-2": 2}, calls)
+	callsMu.Unlock()
+}
+
+func TestLoadFailureTestRunsInspectsMaxRunsIndependentlyOfMaxTotal(t *testing.T) {
+	runs := make([]buildkite.TestEngineRun, 20)
+	for i := range runs {
+		runs[i] = buildkite.TestEngineRun{
+			ID:    fmt.Sprintf("run-%d", i+1),
+			Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
+		}
+	}
+
+	var callsMu sync.Mutex
+	calls := map[string]int{}
+	client := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			callsMu.Lock()
+			calls[runID] = options.PerPage
+			callsMu.Unlock()
+			if runID == "run-20" {
+				return []buildkite.FailedExecution{{ExecutionID: "execution-1"}}, &buildkite.Response{}, nil
+			}
+			return nil, &buildkite.Response{}, nil
+		},
+	}
+
+	results, runsTruncated, failedTestsTruncated, err := loadFailureTestRuns(
+		context.Background(), client, GetBuildFailureSummaryArgs{OrgSlug: "org"}, runs, 20, 20, 1,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, results, 20)
+	require.False(t, runsTruncated)
+	require.False(t, failedTestsTruncated)
+	require.Empty(t, results[0].FailedExecutions)
+	require.Equal(t, "execution-1", results[19].FailedExecutions[0].ExecutionID)
+	callsMu.Lock()
+	require.Len(t, calls, 20)
+	for _, perPage := range calls {
+		require.Equal(t, 1, perPage)
+	}
+	callsMu.Unlock()
+}
+
+func TestLoadFailureTestRunsRedistributesUnusedCapacity(t *testing.T) {
+	client := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			require.Equal(t, 2, options.PerPage)
+			if runID == "run-1" {
+				return nil, &buildkite.Response{}, nil
+			}
+			return []buildkite.FailedExecution{{ExecutionID: "execution-1"}, {ExecutionID: "execution-2"}}, &buildkite.Response{}, nil
+		},
+	}
+	runs := []buildkite.TestEngineRun{
+		{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
+		{ID: "run-2", Suite: buildkite.TestEngineSuite{Slug: "suite-2"}},
+	}
+
+	results, runsTruncated, failedTestsTruncated, err := loadFailureTestRuns(
+		context.Background(), client, GetBuildFailureSummaryArgs{OrgSlug: "org"}, runs, 2, 2, 3,
+	)
+
+	require.NoError(t, err)
+	require.False(t, runsTruncated)
+	require.False(t, failedTestsTruncated)
+	require.Empty(t, results[0].FailedExecutions)
+	require.Len(t, results[1].FailedExecutions, 2)
+}
+
+func TestFailureSummaryOptionalLoadersPropagateUnauthorized(t *testing.T) {
+	unauthorized := fmt.Errorf("wrapped API failure: %w", &buildkite.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "https", Host: "api.buildkite.com"},
+			},
+		},
+	})
+	args := GetBuildFailureSummaryArgs{OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1"}
+
+	t.Run("annotations", func(t *testing.T) {
+		client := &MockAnnotationsClient{
+			ListByBuildFunc: func(context.Context, string, string, string, *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+				return nil, nil, unauthorized
+			},
+		}
+
+		_, _, err := loadFailureAnnotations(context.Background(), client, args, 1)
+		require.ErrorIs(t, err, ErrUnauthorized)
+	})
+
+	t.Run("logs", func(t *testing.T) {
+		client := &MockBuildkiteLogsClient{
+			NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+				return nil, unauthorized
+			},
+		}
+		jobs := []FailureSummaryJob{{}}
+
+		err := loadFailureLogs(context.Background(), client, args, []buildkite.Job{{ID: "job", State: "failed"}}, jobs, 1)
+		require.ErrorIs(t, err, ErrUnauthorized)
+		require.Empty(t, jobs[0].LogError)
+	})
+
+	t.Run("test executions", func(t *testing.T) {
+		client := &MockTestExecutionsClient{
+			GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+				return nil, nil, unauthorized
+			},
+		}
+		runs := []buildkite.TestEngineRun{{ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"}}}
+
+		_, _, _, err := loadFailureTestRuns(context.Background(), client, args, runs, 1, 1, 1)
+		require.ErrorIs(t, err, ErrUnauthorized)
+	})
+}
+
+func TestFailureSummaryOptionalLoadersPreserveOrdinaryErrors(t *testing.T) {
+	args := GetBuildFailureSummaryArgs{OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1"}
+
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+			return nil, errors.New("logs unavailable")
+		},
+	}
+	jobs := []FailureSummaryJob{{}}
+	require.NoError(t, loadFailureLogs(context.Background(), logsClient, args, []buildkite.Job{{ID: "job", State: "failed"}}, jobs, 1))
+	require.Contains(t, jobs[0].LogError, "logs unavailable")
+
+	testClient := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			return nil, nil, errors.New("tests unavailable")
+		},
+	}
+	runs, _, failedTestsTruncated, err := loadFailureTestRuns(context.Background(), testClient, args, []buildkite.TestEngineRun{{ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"}}}, 1, 1, 1)
+	require.NoError(t, err)
+	require.Contains(t, runs[0].Error, "tests unavailable")
+	require.True(t, runs[0].Truncated)
+	require.True(t, failedTestsTruncated)
+}
+
+func TestReadFailureLogTailBoundsEntryContent(t *testing.T) {
+	logPath := t.TempDir() + "/large.parquet"
+	writeTestParquetFile(t, logPath, []string{strings.Repeat("é", failureSummaryEntryContentByteLimit)})
+	client := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+			return buildkitelogs.NewParquetReader(logPath), nil
+		},
+	}
+
+	entries, _, _, contentTruncated, _, err := readFailureLogTail(context.Background(), client, GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+	}, buildkite.Job{ID: "job"}, 1)
+
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.LessOrEqual(t, len(entries[0].C), failureSummaryEntryContentByteLimit)
+	require.True(t, entries[0].ContentTruncated)
+	require.True(t, contentTruncated)
+	require.True(t, utf8.ValidString(entries[0].C))
+}
+
+func TestBoundFailureLogEntriesReportsPartialEntryTruncation(t *testing.T) {
+	entries, omitted, truncated := boundFailureLogEntries([]FailureSummaryLogEntry{{
+		TerseLogEntry: TerseLogEntry{C: "123456"},
+	}}, 5)
+
+	require.Len(t, entries, 1)
+	require.Zero(t, omitted)
+	require.True(t, truncated)
+	require.True(t, entries[0].ContentTruncated)
+	require.LessOrEqual(t, len(entries[0].C), 5)
+}
+
+func TestApplyFailureSummaryContentLimitsBoundsAggregateAndExpandedFailures(t *testing.T) {
+	const jobs = 10
+	const entriesPerJob = 50
+	content := strings.Repeat("x", failureSummaryEntryContentByteLimit)
+	result := BuildFailureSummary{
+		Jobs:        make([]FailureSummaryJob, jobs),
+		Annotations: make([]FailureSummaryAnnotation, 20),
+		TestRuns: []FailureSummaryTestRun{{
+			FailedExecutions: make([]FailureSummaryFailedExecution, 10),
+		}},
+	}
+	for i := range result.Jobs {
+		result.Jobs[i].LogTail = make([]FailureSummaryLogEntry, entriesPerJob)
+		for j := range result.Jobs[i].LogTail {
+			result.Jobs[i].LogTail[j].C = content
+		}
+	}
+	for i := range result.Annotations {
+		result.Annotations[i].BodyHTML = content
+	}
+	for i := range result.TestRuns[0].FailedExecutions {
+		execution := &result.TestRuns[0].FailedExecutions[i]
+		execution.FailureReason = content
+		execution.FailureExpanded = []buildkite.FailureExpanded{{
+			Backtrace: []string{content, content},
+			Expanded:  []string{content, content},
+		}}
+	}
+
+	applyFailureSummaryContentLimits(&result)
+
+	require.Equal(t, failureSummaryContentByteLimit, result.ContentLimitBytes)
+	require.True(t, result.ContentTruncated)
+	for _, job := range result.Jobs {
+		require.True(t, job.LogContentTruncated)
+		require.Positive(t, job.LogEntriesOmitted)
+		require.True(t, job.LogTruncated)
+		for _, entry := range job.LogTail {
+			require.LessOrEqual(t, len(entry.C), failureSummaryEntryContentByteLimit)
+		}
+	}
+	require.True(t, result.Annotations[len(result.Annotations)-1].BodyTruncated)
+	require.True(t, result.TestRuns[0].ContentTruncated)
+	for _, execution := range result.TestRuns[0].FailedExecutions {
+		require.True(t, execution.ContentTruncated)
+	}
+}
+
+func TestLimitFailureExpandedBoundsEmptyArrayStructure(t *testing.T) {
+	tests := map[string][]buildkite.FailureExpanded{
+		"failure expanded items": make([]buildkite.FailureExpanded, failureSummaryContentByteLimit),
+		"backtrace items": {{
+			Backtrace: make([]string, failureSummaryContentByteLimit),
+		}},
+		"expanded items": {{
+			Expanded: make([]string, failureSummaryContentByteLimit),
+		}},
+	}
+
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			entryRemaining := failureSummaryExecutionByteLimit
+			sectionRemaining := failureSummaryTestContentByteLimit
+			limited, truncated := limitFailureExpanded(values, &entryRemaining, &sectionRemaining)
+
+			require.True(t, truncated)
+			require.GreaterOrEqual(t, entryRemaining, 0)
+			require.GreaterOrEqual(t, sectionRemaining, 0)
+			payload, err := json.Marshal(limited)
+			require.NoError(t, err)
+			require.LessOrEqual(t, len(payload), failureSummaryExecutionByteLimit)
+		})
+	}
+}
+
+func TestLimitFailureSummaryLogCollectionsRetainsNewestRowsAndUpdatesMetadata(t *testing.T) {
+	const jobCount = 50
+	const entriesPerJob = 200
+	result := BuildFailureSummary{Jobs: make([]FailureSummaryJob, jobCount)}
+	for i := range result.Jobs {
+		result.Jobs[i].LogTail = make([]FailureSummaryLogEntry, entriesPerJob)
+		for row := range result.Jobs[i].LogTail {
+			result.Jobs[i].LogTail[row] = FailureSummaryLogEntry{
+				TerseLogEntry: TerseLogEntry{C: "0123456789", RN: int64(row)},
+			}
+		}
+	}
+	applyFailureSummaryContentLimits(&result)
+	for _, job := range result.Jobs {
+		require.Len(t, job.LogTail, entriesPerJob)
+	}
+
+	require.NoError(t, limitFailureSummaryLogCollections(&result, failureSummaryContentByteLimit))
+	payload, err := marshalFailureSummaryWithContentBytes(&result)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(payload), failureSummaryContentByteLimit)
+	require.Equal(t, len(payload), result.ContentBytes)
+	require.True(t, result.ContentTruncated)
+
+	for _, job := range result.Jobs {
+		require.NotEmpty(t, job.LogTail)
+		require.Less(t, len(job.LogTail), entriesPerJob)
+		require.Equal(t, int64(entriesPerJob-1), job.LogTail[len(job.LogTail)-1].RN)
+		require.Equal(t, int64(job.LogEntriesOmitted), job.LogTail[0].RN)
+		require.Equal(t, entriesPerJob-len(job.LogTail), job.LogEntriesOmitted)
+		require.True(t, job.LogTruncated)
+		require.True(t, job.LogContentTruncated)
+	}
+
+	genericLimited, err := limitSanitizedJSONPayload(payload, failureSummaryContentByteLimit)
+	require.NoError(t, err)
+	var genericResult BuildFailureSummary
+	require.NoError(t, json.Unmarshal(genericLimited, &genericResult))
+	for i := range result.Jobs {
+		require.Len(t, genericResult.Jobs[i].LogTail, len(result.Jobs[i].LogTail))
+		require.Equal(t, result.Jobs[i].LogTail[0].RN, genericResult.Jobs[i].LogTail[0].RN)
+		require.Equal(t, int64(entriesPerJob-1), genericResult.Jobs[i].LogTail[len(genericResult.Jobs[i].LogTail)-1].RN)
+	}
+}
+
+func TestApplyFailureSummaryContentLimitsPreservesWarnings(t *testing.T) {
+	content := strings.Repeat("x", failureSummaryEntryContentByteLimit)
+	result := BuildFailureSummary{
+		Annotations: make([]FailureSummaryAnnotation, failureSummaryAnnotationContentLimit/failureSummaryEntryContentByteLimit),
+		Warnings:    []string{"annotations unavailable after partial scan: request failed"},
+	}
+	for i := range result.Annotations {
+		result.Annotations[i].BodyHTML = content
+	}
+
+	applyFailureSummaryContentLimits(&result)
+
+	require.Equal(t, "annotations unavailable after partial scan: request failed", result.Warnings[0])
+	require.True(t, result.ContentTruncated)
+	require.True(t, result.Annotations[len(result.Annotations)-1].BodyTruncated)
+}
+
+func TestLoadFailureAnnotationsStopsAtScanLimit(t *testing.T) {
+	pages := 0
+	client := &MockAnnotationsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			pages++
+			return []buildkite.Annotation{{Style: "info", BodyHTML: "not relevant"}}, &buildkite.Response{NextPage: options.Page + 1}, nil
+		},
+	}
+
+	annotations, truncated, err := loadFailureAnnotations(context.Background(), client, GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+	}, defaultFailureSummaryAnnotations)
+
+	require.NoError(t, err)
+	require.Empty(t, annotations)
+	require.True(t, truncated)
+	require.Equal(t, failureSummaryAnnotationScanPages, pages)
+}

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -71,8 +71,12 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 					{ID: "job-promised", Name: "tests", State: "running", PromisedExitStatus: &promisedExitStatus},
 					{ID: "job-running", Name: "unrelated", State: "running"},
 				}}, &buildkite.Response{}, nil
+			case "canceled":
+				require.Equal(t, []string{"canceled"}, options.State)
+				require.Equal(t, defaultFailureSummaryJobs-1, options.PerPage)
+				return buildkite.JobsList{}, &buildkite.Response{}, nil
 			case "broken":
-				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
+				require.Equal(t, []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
 				require.Equal(t, defaultFailureSummaryJobs-1, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "job-broken", Name: "deploy", State: "broken"},
@@ -211,7 +215,7 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	logCallsMu.Unlock()
 }
 
-func TestGetBuildFailureSummaryPrioritizesFailuresBeforeBrokenJobs(t *testing.T) {
+func TestGetBuildFailureSummaryPrioritizesFailuresAndCanceledJobsBeforeDownstreamJobs(t *testing.T) {
 	promisedExitStatus := 1
 	buildsClient := &MockBuildsClient{
 		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
@@ -223,13 +227,17 @@ func TestGetBuildFailureSummaryPrioritizesFailuresBeforeBrokenJobs(t *testing.T)
 			switch options.State[0] {
 			case "failed":
 				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
-				require.Equal(t, 3, options.PerPage)
+				require.Equal(t, 4, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "failed", State: "failed"},
 					{ID: "promised", State: "running", PromisedExitStatus: &promisedExitStatus},
 				}}, &buildkite.Response{}, nil
+			case "canceled":
+				require.Equal(t, []string{"canceled"}, options.State)
+				require.Equal(t, 2, options.PerPage)
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "canceled", State: "canceled"}}}, &buildkite.Response{}, nil
 			case "broken":
-				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
+				require.Equal(t, []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
 				require.Equal(t, 1, options.PerPage)
 				return buildkite.JobsList{Items: []buildkite.Job{
 					{ID: "broken-1", State: "broken"},
@@ -245,14 +253,14 @@ func TestGetBuildFailureSummaryPrioritizesFailuresBeforeBrokenJobs(t *testing.T)
 
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 2,
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 3,
 		IncludeLogs: &include, IncludeAnnotations: &include, IncludeFailedTests: &include,
 	})
 	require.NoError(t, err)
 
 	var summary BuildFailureSummary
 	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
-	require.Equal(t, []string{"failed", "promised"}, []string{summary.Jobs[0].ID, summary.Jobs[1].ID})
+	require.Equal(t, []string{"failed", "promised", "canceled"}, []string{summary.Jobs[0].ID, summary.Jobs[1].ID, summary.Jobs[2].ID})
 	require.True(t, summary.JobsTruncated)
 }
 
@@ -270,7 +278,7 @@ func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
 			case "failed":
 				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
 				return buildkite.JobsList{Items: []buildkite.Job{{ID: "timed-out", State: "timed_out"}}}, &buildkite.Response{}, nil
-			case "broken":
+			case "canceled", "broken":
 				return buildkite.JobsList{}, &buildkite.Response{}, nil
 			default:
 				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
@@ -315,8 +323,11 @@ func TestGetBuildFailureSummaryIncludesExpiredAndDownstreamFailedJobsWithoutLogs
 			case "failed":
 				require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
 				return buildkite.JobsList{Items: []buildkite.Job{{ID: "expired", State: "expired", ExpiredAt: expiredAt}}}, &buildkite.Response{}, nil
+			case "canceled":
+				require.Equal(t, []string{"canceled"}, options.State)
+				return buildkite.JobsList{}, &buildkite.Response{}, nil
 			case "broken":
-				require.Equal(t, []string{"broken", "canceled", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
+				require.Equal(t, []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"}, options.State)
 				return buildkite.JobsList{Items: []buildkite.Job{{ID: "waiting", State: "waiting_failed"}}}, &buildkite.Response{}, nil
 			default:
 				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
@@ -354,29 +365,30 @@ func TestGetBuildFailureSummaryIncludesExpiredAndDownstreamFailedJobsWithoutLogs
 func TestFailureSummaryJobClassification(t *testing.T) {
 	promisedExitStatus := 1
 	tests := []struct {
-		name      string
-		job       buildkite.Job
-		primary   bool
-		secondary bool
-		readLog   bool
+		name       string
+		job        buildkite.Job
+		primary    bool
+		canceled   bool
+		downstream bool
+		readLog    bool
 	}{
 		{name: "failed", job: buildkite.Job{State: "failed"}, primary: true, readLog: true},
 		{name: "timed out", job: buildkite.Job{State: "timed_out"}, primary: true, readLog: true},
 		{name: "expired", job: buildkite.Job{State: "expired"}, primary: true},
-		{name: "canceled", job: buildkite.Job{State: "canceled"}, secondary: true, readLog: true},
+		{name: "canceled", job: buildkite.Job{State: "canceled"}, canceled: true, readLog: true},
 		{name: "promised failure", job: buildkite.Job{State: "running", PromisedExitStatus: &promisedExitStatus}, primary: true, readLog: true},
-		{name: "broken", job: buildkite.Job{State: "broken"}, secondary: true},
-		{name: "waiting failed", job: buildkite.Job{State: "waiting_failed"}, secondary: true},
-		{name: "blocked failed", job: buildkite.Job{State: "blocked_failed"}, secondary: true},
-		{name: "unblocked failed", job: buildkite.Job{State: "unblocked_failed"}, secondary: true},
+		{name: "broken", job: buildkite.Job{State: "broken"}, downstream: true},
+		{name: "waiting failed", job: buildkite.Job{State: "waiting_failed"}, downstream: true},
+		{name: "blocked failed", job: buildkite.Job{State: "blocked_failed"}, downstream: true},
+		{name: "unblocked failed", job: buildkite.Job{State: "unblocked_failed"}, downstream: true},
 		{name: "passed", job: buildkite.Job{State: "passed"}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.primary, isPrimaryFailureSummaryJob(test.job))
-			require.Equal(t, test.secondary, isSecondaryFailureSummaryJob(test.job))
-			require.Equal(t, test.primary || test.secondary, isFailureSummaryJob(test.job))
+			require.Equal(t, test.canceled, isCanceledFailureSummaryJob(test.job))
+			require.Equal(t, test.downstream, isDownstreamFailureSummaryJob(test.job))
 			require.Equal(t, test.readLog, shouldReadFailureLog(test.job))
 		})
 	}
@@ -601,6 +613,76 @@ func TestLoadFailureTestRunsRedistributesUnusedCapacity(t *testing.T) {
 	require.False(t, failedTestsTruncated)
 	require.Empty(t, results[0].FailedExecutions)
 	require.Len(t, results[1].FailedExecutions, 2)
+}
+
+func TestGetBuildFailureSummaryPreservesPartialResultForForbiddenOptionalSections(t *testing.T) {
+	forbidden := &buildkite.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "https", Host: "api.buildkite.com"},
+			},
+		},
+		Message: "Your access token doesn't have the required scope",
+	}
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+				Number: 1,
+				State:  "failed",
+				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
+					ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"},
+				}}},
+			}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			if options.State[0] == "failed" {
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "job", State: "failed"}}}, &buildkite.Response{}, nil
+			}
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+			return nil, forbidden
+		},
+	}
+	annotationsClient := &MockAnnotationsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			return nil, nil, forbidden
+		},
+	}
+	testExecutionsClient := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			return nil, nil, forbidden
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:         buildsClient,
+		JobsClient:           jobsClient,
+		BuildkiteLogsClient:  logsClient,
+		AnnotationsClient:    annotationsClient,
+		TestExecutionsClient: testExecutionsClient,
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+	})
+
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Len(t, summary.Jobs, 1)
+	require.Contains(t, summary.Jobs[0].LogError, forbidden.Message)
+	require.Len(t, summary.Warnings, 1)
+	require.Contains(t, summary.Warnings[0], forbidden.Message)
+	require.Len(t, summary.TestRuns, 1)
+	require.Contains(t, summary.TestRuns[0].Error, forbidden.Message)
 }
 
 func TestFailureSummaryOptionalLoadersPropagateUnauthorized(t *testing.T) {

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -60,16 +60,26 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	promisedExitStatus := 1
 	jobsClient := &MockJobsClient{
 		ListByBuildFunc: func(_ context.Context, org, pipeline, number string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
-			require.Equal(t, []string{"failed", "broken"}, options.State)
-			require.Equal(t, 100, options.PerPage)
 			require.NotNil(t, options.IncludeRetriedJobs)
 			require.False(t, *options.IncludeRetriedJobs)
-			return buildkite.JobsList{Items: []buildkite.Job{
-				{ID: "job-failed", Name: "compile", State: "failed", Command: "make build", ExitStatus: testPtr(1)},
-				{ID: "job-broken", Name: "deploy", State: "broken"},
-				{ID: "job-promised", Name: "tests", State: "running", PromisedExitStatus: &promisedExitStatus},
-				{ID: "job-running", Name: "unrelated", State: "running"},
-			}}, &buildkite.Response{}, nil
+			switch options.State[0] {
+			case "failed":
+				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				require.Equal(t, defaultFailureSummaryJobs+1, options.PerPage)
+				return buildkite.JobsList{Items: []buildkite.Job{
+					{ID: "job-failed", Name: "compile", State: "failed", Command: "make build", ExitStatus: testPtr(1)},
+					{ID: "job-promised", Name: "tests", State: "running", PromisedExitStatus: &promisedExitStatus},
+					{ID: "job-running", Name: "unrelated", State: "running"},
+				}}, &buildkite.Response{}, nil
+			case "broken":
+				require.Equal(t, []string{"broken"}, options.State)
+				require.Equal(t, defaultFailureSummaryJobs-1, options.PerPage)
+				return buildkite.JobsList{Items: []buildkite.Job{
+					{ID: "job-broken", Name: "deploy", State: "broken"},
+				}}, &buildkite.Response{}, nil
+			default:
+				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
+			}
 		},
 	}
 
@@ -166,13 +176,13 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	require.True(t, summary.Jobs[0].LogTruncated)
 	require.Equal(t, []string{"compile error", "build failed"}, []string{summary.Jobs[0].LogTail[0].C, summary.Jobs[0].LogTail[1].C})
 
-	require.Equal(t, "job-broken", summary.Jobs[1].ID)
-	require.Empty(t, summary.Jobs[1].LogTail)
-	require.Empty(t, summary.Jobs[1].LogError)
+	require.Equal(t, "job-promised", summary.Jobs[1].ID)
+	require.Equal(t, 1, *summary.Jobs[1].PromisedExitStatus)
+	require.Len(t, summary.Jobs[1].LogTail, 2)
 
-	require.Equal(t, "job-promised", summary.Jobs[2].ID)
-	require.Equal(t, 1, *summary.Jobs[2].PromisedExitStatus)
-	require.Len(t, summary.Jobs[2].LogTail, 2)
+	require.Equal(t, "job-broken", summary.Jobs[2].ID)
+	require.Empty(t, summary.Jobs[2].LogTail)
+	require.Empty(t, summary.Jobs[2].LogError)
 
 	require.Len(t, summary.Annotations, 2)
 	require.False(t, summary.AnnotationsTruncated)
@@ -199,6 +209,96 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 		"job-promised": {{ttl: 30 * time.Second}},
 	}, logCalls)
 	logCallsMu.Unlock()
+}
+
+func TestGetBuildFailureSummaryPrioritizesFailuresBeforeBrokenJobs(t *testing.T) {
+	promisedExitStatus := 1
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "failing"}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			switch options.State[0] {
+			case "failed":
+				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				require.Equal(t, 3, options.PerPage)
+				return buildkite.JobsList{Items: []buildkite.Job{
+					{ID: "failed", State: "failed"},
+					{ID: "promised", State: "running", PromisedExitStatus: &promisedExitStatus},
+				}}, &buildkite.Response{}, nil
+			case "broken":
+				require.Equal(t, 1, options.PerPage)
+				return buildkite.JobsList{Items: []buildkite.Job{
+					{ID: "broken-1", State: "broken"},
+					{ID: "broken-2", State: "broken"},
+				}}, &buildkite.Response{}, nil
+			default:
+				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
+			}
+		},
+	}
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: buildsClient, JobsClient: jobsClient})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 2,
+		IncludeLogs: &include, IncludeAnnotations: &include, IncludeFailedTests: &include,
+	})
+	require.NoError(t, err)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Equal(t, []string{"failed", "promised"}, []string{summary.Jobs[0].ID, summary.Jobs[1].ID})
+	require.True(t, summary.JobsTruncated)
+}
+
+func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
+	logPath := t.TempDir() + "/timed-out.parquet"
+	writeTestParquetFile(t, logPath, []string{"running", "job timed out"})
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "failed"}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			switch options.State[0] {
+			case "failed":
+				require.Equal(t, []string{"failed", "timed_out"}, options.State)
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "timed-out", State: "timed_out"}}}, &buildkite.Response{}, nil
+			case "broken":
+				return buildkite.JobsList{}, &buildkite.Response{}, nil
+			default:
+				return buildkite.JobsList{}, nil, fmt.Errorf("unexpected job states: %v", options.State)
+			}
+		},
+	}
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(_ context.Context, _, _, _, job string, _ time.Duration, _ bool) (*buildkitelogs.ParquetReader, error) {
+			require.Equal(t, "timed-out", job)
+			return buildkitelogs.NewParquetReader(logPath), nil
+		},
+	}
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient: buildsClient, JobsClient: jobsClient, BuildkiteLogsClient: logsClient,
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		IncludeAnnotations: &include, IncludeFailedTests: &include,
+	})
+	require.NoError(t, err)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Len(t, summary.Jobs, 1)
+	require.Equal(t, "timed_out", summary.Jobs[0].State)
+	require.Equal(t, []string{"running", "job timed out"}, []string{summary.Jobs[0].LogTail[0].C, summary.Jobs[0].LogTail[1].C})
 }
 
 func TestGetBuildFailureSummaryCanDisableOptionalSections(t *testing.T) {

--- a/pkg/buildkite/resources/debug-logs-guide.md
+++ b/pkg/buildkite/resources/debug-logs-guide.md
@@ -10,15 +10,20 @@ This guide explains how to effectively use the Buildkite MCP server's log tools 
 
 ## Tools Overview
 
-The server provides these tools for log analysis:
+The server provides a composite investigation tool and lower-level log tools:
 
-### 1. tail_logs - Start Here for Failures
-**Best first step for diagnosing failures** — shows the last N log lines where errors typically appear.
+### 1. get_build_failure_summary - Start Here
+**Best first step for diagnosing a build failure** — combines build state, failed and broken jobs, promised failures from still-running jobs, bounded log tails, error/warning annotations, and failed Test Engine executions in one call.
+
+The default 50-line tail per failed job is usually enough for an initial diagnosis. Use the lower-level tools only when the summary identifies an area that needs deeper inspection. You can reduce output with `log_tail`, `max_jobs`, `max_annotations`, `max_test_runs`, `max_failed_tests`, and `max_failed_tests_per_run`, or disable optional sections with `include_logs`, `include_annotations`, and `include_failed_tests`. Test Engine work defaults to at most 5 runs and 100 failed executions total.
+
+### 2. tail_logs - Focused Follow-up
+Shows the last N entries for one job when the composite summary needs more log context.
 
 Defaults to 10 lines if `tail` is omitted or zero.
 Use `tail: 50-100` for an initial failure check when you want more than the default.
 
-### 2. search_logs - For Specific Issues
+### 3. search_logs - For Specific Issues
 **Most powerful tool** for finding specific error patterns with context.
 
 **Key Parameters:**
@@ -33,21 +38,22 @@ Use `tail: 50-100` for an initial failure check when you want more than the defa
 
 Recommended starting values: use `context: 3`, `limit: 10-20`, and leave boolean options false unless you need them. If `limit` is omitted, search can return every match.
 
-### 3. read_logs - For Sequential Reading
+### 4. read_logs - For Sequential Reading
 **Use when you need to read a specific section** of logs in order, using a row number found via search_logs.
 
 Always set `limit` — logs can be very large.
 
 ## Debugging Workflow
 
-### Step 0: Identify the Failing Job
-Before pulling any logs, call `list_jobs` with `state=failed,broken` to narrow down which jobs need attention.
+### Step 0: Get the Failure Summary
+Call `get_build_failure_summary` with the organization slug, pipeline slug, and build number. In most cases this is enough to identify the root cause without additional calls.
 
-This returns only the jobs that didn't pass. From the results:
+Interpret its jobs as follows:
 - **`failed`** jobs actually ran and exited non-zero — these are the root cause, start here
-- **`broken`** jobs never ran due to a failed dependency or unmet `if` condition — they are usually downstream victims of the `failed` job
+- **`broken`** jobs never ran due to a failed dependency or unmet `if` condition — they are usually downstream victims of a `failed` job
+- **`running` with a non-zero `promised_exit_status`** has declared an early failure but may still produce more logs, artifacts, or test results before it finishes
 
-Take the `id` of the `failed` job as your `job_id` for log investigation.
+If you need more context, take a failed job's `id` as the `job_id` for the lower-level log tools.
 
 ### Step 1: Quick Assessment
 Use `tail_logs` with `tail: 50-100` to see the most recent output. Most failures surface here.

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -57,6 +57,16 @@ func TestGetBuildArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 }
 
+func TestGetBuildFailureSummaryArgsSchema(t *testing.T) {
+	s := schemaFor[GetBuildFailureSummaryArgs](t)
+	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[GetBuildFailureSummaryArgs](t))
+
+	for _, opt := range []string{"log_tail", "max_jobs", "max_annotations", "max_test_runs", "max_failed_tests", "max_failed_tests_per_run", "include_logs", "include_annotations", "include_failed_tests", "include_failure_expanded"} {
+		require.Contains(t, s.Properties, opt)
+		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
+	}
+}
+
 func TestGetPipelineArgsSchema(t *testing.T) {
 	req := sortedRequired[GetPipelineArgs](t)
 	require.Equal(t, []string{"org_slug", "pipeline_slug"}, req)

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -86,6 +86,10 @@ var instructionSections = []instructionSection{
 	{text: "Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation."},
 	{text: "Common pitfalls:\n\nbuild_number is a sequential integer string (e.g. \"42\"), not a UUID. Build, job, artifact, and log tools all require this identifier — do not use the build's UUID id field."},
 	{
+		toolset: toolsets.ToolsetInvestigations,
+		text:    "Build failure investigation: start with get_build_failure_summary. It combines build state, failed and broken jobs, promised failures from running jobs, bounded log tails, relevant annotations, and failed tests in one response. Use the individual build, job, log, annotation, and test tools only when the summary identifies an area that needs deeper inspection.",
+	},
+	{
 		toolset: toolsets.ToolsetBuilds,
 		text:    "Job state \"broken\" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.",
 	},

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -19,6 +19,7 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		jobStateBroken   = `Job state "broken"`
 		logInvestigation = "Log investigation order:"
 		annotationScope  = "Annotation scope:"
+		failureSummary   = "Build failure investigation:"
 	)
 
 	always := []string{authorization, buildNumber}
@@ -33,32 +34,38 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		{
 			name:    "all toolsets includes every section",
 			enabled: []string{"all"},
-			want:    append(append([]string{}, always...), startHere, skillDiscovery, jobStateBroken, logInvestigation, annotationScope),
+			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, logInvestigation, annotationScope),
 		},
 		{
 			name:    "builds alone",
 			enabled: []string{"builds"},
 			want:    append(append([]string{}, always...), jobStateBroken),
-			notWant: []string{startHere, skillDiscovery, logInvestigation, annotationScope},
+			notWant: []string{startHere, skillDiscovery, failureSummary, logInvestigation, annotationScope},
 		},
 		{
 			name:    "skills alone",
 			enabled: []string{"skills"},
 			want:    append(append([]string{}, always...), skillDiscovery),
-			notWant: []string{startHere, jobStateBroken, logInvestigation, annotationScope},
+			notWant: []string{startHere, failureSummary, jobStateBroken, logInvestigation, annotationScope},
 		},
 		{
 			name:    "user alone",
 			enabled: []string{"user"},
 			want:    append(append([]string{}, always...), startHere),
-			notWant: []string{skillDiscovery, jobStateBroken, logInvestigation, annotationScope},
+			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, logInvestigation, annotationScope},
 		},
 		{
 			name:     "all toolsets, read-only, omits annotation scope",
 			enabled:  []string{"all"},
 			readOnly: true,
-			want:     append(append([]string{}, always...), startHere, skillDiscovery, jobStateBroken, logInvestigation),
+			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, logInvestigation),
 			notWant:  []string{annotationScope},
+		},
+		{
+			name:    "investigations alone",
+			enabled: []string{"investigations"},
+			want:    append(append([]string{}, always...), failureSummary),
+			notWant: []string{startHere, skillDiscovery, jobStateBroken, logInvestigation, annotationScope},
 		},
 		{
 			name:     "annotations toolset, read-only, omits annotation scope",

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -235,17 +235,18 @@ func NewTool(tool mcp.Tool, register func(s *mcp.Server), scopes []string) ToolD
 }
 
 const (
-	ToolsetAll         = "all" // Special name to enable all toolsets
-	ToolsetClusters    = "clusters"
-	ToolsetAgents      = "agents"
-	ToolsetPipelines   = "pipelines"
-	ToolsetBuilds      = "builds"
-	ToolsetArtifacts   = "artifacts"
-	ToolsetLogs        = "logs"
-	ToolsetTests       = "tests"
-	ToolsetAnnotations = "annotations"
-	ToolsetUser        = "user"
-	ToolsetSkills      = "skills"
+	ToolsetAll            = "all" // Special name to enable all toolsets
+	ToolsetClusters       = "clusters"
+	ToolsetAgents         = "agents"
+	ToolsetPipelines      = "pipelines"
+	ToolsetBuilds         = "builds"
+	ToolsetArtifacts      = "artifacts"
+	ToolsetLogs           = "logs"
+	ToolsetTests          = "tests"
+	ToolsetAnnotations    = "annotations"
+	ToolsetInvestigations = "investigations"
+	ToolsetUser           = "user"
+	ToolsetSkills         = "skills"
 )
 
 var ValidToolsets = []string{
@@ -258,6 +259,7 @@ var ValidToolsets = []string{
 	ToolsetLogs,
 	ToolsetTests,
 	ToolsetAnnotations,
+	ToolsetInvestigations,
 	ToolsetUser,
 	ToolsetSkills,
 }
@@ -394,6 +396,13 @@ func CreateBuiltinToolsets() map[string]Toolset {
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.ListAnnotations),
 				newToolDef(buildkite.CreateAnnotation),
+			},
+		},
+		ToolsetInvestigations: {
+			Name:        "Build Investigations",
+			Description: "Cross-domain tools for diagnosing Buildkite build failures",
+			Tools: []ToolDefinition{
+				newToolDef(buildkite.GetBuildFailureSummary),
 			},
 		},
 		ToolsetUser: {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -583,6 +583,7 @@ func TestIsValidToolset(t *testing.T) {
 		{"valid toolset - logs", "logs", true},
 		{"valid toolset - tests", "tests", true},
 		{"valid toolset - annotations", "annotations", true},
+		{"valid toolset - investigations", "investigations", true},
 		{"valid toolset - user", "user", true},
 		{"valid toolset - skills", "skills", true},
 		{"invalid toolset", "invalid", false},
@@ -625,7 +626,7 @@ func TestIsToolsetEnabled(t *testing.T) {
 func TestValidateToolsets(t *testing.T) {
 	t.Run("all valid toolsets", func(t *testing.T) {
 		assert := require.New(t)
-		valid := []string{"all", "clusters", "pipelines"}
+		valid := []string{"all", "clusters", "pipelines", "investigations"}
 		err := ValidateToolsets(valid)
 		assert.NoError(err)
 	})
@@ -654,9 +655,15 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	registry.RegisterToolsets(builtin)
 
 	// Check that expected toolsets are registered
-	expectedToolsets := []string{"clusters", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "user", "skills"}
+	expectedToolsets := []string{"clusters", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "investigations", "user", "skills"}
 	for _, name := range expectedToolsets {
 		_, exists := registry.Get(name)
 		assert.True(exists, "expected toolset %s to be registered", name)
 	}
+
+	investigations, exists := registry.Get(ToolsetInvestigations)
+	assert.True(exists)
+	assert.Len(investigations.Tools, 1)
+	assert.Equal("get_build_failure_summary", investigations.Tools[0].Tool.Name)
+	assert.Equal([]string{"read_build_logs", "read_builds", "read_suites"}, investigations.GetRequiredScopes())
 }


### PR DESCRIPTION
## Description

This adds a tool, `get_build_failure_summary`, which introduces a tool following Anthropic's own best practices for tool creation; https://www.anthropic.com/engineering/writing-tools-for-agents.

The idea is that instead of many tool calls via `get_pipeline`, `list_builds`, `get_build`, `search_logs`, we can instead implement a single tool which provides the function which LLMs need in order to diagnose a failure more efficiently.

## Changes

- adds `get_build_failure_summary` as a tool option
- refactors the `unauthorized` error to be more idiomatic
- implements some sanitisation to json payloads for summary
- expands the debugging guide so that agents reach for the new tool first
- adds investigations toolset group with new tool available in it
- tests
