### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # buildkite-mcp-server
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fbuildkite%2Fbuildkite-mcp-server.svg)](https://mcptoplist.com/server/glama%2Fbuildkite%2Fbuildkite-mcp-server)
+
 [![Build status](https://badge.buildkite.com/79fefd75bc7f1898fb35249f7ebd8541a99beef6776e7da1b4.svg?branch=main)](https://buildkite.com/buildkite/buildkite-mcp-server)
 
 > **[Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) server exposing Buildkite data (pipelines, builds, jobs, tests) to AI tooling and editors.**


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,686 MCP servers across the major
registries, and **buildkite-mcp-server** is currently ranked **#625**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fbuildkite%2Fbuildkite-mcp-server.svg)](https://mcptoplist.com/server/glama%2Fbuildkite%2Fbuildkite-mcp-server)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building buildkite-mcp-server!
