### PR TITLE
chore(deps): upgraded go-buildkite and added agent filtering by queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.7.0
+	github.com/buildkite/go-buildkite/v5 v5.9.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.23
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.7.0 h1:UY2vlF5AceV7zqWUN+uU7bjEXgEFdKrwayvZ8bZgcj0=
-github.com/buildkite/go-buildkite/v5 v5.7.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.9.0 h1:R3T4zZPWdV0uZXPY62eUDKWKCxB8aP57flbOnVT0P9g=
+github.com/buildkite/go-buildkite/v5 v5.9.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/agents.go
+++ b/pkg/buildkite/agents.go
@@ -16,13 +16,14 @@ type AgentsClient interface {
 }
 
 type ListAgentsArgs struct {
-	OrgSlug     string `json:"org_slug"`
-	Name        string `json:"name,omitempty"`
-	Hostname    string `json:"hostname,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Page        int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
-	PerPage     int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
-	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default), 'detailed', or 'full'"`
+	OrgSlug        string `json:"org_slug"`
+	Name           string `json:"name,omitempty"`
+	Hostname       string `json:"hostname,omitempty"`
+	Version        string `json:"version,omitempty"`
+	ClusterQueueID string `json:"cluster_queue_id,omitempty" jsonschema:"Filter agents by cluster queue ID (UUID)"`
+	Page           int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
+	PerPage        int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+	DetailLevel    string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary' (default), 'detailed', or 'full'"`
 }
 
 type GetAgentArgs struct {
@@ -162,6 +163,7 @@ func ListAgents() (mcp.Tool, mcp.ToolHandlerFor[ListAgentsArgs, any], []string) 
 				attribute.String("name_filter", args.Name),
 				attribute.String("hostname_filter", args.Hostname),
 				attribute.String("version_filter", args.Version),
+				attribute.String("cluster_queue_id_filter", args.ClusterQueueID),
 				attribute.String("detail_level", args.DetailLevel),
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
@@ -169,10 +171,11 @@ func ListAgents() (mcp.Tool, mcp.ToolHandlerFor[ListAgentsArgs, any], []string) 
 
 			deps := DepsFromContext(ctx)
 			agents, resp, err := deps.AgentsClient.List(ctx, args.OrgSlug, &buildkite.AgentListOptions{
-				ListOptions: paginationParams,
-				Name:        args.Name,
-				Hostname:    args.Hostname,
-				Version:     args.Version,
+				ListOptions:    paginationParams,
+				Name:           args.Name,
+				Hostname:       args.Hostname,
+				Version:        args.Version,
+				ClusterQueueID: args.ClusterQueueID,
 			})
 			if err != nil {
 				return handleBuildkiteError(err)

--- a/pkg/buildkite/agents_test.go
+++ b/pkg/buildkite/agents_test.go
@@ -41,6 +41,7 @@ func TestListAgents(t *testing.T) {
 			assert.Equal("agent-name", opts.Name)
 			assert.Equal("host-1", opts.Hostname)
 			assert.Equal("3.90.0", opts.Version)
+			assert.Equal("queue-id", opts.ClusterQueueID)
 			assert.Equal(2, opts.Page)
 			assert.Equal(50, opts.PerPage)
 
@@ -68,13 +69,14 @@ func TestListAgents(t *testing.T) {
 
 	request := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, request, ListAgentsArgs{
-		OrgSlug:     "org",
-		Name:        "agent-name",
-		Hostname:    "host-1",
-		Version:     "3.90.0",
-		Page:        2,
-		PerPage:     50,
-		DetailLevel: "summary",
+		OrgSlug:        "org",
+		Name:           "agent-name",
+		Hostname:       "host-1",
+		Version:        "3.90.0",
+		ClusterQueueID: "queue-id",
+		Page:           2,
+		PerPage:        50,
+		DetailLevel:    "summary",
 	})
 	assert.NoError(err)
 

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -65,7 +65,7 @@ type JobDetail struct {
 	Type               string               `json:"type,omitempty"`
 	Label              string               `json:"label,omitempty"`
 	GroupKey           string               `json:"group_key,omitempty"`
-	Signal             *int                 `json:"signal,omitempty"`
+	Signal             string               `json:"signal,omitempty"`
 	CreatedAt          *buildkite.Timestamp `json:"created_at,omitempty"`
 	StartedAt          *buildkite.Timestamp `json:"started_at,omitempty"`
 	FinishedAt         *buildkite.Timestamp `json:"finished_at,omitempty"`

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -422,7 +422,7 @@ func TestListJobs(t *testing.T) {
 					Items: []buildkite.Job{{
 						ID: "job-1", Name: "test", State: "failed", Command: "go test ./...",
 						CreatedAt: timestamp, StartedAt: timestamp, FinishedAt: timestamp,
-						Signal: intPtr(9), SignalReason: "agent_stop", Retried: true,
+						Signal: "9", SignalReason: "agent_stop", Retried: true,
 						RetriedInJobID: "job-2", RetriesCount: 1,
 						RetrySource:        &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"},
 						SoftFailed:         true,
@@ -452,7 +452,7 @@ func TestListJobs(t *testing.T) {
 		assert.Equal(t, timestamp, job.CreatedAt)
 		assert.Equal(t, timestamp, job.StartedAt)
 		assert.Equal(t, timestamp, job.FinishedAt)
-		assert.Equal(t, intPtr(9), job.Signal)
+		assert.Equal(t, "9", job.Signal)
 		assert.Equal(t, "agent_stop", job.SignalReason)
 		assert.True(t, job.Retried)
 		assert.Equal(t, "job-2", job.RetriedInJobID)

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -287,7 +287,7 @@ func TestListAgentsArgsSchema(t *testing.T) {
 	slices.Sort(req)
 	require.Equal(t, []string{"org_slug"}, req)
 
-	for _, opt := range []string{"name", "hostname", "version", "page", "per_page", "detail_level"} {
+	for _, opt := range []string{"name", "hostname", "version", "page", "per_page", "detail_level", "cluster_queue_id"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
 }


### PR DESCRIPTION
* Bumped go-buildkite to v5.9.0
* Changed Signal from *int to string in Jobs to match upstream fix, which now matches the API
