### PR TITLE
chore(http): correctly return 4XX responses

### DIFF
--- a/pkg/buildkite/errors_test.go
+++ b/pkg/buildkite/errors_test.go
@@ -21,6 +21,22 @@ func TestHandleBuildkiteError_Unauthorized(t *testing.T) {
 	require.ErrorIs(t, err, ErrUnauthorized)
 }
 
+func TestHandleBuildkiteError_Forbidden(t *testing.T) {
+	errResp := &buildkite.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusForbidden},
+		Message:  "Your access token doesn't have the read_suites scope",
+	}
+
+	result, data, err := handleBuildkiteError(errResp)
+
+	require.NoError(t, err)
+	require.Nil(t, data)
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+	textContent := getTextResult(t, result)
+	require.Equal(t, "Your access token doesn't have the read_suites scope", textContent.Text)
+}
+
 func TestHandleBuildkiteError_WithRawBody(t *testing.T) {
 	errResp := &buildkite.ErrorResponse{
 		Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -83,7 +83,7 @@ var instructionSections = []instructionSection{
 		toolset: toolsets.ToolsetSkills,
 		text:    "Skill discovery: Always call list_skills early in a session — it's cheap (names and one-line descriptions only) and surfaces guidance not visible in any tool's name or schema. When a task matches a listed skill (e.g. debugging a build failure, tuning search_logs), call load_skill for that guide — it covers parameter tuning, caching behavior, and details beyond the summaries below.",
 	},
-	{text: "Authorization: Tools available depend on the scopes granted to the configured API token. A 401 response from a tool means the token lacks the required scope for that operation."},
+	{text: "Authorization: Tools available depend on the scopes and organization access granted to the configured API token. A 401 response means the token is invalid, expired, or revoked and requires reauthentication. A 403 response means the credentials were accepted but access was denied, commonly because the token lacks a required scope or organization access, or the user lacks permission."},
 	{text: "Common pitfalls:\n\nbuild_number is a sequential integer string (e.g. \"42\"), not a UUID. Build, job, artifact, and log tools all require this identifier — do not use the build's UUID id field."},
 	{
 		toolset: toolsets.ToolsetBuilds,

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -15,13 +15,15 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		startHere        = "Start here:"
 		skillDiscovery   = "Skill discovery:"
 		authorization    = "Authorization:"
+		invalidToken     = "A 401 response means the token is invalid, expired, or revoked"
+		forbiddenAccess  = "A 403 response means the credentials were accepted but access was denied"
 		buildNumber      = "build_number is a sequential"
 		jobStateBroken   = `Job state "broken"`
 		logInvestigation = "Log investigation order:"
 		annotationScope  = "Annotation scope:"
 	)
 
-	always := []string{authorization, buildNumber}
+	always := []string{authorization, invalidToken, forbiddenAccess, buildNumber}
 
 	tests := []struct {
 		name     string

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -15,7 +15,7 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		startHere        = "Start here:"
 		skillDiscovery   = "Skill discovery:"
 		authorization    = "Authorization:"
-		invalidToken     = "A 401 response means the token is invalid, expired, or revoked"
+		invalidToken     = "A 401 response means the token is invalid, expired, or revoked" //nolint:gosec // documentation assertion, not a credential
 		forbiddenAccess  = "A 403 response means the credentials were accepted but access was denied"
 		buildNumber      = "build_number is a sequential"
 		jobStateBroken   = `Job state "broken"`


### PR DESCRIPTION
## Description

Returns the correct HTTP response where token scope is the issue rather than valid credentials.
