### PR TITLE
Move buildkite-mcp-evals from forked nethsix/buildkite-mcp-server

### DIFF
--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Build an image for the toolchain and load it into the local image store.
+if [ "${BUILDKITE_STEP_KEY:-}" == "agent" ]; then
+    docker build \
+	-f evals/Dockerfile \
+        --load \
+        --build-arg GITHUB_CLI_VERSION="${GITHUB_CLI_VERSION}" \
+        --platform linux/amd64 \
+        -t buildkite-mcp-server-evals:latest .
+fi

--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -1,0 +1,104 @@
+image: "buildkite/hosted-agent-base-images:ubuntu-jammy"
+
+env:
+  GITHUB_CLI_VERSION: "2.83.0"
+  BUILDKITE_MCP_SERVER_VERSION: "0.7.3"
+  MODEL_PROVIDER: "anthropic"
+  # CROSS-REPO DEPENDENCY: the eval's red->green CI signal lives outside this
+  # repo. babystand.sh clones EVAL_REPO_SLUG (default: the nethsix fork), pushes
+  # mcp-eval-scenario-* branches there, and the agent watches their builds on
+  # this org/pipeline, which must keep building branch pushes. Scenario branches
+  # never exist in THIS repo, so this pipeline's eval step can't recurse.
+  # Buildkite API tokens are single-org, so two are needed: the EXTERNAL_ORG
+  # token (EVAL_ORG_SLUG, used by the agent's MCP server) and the BUILDKITE_ORG
+  # token (this org, used by bk-eval-compare.sh).
+  EVAL_ORG_SLUG: "anothertest"
+  EVAL_PIPELINE_SLUG: "buildkite-mcp-server"
+
+# PR CI (lint/test) and the generator step run here. The bork PR builds the eval
+# waits on also run on this queue.
+agents:
+  queue: hosted
+
+cache:
+  name: "build-cache"
+  paths:
+    - "/gocache"
+    - "/gomodcache"
+  size: "100g"
+
+steps:
+  - group: ":mag: Quality Checks"
+    key: quality-checks
+    steps:
+    - name: ":golangci-lint: lint"
+      command: golangci-lint run --output.checkstyle.path checkstyle.xml --verbose --timeout 3m
+      artifact_paths:
+        - checkstyle.xml
+      env:
+        GOCACHE: /gocache
+        GOMODCACHE: /gomodcache
+      plugins:
+        - mise#v1.1.1: ~
+
+    - name: ":go: test"
+      artifact_paths:
+        - cover-tree.svg
+        - junit.xml
+      commands:
+        - go run gotest.tools/gotestsum@latest --junitfile junit.xml --format testname -- -coverprofile=cover.out ./...
+        - go run github.com/nikolaydubina/go-cover-treemap@latest -coverprofile cover.out > cover-tree.svg
+        - echo '<details><summary>Coverage tree map</summary><img src="artifact://cover-tree.svg" alt="Test coverage tree map" width="70%"></details>' | buildkite-agent annotate --style "info"
+      env:
+        GOCACHE: /gocache
+        GOMODCACHE: /gomodcache
+      plugins:
+        - mise#v1.1.1: ~
+  - label: ":buildkite: Running scenarios"
+    key: agent
+    depends_on: quality-checks
+    command: ./scripts/babystand.sh
+    # The scenario builds this (blocking) eval agent waits on run in the
+    # EVAL_ORG_SLUG org (see above), on a different cluster's agents, so sharing
+    # this repo's hosted queue cannot starve them.
+    agents:
+      queue: hosted
+    plugins:
+      - docker#v5.11.0:
+          image: buildkite-mcp-server-evals:latest
+          mount-checkout: false
+          mount-buildkite-agent: true
+          environment:
+            - BUILDKITE
+            - BUILDKITE_AGENT_ENDPOINT
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - BUILDKITE_API_TOKEN
+            - EVAL_COMPARE_BUILDKITE_API_TOKEN
+            - BUILDKITE_BUILD_URL
+            - BUILDKITE_ORGANIZATION_SLUG
+            - BUILDKITE_PIPELINE_SLUG
+            - BUILDKITE_MCP_SERVER_VERSION
+            - EVAL_ORG_SLUG
+            - EVAL_PIPELINE_SLUG
+            - GITHUB_CLI_VERSION
+            - GITHUB_TOKEN
+            - MODEL_PROVIDER
+            # Select the sandboxed claude.sh execution path in babystand.sh.
+            - RUN_IN_CI=true
+            - LOCAL_CI=false
+            - DEBUG_PERMISSIONS=false
+            # Required by babystand.sh (no default). Inert in CI — claude.sh
+            # always runs bypassPermissions — but declared consciously here;
+            # see evals/README.md for the local-mode meaning.
+            - LOCAL_BYPASS_PERMISSION=false
+            # Per-message parser annotations are on by default; set to "false"
+            # (in the top-level env: block) to rely only on the curated summaries.
+            - ANNOTATE_MESSAGES
+    # Secrets are scoped to this step only: the lint/test jobs execute code
+    # from the pushed branch and must not see credentials.
+    # NOTE: secret-mapped env var names must not start with BUILDKITE/BK
+    # (BUILDKITE_API_TOKEN itself is an allowed exception).
+    secrets:
+      GITHUB_TOKEN: MCP_EVAL_FRAMEWORK_EXTERNAL_REPO_GITHUB_TOKEN
+      BUILDKITE_API_TOKEN: MCP_EVAL_FRAMEWORK_EXTERNAL_ORG_BUILDKITE_API_TOKEN
+      EVAL_COMPARE_BUILDKITE_API_TOKEN: MCP_EVAL_FRAMEWORK_BUILDKITE_ORG_BUILDKITE_API_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+node_modules/
 .envrc*
 .zed
 .vscode

--- a/evals/Dockerfile
+++ b/evals/Dockerfile
@@ -1,0 +1,69 @@
+# Build the Buildkite MCP server from this repo's source, so the eval exercises
+# the code under review rather than a published release.
+ARG GO_VERSION="1.25"
+FROM golang:${GO_VERSION} AS mcp-builder
+WORKDIR /src
+# Cache module downloads separately from the source.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd ./cmd
+COPY pkg ./pkg
+COPY internal ./internal
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/buildkite-mcp-server ./cmd/buildkite-mcp-server
+
+FROM ubuntu:22.04
+
+# Expected arguments for tool versions.
+ARG NODE_VERSION="24"
+ARG GITHUB_CLI_VERSION
+
+# Install system dependencies.
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    ca-certificates \
+    gnupg \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js.
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the GitHub CLI.
+RUN curl -fsSL https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz | tar -xz -C /tmp
+RUN cp /tmp/gh_${GITHUB_CLI_VERSION}_linux_amd64/bin/gh /usr/local/bin/
+
+# Install the Buildkite MCP server, built from source in the mcp-builder stage.
+COPY --from=mcp-builder /out/buildkite-mcp-server /usr/local/bin/buildkite-mcp-server
+
+# Install Claude Code.
+RUN npm install -g @anthropic-ai/claude-code
+
+# Create a non-root user to run the agent in isolation.
+RUN useradd -m -u 1000 -s /bin/bash agent
+
+# Create the workspace.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Copy in the necessary files.
+COPY evals/scripts /workspace/scripts
+COPY evals/prompts /workspace/prompts
+COPY evals/package*.json /workspace/
+COPY evals/tsconfig.json /workspace/
+COPY evals/mcp_in_ci.json /workspace/
+
+# Run the build.
+RUN npm ci && npm run build
+RUN rm scripts/*.ts tsconfig.json
+
+# Give the non-root user ownership of the workspace.
+RUN chown -R agent:agent /workspace
+
+# Switch to the non-root user.
+USER agent
+
+# Default command
+CMD ["/bin/bash"]

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,83 @@
+## What is this?
+
+Under certain conditions, e.g., branch being pushed/created in repo, PR created, etc., this pipeline will run, kicking-off a specified LLM agent backed by a specified model to exercise a specified buildkite-mcp-server against preset scenarios to evaluate the performance of the buildkite-mcp-server.
+
+## What is the output?
+
+A set of artifacts, and annotations in the Buildkite build showing:
+* LLM agent metrics
+  * Tool calls, input/output tokens, input/output cache tokens, etc.
+* Quantitative evaluation report
+  * List of things order by criticality that the LLM agent could have done better, due to harness loop, tool call choices, etc.
+* Comparison reports
+  * LLM agent metrics
+  * High-level steps taken by LLM agent to complete scenarios
+
+## Permission posture
+
+In CI the LLM agent runs with `--permission-mode bypassPermissions` and NO tool allowlist. This is deliberate: real users rarely restrict tools, so tool CHOICE is part of what the eval measures — an agent that reaches for `curl` against the Buildkite API instead of the MCP tools is signal that the tools aren't compelling. Check the `eval-tools` annotation on each build to see what was actually called.
+
+Containment does not come from permissions; it comes from layers the agent cannot talk its way around:
+* The docker container sandbox (throwaway, non-root)
+* The MCP server's `--read-only` mode (write tools are never registered, see `mcp_in_ci.json`/`mcp.json`)
+* The read-only Buildkite API token
+
+Locally there is no container sandbox, so the posture is a conscious choice via `LOCAL_BYPASS_PERMISSION` (required, deliberately NO default — the script fails loudly and points here):
+* `false`: restricted mode — the agent gets `Edit`, `go`/`make`/`git` Bash, and the MCP server's tools (server name derived from `mcp.json`, override with `MCP_SERVER_NAME`). Safe on a host machine, but NOT comparable to CI runs since the agent's tool choice is constrained.
+* `true`: CI parity — `bypassPermissions`, i.e. the agent has unrestricted Bash ON YOUR MACHINE. Use with care.
+
+## Setup
+
+### Code
+
+All new code are mostly in `evals/` folder
+
+* Add pipeline (.buildkite/pipeline.evals.yml) which run evals
+* In 'evals/prompts/' folder:
+  * klaren.md
+    * Review LLM agent session log and complain loudly about what could've been better
+* In 'evals/scripts/' folder:
+  * babystand.sh
+    * This script actually can be run locally as well for testing/debugging
+      * `LOCAL_CI`: If false, then prompt specifically instructs LLM agent not to cheat by running local CI to uncover issues, but instead wait for CI to be red before attempting to turn it green
+      * `DEBUG_PERMISSIONS`: If true, then prompt specifically instructs LLM agent to fail instead of trying to bypass. This is useful when you're trying to setup the env to run scenarios.
+      * `LOCAL_BYPASS_PERMISSION`: See "Permission posture" above. Required, no default.
+    * Running locally: from this repo's root, with `./buildkite-mcp-server` built (`make build`) and your git credentials able to push to the eval repo:
+      ```bash
+      BUILDKITE_API_TOKEN=... \
+      LOCAL_CI=false \
+      DEBUG_PERMISSIONS=false \
+      LOCAL_BYPASS_PERMISSION=false \
+      ./evals/scripts/babystand.sh
+      ```
+      The script clones the eval repo (`EVAL_REPO_SLUG`) into `~/eval-repo-<timestamp>`, copies your built server binary into it, and runs the agent there — the scenario branches live in the eval repo, not this one.
+    * Setup various scenarios 
+    * Calls LLM agent with prompts to evaluate scenarios
+    * Calls klaren.md prompt to review LLM agent performance
+  * bk-eval-compare.sh
+    * Compare current eval result with previous 
+  * bk-tool-audit-v2.sh
+    * Retrieve stats about tool calls, input/output token/cache usage from LLM session logs
+  * parser.ts
+    * Parse LLM agent assistant/user convo into bk annotation
+  * Dockerfile
+    * Given an buildkite mcp version, build that buildkite mcp version into a docker image (not implemented yet, currently it just builds the buildkite mcp based on current code
+  * mcp_in_ci.json
+    * The mcp config used when `babystand.sh` is running in ci
+  * mcp.json
+    * The mcp config used when `babystand.sh` is running locally
+  * package.json/package-lock.json
+    * npm packages required
+  * tsconfig.json
+    * Typescript config
+
+### On buildkite.com
+
+* Pipeline is set at - https://buildkite.com/buildkite/buildkite-mcp-server-evals-framework
+  * This pipeline is set to:
+    * Upload .buildkite/pipeline.evals.yml
+    * Use buildkite-mcp-evals cluster (https://buildkite.com/organizations/buildkite/clusters/1295e59e-8fa9-4525-b873-f3a0ce2efe45/queues)
+    * Secrets for
+      * Github to access scenarios (read/write) in external repo
+      * Buildkite for bk org to retrieve the last successful build (read) to compare
+      * Buildkite for anothertest org where the external repo scenario pipelines (read) are (to monitor scenarios from red-to-green)

--- a/evals/mcp.json
+++ b/evals/mcp.json
@@ -1,0 +1,11 @@
+{
+    "mcpServers": {
+        "buildkite": {
+            "command": "./buildkite-mcp-server",
+            "args": ["stdio", "--read-only"],
+            "env": {
+                "BUILDKITE_API_TOKEN": "${BUILDKITE_API_TOKEN}"
+            }
+        }
+    }
+}

--- a/evals/mcp_in_ci.json
+++ b/evals/mcp_in_ci.json
@@ -1,0 +1,11 @@
+{
+    "mcpServers": {
+        "buildkite": {
+            "command": "buildkite-mcp-server",
+            "args": ["stdio", "--read-only"],
+            "env": {
+                "BUILDKITE_API_TOKEN": "${BUILDKITE_API_TOKEN}"
+            }
+        }
+    }
+}

--- a/evals/package-lock.json
+++ b/evals/package-lock.json
@@ -1,0 +1,63 @@
+{
+    "name": "pipeline",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "pipeline",
+            "license": "MIT",
+            "devDependencies": {
+                "@types/node": "^24",
+                "prettier": "^3.6",
+                "typescript": "^5"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "24.10.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+            "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~7.16.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "dev": true,
+            "license": "MIT"
+        }
+    }
+}

--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "pipeline",
+    "module": "index.ts",
+    "type": "module",
+    "license": "MIT",
+    "devDependencies": {
+        "@types/node": "^24",
+        "prettier": "^3.6",
+        "typescript": "^5"
+    },
+    "scripts": {
+        "build": "tsc"
+    }
+}

--- a/evals/prompts/klaren.md
+++ b/evals/prompts/klaren.md
@@ -1,0 +1,34 @@
+---
+name: klaren-llm-session-review
+description: When being a Karen is helpful; complain about how an LLM is performing poorly by examining its session log. The complains should cover everything, from the harness loop, decisions made, the tools/CLIs/APIs chosen, etc. The complain helps people to improve the LLM experience by fixing things the LLM relies on.
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+## Important
+
+* The tool name is 'klaren', NOT 'karen'. Do not attempt to correct the spelling to 'karen'.
+
+## Requirements
+
+* An LLM session log file. If not FAIL HARD and LOUD. Do NOT contiue.
+  * The goal the LLM was trying to achieve should be the user prompt in the session log.
+    * If the goal was unclear, FAIL HARD and LOUD. Do NOT coninue.
+
+## Goal
+
+Your job is to analyze a LLM session and complain about what the tools/CLIs/APIs called, their descriptions/documentation, input options/arguments, and output data (the format, the actual content or lack of it, etc.), and enumerate what could have otherwise made your task/goal easier, less time/token consuming, e.g., we should  modify the tools/CLIs/APIs (input, output, etc.), and their descriptions/documentations, input options/arguments, and outputs, e.g., by adding more/better option/arguments to retrieve more specific data, return more data, introduce another tool/CLI/API endpoint, a better harness/loop of the agent, e.g., writing a code instead to run once isntead of multiple tool calls,  etc.
+
+Example (not exhaustive) of things to look for:
+* High repetitive activity could indicate issues
+* High frequency activity could poor choice of polling period
+* Cyclic calls of same tools, could indicate the availability of a consolidated API endpoint could be better
+* Use of tools, APIs, CLIs, whose output did not yield expected results, or the results were not used
+* Use of tools, APIs, CLIs, whose output overlaps significantly
+* The lack of parameters/filters which could have reduced superfluous output
+* Un-ncessary steps/detours that could have been avoided
+
+## Output
+
+* Summary of stesp of plan the LLM took
+* Summary of tools, APIS, CLIs, etc, the LLM used to fullfil each step of the plan
+* Summary of the issues, tool/API/CLI, etc.., fixes, quantify wastage (by time/tokens), severities

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+set -euo pipefail
+
+# Resolve the harness directory so sibling scripts keep resolving after we cd
+# into a separate git checkout (the subject under test) below.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${LOCAL_CI}" == "true" ]]; then
+  WAIT_STATUS_STRING="(perform local CI)"
+else
+  WAIT_STATUS_STRING="(patiently check for cloud CI failure status before proceeding with anything. DO NOT VIOLATE THIS)"
+fi
+
+if [[ "${DEBUG_PERMISSIONS}" == "true" ]]; then
+  DEBUG_STRING=" If you do NOT have permissions to perform something, flag it loudly and BAIL!"
+else
+  DEBUG_STRING=""
+fi
+
+DATETIME=$(date +%Y-%m-%d-%H%M%S)
+
+# Both modes clone a fresh working copy of the EVAL repo — the repo holding the
+# scenario base branch, which is NOT the repo this script ships in — for the
+# eval (and the agent) to operate on.
+REPO_SLUG="${EVAL_REPO_SLUG:-nethsix/buildkite-mcp-server}"
+WORKDIR="$HOME/eval-repo-$DATETIME"
+
+if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+  # In CI the container is built via COPY (mount-checkout=false), so nothing is
+  # a git checkout. gh already authenticates from GITHUB_TOKEN in the env;
+  # `gh auth setup-git` wires that into git so clone/push work too. (Do NOT
+  # `gh auth login --with-token` here: it errors when GITHUB_TOKEN is set.)
+  # The MCP server under test was built into the image from this repo's source
+  # (see evals/Dockerfile).
+  gh auth setup-git
+  git clone "https://github.com/${REPO_SLUG}.git" "$WORKDIR"
+else
+  # Locally, clone/push use the caller's ambient git credentials, and the MCP
+  # server under test is the binary the caller built at this repo's root
+  # (`make build`) — copied into the clone so mcp.json's ./buildkite-mcp-server
+  # command resolves against the clone (claude's working directory).
+  HARNESS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  if [[ ! -x "$HARNESS_ROOT/buildkite-mcp-server" ]]; then
+    echo "ERROR: $HARNESS_ROOT/buildkite-mcp-server not found; run 'make build' first." >&2
+    exit 1
+  fi
+  git clone "https://github.com/${REPO_SLUG}.git" "$WORKDIR"
+  cp "$HARNESS_ROOT/buildkite-mcp-server" "$WORKDIR/"
+fi
+cd "$WORKDIR"
+
+# Create the scenario branch from the deliberately-broken base branch and push it.
+# We push the BRANCH only and deliberately do NOT open a PR: the branch push
+# triggers its own Quality Checks build (build_branches), which is the red->green
+# CI signal the agent fixes.
+SCENARIO_BRANCH="mcp-eval-scenario-$DATETIME"
+git fetch && git checkout -b "$SCENARIO_BRANCH" origin/test-broken-and-failed-jobs
+git push -u origin HEAD
+
+# The org/pipeline the agent watches for the scenario branch's builds. This is
+# the EVAL repo's pipeline (see EVAL_REPO_SLUG above), NOT the ambient
+# BUILDKITE_ORGANIZATION_SLUG/BUILDKITE_PIPELINE_SLUG of the build running this
+# script — those refer to the pipeline hosting the eval, which never builds
+# scenario branches.
+ORG_SLUG="${EVAL_ORG_SLUG:-anothertest}"
+PIPELINE_SLUG="${EVAL_PIPELINE_SLUG:-buildkite-mcp-server}"
+LLM_PROMPT="/goal make the CI for git branch '$SCENARIO_BRANCH' (Buildkite org '$ORG_SLUG', pipeline '$PIPELINE_SLUG') from red $WAIT_STATUS_STRING to green. Push your fixes to that same branch and confirm its build passes. Do NOT read/reverse-engineer babystand.sh.$DEBUG_STRING"
+
+# Echo env vars
+echo "*** Initial Env Vars"
+echo "***"
+echo "*** LOCAL_CI: $LOCAL_CI"
+echo "*** DEBUG_PERMISSIONS: $DEBUG_PERMISSIONS"
+echo "*** RUN_IN_CI: ${RUN_IN_CI:-false}"
+echo "*** LOCAL_BYPASS_PERMISSION: $LOCAL_BYPASS_PERMISSION"
+echo "***"
+echo "----------------------"
+echo "***"
+echo "*** Derived Env Vars"
+echo "***"
+echo "*** SCENARIO_BRANCH: $SCENARIO_BRANCH"
+echo "*** WAIT_STATUS_STRING: $WAIT_STATUS_STRING"
+echo "*** DEBUG_STRING: $DEBUG_STRING"
+echo "***"
+echo "----------------------"
+echo "***"
+echo "*** LLM_PROMPT: $LLM_PROMPT"
+echo "***"
+
+LOG="/tmp/babystand-$DATETIME.log"
+
+# Format a duration in whole seconds as "Nm Ns".
+fmt_elapsed() { printf '%dm %ds' $(($1 / 60)) $(($1 % 60)); }
+
+# Claude args shared by both execution modes.
+CLAUDE_TOOL_ARGS=(
+    --output-format stream-json --verbose
+)
+
+# Permission posture.
+# CI: claude.sh runs with --permission-mode bypassPermissions and no allowlist
+# — tool CHOICE (MCP tools vs raw curl/gh against the API) is part of what the
+# eval measures, and the agent is contained by the container sandbox, the
+# server's --read-only mode, and the read-only API token.
+# Local: the same posture is opt-in via LOCAL_BYPASS_PERMISSION=true, because
+# it gives the agent unrestricted Bash on the host. With it false, a restricted
+# allowlist applies, which must include the MCP server's tools (headless
+# denials are silent) — the server name is derived from mcp.json, overridable
+# via MCP_SERVER_NAME, and missing both is a loud failure.
+# LOCAL_BYPASS_PERMISSION has NO default, deliberately: every caller (CI sets
+# it in the docker plugin env) must make the choice consciously.
+: "${LOCAL_BYPASS_PERMISSION:?must be set to true or false — see evals/README.md}"
+if [[ "${RUN_IN_CI:-false}" != "true" ]]; then
+    if [[ "$LOCAL_BYPASS_PERMISSION" == "true" ]]; then
+        CLAUDE_TOOL_ARGS+=(--permission-mode bypassPermissions)
+    else
+        MCP_SERVER_NAME="${MCP_SERVER_NAME:-$(jq -r '.mcpServers | keys | first // empty' "$SCRIPT_DIR/../mcp.json")}"
+        if [[ -z "$MCP_SERVER_NAME" ]]; then
+            echo "ERROR: MCP_SERVER_NAME is unset and could not be derived from $SCRIPT_DIR/../mcp.json" >&2
+            exit 1
+        fi
+        CLAUDE_TOOL_ARGS+=(--allowedTools "Edit" "Bash(go:*)" "Bash(make:*)" "Bash(git:*)" "mcp__${MCP_SERVER_NAME}")
+    fi
+fi
+
+EVAL_START=$(date +%s)
+if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+    # Sandboxed CI execution: run inside the container via claude.sh, which owns
+    # the mcp_in_ci.json config, appends the system prompt, and pipes through the
+    # parser. It prints CLAUDE_SESSION_ID / CLAUDE_TRANSCRIPT pointers on stdout.
+    GOAL_FILE="$(mktemp)"
+    echo "$LLM_PROMPT" > "$GOAL_FILE"
+    ANNOTATION_CONTEXT_PREFIX=eval \
+        "$SCRIPT_DIR/claude.sh" "$GOAL_FILE" "${CLAUDE_TOOL_ARGS[@]}" | tee "$LOG"
+
+    # Recover the session transcript location from claude.sh's emitted pointers
+    # (resolved in the agent's user context, so the $HOME is correct).
+    SESSION_ID=$(sed -n 's/^CLAUDE_SESSION_ID=//p' "$LOG" | tail -n1)
+    TRANSCRIPT=$(sed -n 's/^CLAUDE_TRANSCRIPT=//p' "$LOG" | tail -n1)
+    EVAL_RESULT_FILE=$(sed -n 's/^CLAUDE_RESULT_FILE=//p' "$LOG" | tail -n1)
+else
+    # Local execution: run claude directly against the harness mcp.json (cwd is
+    # now the eval-repo clone, so a relative path would not resolve).
+    claude -p "$LLM_PROMPT" \
+        --mcp-config "$SCRIPT_DIR/../mcp.json" \
+        "${CLAUDE_TOOL_ARGS[@]}" \
+        | tee "$LOG"
+
+    # The raw stream-json is in $LOG, so derive the session id / transcript here.
+    SESSION_ID=$(jq -r 'select(.type == "system" and .subtype == "init") | .session_id' "$LOG" | head -n1)
+    TRANSCRIPT=~/.claude/projects/$(pwd | sed -e 's/[\/.]/-/g')/$SESSION_ID.jsonl
+fi
+EVAL_ELAPSED=$(fmt_elapsed $(( $(date +%s) - EVAL_START )))
+echo "*** EVAL ELAPSED (red-to-green): $EVAL_ELAPSED"
+
+echo "*** SESSION_ID: $SESSION_ID"
+echo "*** TRANSCRIPT: $TRANSCRIPT"
+
+# Upload the eval session log (transcript) as a build artifact. Best-effort and
+# CI-only (buildkite-agent is unavailable locally); never fail the build.
+if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+    if [[ -s "$TRANSCRIPT" ]]; then
+        buildkite-agent artifact upload "$TRANSCRIPT" \
+            || echo "WARNING: failed to upload session transcript artifact" >&2
+    else
+        echo "WARNING: session transcript not found or empty: $TRANSCRIPT" >&2
+    fi
+fi
+
+AUDIT_TOOLS_FILE="$(mktemp)"
+AUDIT_METRICS_FILE="$(mktemp)"
+echo "*** Session Details ***"
+"$SCRIPT_DIR/bk-tool-audit-v2.sh" --all "$TRANSCRIPT" | tee "$AUDIT_TOOLS_FILE"
+echo "*** Session Metrics ***"
+"$SCRIPT_DIR/bk-tool-audit-v2.sh" metrics "$TRANSCRIPT" | tee "$AUDIT_METRICS_FILE"
+
+# --- Review the eval session with the klaren prompt -------------------------
+# Best-effort, post-run analysis: a failure here must NOT fail the eval, which
+# has already completed. klaren.md requires the session log path, so append it
+# to the prompt. Use the harness copy of the prompt (alongside this script), not
+# the checked-out subject-under-test copy.
+echo "--- :female-detective: Reviewing the session (klaren)"
+KLAREN_LOG="/tmp/klaren-$DATETIME.log"
+KLAREN_PROMPT_FILE="$(mktemp)"
+{
+    cat "$SCRIPT_DIR/../prompts/klaren.md"
+    echo
+    echo "The LLM session log file to analyze is: $TRANSCRIPT"
+} > "$KLAREN_PROMPT_FILE"
+
+# klaren reads the transcript and inspects the repo; it needs read/search tools.
+# Same permission posture as the eval run above: CI bypasses via claude.sh;
+# local bypasses only when LOCAL_BYPASS_PERMISSION=true, else an allowlist
+# (no MCP entry — klaren analyzes the transcript file, not Buildkite).
+KLAREN_TOOL_ARGS=(
+    --output-format stream-json --verbose
+)
+if [[ "${RUN_IN_CI:-false}" != "true" ]]; then
+    if [[ "$LOCAL_BYPASS_PERMISSION" == "true" ]]; then
+        KLAREN_TOOL_ARGS+=(--permission-mode bypassPermissions)
+    else
+        KLAREN_TOOL_ARGS+=(--allowedTools "Read" "Grep" "Glob" "Bash")
+    fi
+fi
+
+KLAREN_RESULT_FILE=""
+KLAREN_START=$(date +%s)
+if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+    if ! ANNOTATION_CONTEXT_PREFIX=klaren \
+        "$SCRIPT_DIR/claude.sh" "$KLAREN_PROMPT_FILE" "${KLAREN_TOOL_ARGS[@]}" | tee "$KLAREN_LOG"; then
+        echo "WARNING: klaren review failed" >&2
+    fi
+    KLAREN_RESULT_FILE=$(sed -n 's/^CLAUDE_RESULT_FILE=//p' "$KLAREN_LOG" | tail -n1)
+    buildkite-agent artifact upload "$KLAREN_LOG" || echo "WARNING: failed to upload klaren artifact" >&2
+else
+    if ! claude -p "$(cat "$KLAREN_PROMPT_FILE")" \
+        --mcp-config "$SCRIPT_DIR/../mcp.json" \
+        "${KLAREN_TOOL_ARGS[@]}" \
+        | tee "$KLAREN_LOG"; then
+        echo "WARNING: klaren review failed" >&2
+    fi
+fi
+KLAREN_ELAPSED=$(fmt_elapsed $(( $(date +%s) - KLAREN_START )))
+echo "*** KLAREN ELAPSED: $KLAREN_ELAPSED"
+
+echo "*** KLAREN_LOG: $KLAREN_LOG"
+
+# --- Curated summary annotations --------------------------------------------
+# In addition to the per-message annotations from the parser (which stay on
+# unless ANNOTATE_MESSAGES=false), surface a few high-signal summaries at the top
+# of the build (priority 10 > the parser's 5). CI-only: buildkite-agent annotate
+# is unavailable locally. All best-effort; never fail the build.
+if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+    # annotate_markdown <context> <title> <file> <meta> [style]
+    # content is already markdown; collapsed by default (like the code-block
+    # annotations). The always-visible summary shows the title + <meta> (e.g.
+    # elapsed time); the markdown body is inside the collapsed <details>.
+    annotate_markdown() {
+        local context="$1" title="$2" file="$3" meta="$4" style="${5:-info}"
+        {
+            printf '<details><summary>%s' "$title"
+            [[ -n "$meta" ]] && printf ' — %s' "$meta"
+            printf '</summary>\n\n'
+            if [[ -s "$file" ]]; then
+                cat "$file"
+            else
+                printf '_(no final output captured)_\n'
+            fi
+            printf '\n\n</details>\n'
+        } | buildkite-agent annotate --context "$context" --style "$style" --priority 10 \
+            || echo "WARNING: failed to annotate '$context'" >&2
+    }
+
+    # annotate_codeblock <context> <title> <file>  -- content is plain text; collapse it
+    annotate_codeblock() {
+        local context="$1" title="$2" file="$3"
+        if [[ ! -s "$file" ]]; then
+            echo "WARNING: nothing to annotate for '$context'" >&2
+            return 0
+        fi
+        { printf '<details><summary>%s</summary>\n\n```\n' "$title"; cat "$file"; printf '\n```\n\n</details>\n'; } \
+            | buildkite-agent annotate --context "$context" --style info --priority 10 \
+            || echo "WARNING: failed to annotate '$context'" >&2
+    }
+
+    annotate_markdown "eval-final"    ":robot_face: Eval — final output"      "${EVAL_RESULT_FILE:-}" "⏱️ Red-to-green elapsed: ${EVAL_ELAPSED}" "success"
+    annotate_codeblock "eval-metrics" ":bar_chart: Eval — session metrics"    "$AUDIT_METRICS_FILE"
+    annotate_codeblock "eval-tools"   ":hammer_and_wrench: Eval — tool calls" "$AUDIT_TOOLS_FILE"
+    annotate_markdown "klaren-final"  ":female-detective: Klaren — session review" "${KLAREN_RESULT_FILE:-}" "⏱️ Klaren elapsed: ${KLAREN_ELAPSED}"
+fi
+
+# --- Compare against last passing main build (best-effort) ------------------
+# Diffs this build's eval summary, metrics, and klaren report against the last
+# passing `main` build, and publishes an `eval-compare` annotation. Best-effort:
+# never fails the eval, which has already completed.
+EVAL_RESULT_FILE="${EVAL_RESULT_FILE:-}" \
+AUDIT_METRICS_FILE="$AUDIT_METRICS_FILE" \
+AUDIT_TOOLS_FILE="$AUDIT_TOOLS_FILE" \
+KLAREN_RESULT_FILE="${KLAREN_RESULT_FILE:-}" \
+  "$SCRIPT_DIR/bk-eval-compare.sh" || echo "WARNING: eval comparison failed" >&2

--- a/evals/scripts/bk-eval-compare.sh
+++ b/evals/scripts/bk-eval-compare.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+#
+# bk-eval-compare.sh — compare the CURRENT eval build against the last
+# successful build on `main`, and publish the comparison as a Buildkite
+# annotation on the current build.
+#
+# It compares the same signals babystand.sh already surfaces:
+#   * Eval Summary  (eval-final)  — Goal (achieved?) and Plan Steps (side-by-side)
+#   * Metrics       (eval-metrics)— input/output tokens, cache usage, tool calls,
+#                                    duration, cost (side-by-side with deltas)
+#   * Klaren report (klaren-final)— weighted score + issue diff (gone/new/remaining)
+#
+# HOW THE BASELINE IS OBTAINED
+#   The current build's raw comparison inputs are uploaded as build artifacts
+#   under `eval-compare/`. To compare, we look up the most recent PASSED build on
+#   `main` via the Buildkite REST API and download ITS `eval-compare/` artifacts.
+#   (So the very first main build after this lands has nothing to baseline
+#   against; every run after that does. This is reported gracefully.)
+#
+# DETERMINISTIC vs SEMANTIC
+#   Metrics are numeric, so they are diffed deterministically with jq.
+#   Eval Summary + Klaren are free-form prose, so the semantic comparison
+#   (goal achievement, plan-step diff, weighted Klaren score, issue diff) is done
+#   by `claude` — reusing claude.sh in CI exactly like babystand.sh does for
+#   klaren, so Buildkite Hosted Models auth + the parser are handled for us.
+#
+# USAGE — append to the END of scripts/babystand.sh (best-effort; guarded):
+#
+#     # --- Compare against last passing main build (best-effort) --------------
+#     EVAL_RESULT_FILE="${EVAL_RESULT_FILE:-}" \
+#     AUDIT_METRICS_FILE="$AUDIT_METRICS_FILE" \
+#     AUDIT_TOOLS_FILE="$AUDIT_TOOLS_FILE" \
+#     KLAREN_RESULT_FILE="${KLAREN_RESULT_FILE:-}" \
+#       "$SCRIPT_DIR/bk-eval-compare.sh" || echo "WARNING: eval comparison failed" >&2
+#
+#   The four files are the same ones babystand.sh already produced; they are read
+#   from the environment. Everything else (org, pipeline, token, build url,
+#   RUN_IN_CI) comes from the standard Buildkite job environment.
+#
+# This script NEVER exits non-zero: a comparison failure must not fail an eval
+# that already completed.
+
+# Deliberately NOT `set -e`: this is post-run, best-effort analysis.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Everything below is wrapped so any unexpected error still lets us `exit 0`.
+main() {
+  command -v jq >/dev/null || { echo "bk-eval-compare: jq required, skipping" >&2; return 0; }
+
+  # --- Inputs (current build) ---------------------------------------------
+  local CUR_EVAL="${EVAL_RESULT_FILE:-}"
+  local CUR_METRICS="${AUDIT_METRICS_FILE:-}"
+  local CUR_TOOLS="${AUDIT_TOOLS_FILE:-}"
+  local CUR_KLAREN="${KLAREN_RESULT_FILE:-}"
+
+  local ORG="${BUILDKITE_ORGANIZATION_SLUG:-}"
+  local PIPELINE="${BUILDKITE_PIPELINE_SLUG:-}"
+  # This script queries the org hosting the eval build, which is a different
+  # org from the one the agent's MCP server watches (BUILDKITE_API_TOKEN).
+  # Buildkite API tokens are single-org, so a dedicated token is required;
+  # fall back to BUILDKITE_API_TOKEN for single-org (local/fork) setups.
+  local TOKEN="${EVAL_COMPARE_BUILDKITE_API_TOKEN:-${BUILDKITE_API_TOKEN:-}}"
+  local BUILD_URL="${BUILDKITE_BUILD_URL:-}"
+  local CUR_NUM="${BUILDKITE_BUILD_NUMBER:-}"
+  # BUILDKITE_BUILD_NUMBER isn't forwarded into the eval container, but the URL
+  # (which ends in the build number) is — fall back to parsing it.
+  [[ -z "$CUR_NUM" && -n "$BUILD_URL" ]] && CUR_NUM="${BUILD_URL##*/}"
+
+  local IN_CI="false"
+  [[ "${RUN_IN_CI:-false}" == "true" ]] && command -v buildkite-agent >/dev/null 2>&1 && IN_CI="true"
+
+  if [[ "$IN_CI" != "true" ]]; then
+    echo "bk-eval-compare: not running in CI (no buildkite-agent); nothing to compare." >&2
+    return 0
+  fi
+  if [[ -z "$ORG" || -z "$PIPELINE" || -z "$TOKEN" ]]; then
+    echo "bk-eval-compare: missing ORG/PIPELINE/EVAL_COMPARE_BUILDKITE_API_TOKEN; skipping." >&2
+    return 0
+  fi
+
+  echo "--- :scales: Comparing eval against last passing main build"
+
+  # --- Publish current inputs as artifacts (baseline for future runs) ------
+  local STAGE; STAGE="$(mktemp -d)"
+  mkdir -p "$STAGE/eval-compare"
+  [[ -s "$CUR_EVAL"    ]] && cp "$CUR_EVAL"    "$STAGE/eval-compare/eval-final.md"    2>/dev/null || true
+  [[ -s "$CUR_METRICS" ]] && cp "$CUR_METRICS" "$STAGE/eval-compare/eval-metrics.json" 2>/dev/null || true
+  [[ -s "$CUR_TOOLS"   ]] && cp "$CUR_TOOLS"   "$STAGE/eval-compare/eval-tools.txt"    2>/dev/null || true
+  [[ -s "$CUR_KLAREN"  ]] && cp "$CUR_KLAREN"  "$STAGE/eval-compare/klaren-final.md"   2>/dev/null || true
+  ( cd "$STAGE" && buildkite-agent artifact upload "eval-compare/*" ) \
+    || echo "bk-eval-compare: WARNING failed to upload comparison artifacts" >&2
+
+  # --- Find the last PASSED build on main (excluding this one) --------------
+  local api="https://api.buildkite.com/v2/organizations/$ORG/pipelines/$PIPELINE/builds"
+  local builds
+  builds="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+      "$api?branch=main&state=passed&per_page=10" 2>/dev/null)" || builds=""
+
+  local BASE_ID BASE_NUM BASE_WEB
+  BASE_ID="$(jq -r --arg cur "$CUR_NUM" \
+      'map(select((.number|tostring) != $cur)) | .[0].id // empty' <<<"${builds:-[]}" 2>/dev/null)"
+  BASE_NUM="$(jq -r --arg cur "$CUR_NUM" \
+      'map(select((.number|tostring) != $cur)) | .[0].number // empty' <<<"${builds:-[]}" 2>/dev/null)"
+  BASE_WEB="$(jq -r --arg cur "$CUR_NUM" \
+      'map(select((.number|tostring) != $cur)) | .[0].web_url // empty' <<<"${builds:-[]}" 2>/dev/null)"
+
+  if [[ -z "$BASE_ID" ]]; then
+    annotate "eval-compare" ":scales: Eval — comparison vs last main" \
+      "_No prior passing \`main\` build found to compare against._"
+    return 0
+  fi
+  echo "bk-eval-compare: baseline = build #$BASE_NUM ($BASE_ID)"
+
+  # --- Download baseline artifacts -----------------------------------------
+  local BASE_DIR; BASE_DIR="$(mktemp -d)"
+  buildkite-agent artifact download "eval-compare/*" "$BASE_DIR" --build "$BASE_ID" \
+    2>/dev/null || true
+  local B_EVAL="$BASE_DIR/eval-compare/eval-final.md"
+  local B_METRICS="$BASE_DIR/eval-compare/eval-metrics.json"
+  local B_KLAREN="$BASE_DIR/eval-compare/klaren-final.md"
+
+  local base_link="build [#$BASE_NUM](${BASE_WEB:-#})"
+  if [[ ! -s "$B_METRICS" && ! -s "$B_EVAL" && ! -s "$B_KLAREN" ]]; then
+    annotate "eval-compare" ":scales: Eval — comparison vs last main" \
+      "_Baseline $base_link predates comparison artifacts — nothing to compare yet. Future runs will compare against builds produced after this change._"
+    return 0
+  fi
+
+  # --- Build the report ----------------------------------------------------
+  local REPORT; REPORT="$(mktemp)"
+  {
+    echo "Baseline: last passing **main** $base_link"
+    echo
+    # ---- Metrics (deterministic) ----
+    echo "## :bar_chart: Metrics"
+    echo
+    if [[ -s "$B_METRICS" && -s "$CUR_METRICS" ]]; then
+      metrics_table "$B_METRICS" "$CUR_METRICS" "$BASE_NUM" "$CUR_NUM"
+      echo
+      echo "<details><summary>Per-tool call counts</summary>"
+      echo
+      tool_table "$B_METRICS" "$CUR_METRICS"
+      echo
+      echo "</details>"
+    else
+      echo "_Metrics unavailable (missing baseline or current metrics)._"
+    fi
+    echo
+    # ---- Eval Summary + Klaren (semantic, via claude) ----
+    local SEM; SEM="$(semantic_compare "$B_EVAL" "$CUR_EVAL" "$B_KLAREN" "$CUR_KLAREN")"
+    if [[ -n "$SEM" ]]; then
+      echo "$SEM"
+    else
+      echo "## :robot_face: Eval Summary & :female-detective: Klaren"
+      echo
+      echo "_Semantic comparison unavailable._"
+    fi
+  } > "$REPORT"
+
+  annotate_file "eval-compare" ":scales: Eval — comparison vs last main" "$REPORT"
+  echo "--- :scales: Comparison published (eval-compare annotation)"
+}
+
+# ---------------------------------------------------------------------------
+# metrics_table BASE_JSON CUR_JSON BASE_NUM CUR_NUM  -> markdown table on stdout
+metrics_table() {
+  jq -rn \
+    --slurpfile b "$1" --slurpfile c "$2" \
+    --arg bn "$3" --arg cn "$4" '
+    ($b[0] // {}) as $B | ($c[0] // {}) as $C |
+    def num(x): (x // 0);
+    def rnd(x): ((x*100|round)/100);
+    def sign(x): (rnd(x)) as $y | (if $y > 0 then "+\($y)" elif $y < 0 then "\($y)" else "0" end);
+    def r(lbl; bv; cv): "| \(lbl) | \(num(bv)) | \(num(cv)) | \(sign(num(cv)-num(bv))) |";
+    [
+      "| Metric | Baseline #\($bn) | Current #\($cn) | Δ |",
+      "|---|---:|---:|---:|",
+      r("Input tokens";        $B.tokens.input;          $C.tokens.input),
+      r("Output tokens";       $B.tokens.output;         $C.tokens.output),
+      r("Cache write (5m)";    $B.tokens.cache_write_5m; $C.tokens.cache_write_5m),
+      r("Cache write (1h)";    $B.tokens.cache_write_1h; $C.tokens.cache_write_1h),
+      r("Cache read";          $B.tokens.cache_read;     $C.tokens.cache_read),
+      r("Tool calls (total)";  $B.tool_calls_total;      $C.tool_calls_total),
+      r("Assistant responses"; $B.assistant_responses;   $C.assistant_responses),
+      r("User messages";       $B.user_messages;         $C.user_messages),
+      r("Duration (min)";      $B.duration_min;          $C.duration_min),
+      r("Est. cost (USD)";     $B.est_cost_usd;          $C.est_cost_usd)
+    ] | .[]'
+}
+
+# tool_table BASE_JSON CUR_JSON  -> per-tool call-count comparison table
+tool_table() {
+  jq -rn \
+    --slurpfile b "$1" --slurpfile c "$2" '
+    def tomap(a): ((a // [])
+      | map(capture("^(?<n>[0-9]+) (?<name>.+)$"))
+      | map({(.name): (.n|tonumber)}) | add // {});
+    (tomap($b[0].tool_calls_by_name)) as $B |
+    (tomap($c[0].tool_calls_by_name)) as $C |
+    (($B|keys) + ($C|keys) | unique) as $names |
+    (["| Tool | Baseline | Current | Δ |", "|---|---:|---:|---:|"]
+     + ($names | map(. as $n
+         | (($B[$n]) // 0) as $bv | (($C[$n]) // 0) as $cv
+         | "| `\($n)` | \($bv) | \($cv) | \(if ($cv-$bv)>0 then "+\($cv-$bv)" else "\($cv-$bv)" end) |")))
+    | .[]'
+}
+
+# _sect FILE -- print a file's contents, or a placeholder if empty/missing.
+_sect() { if [[ -s "$1" ]]; then cat "$1"; else echo "_(not available)_"; fi; }
+
+# ---------------------------------------------------------------------------
+# semantic_compare BASE_EVAL CUR_EVAL BASE_KLAREN CUR_KLAREN -> markdown on stdout
+semantic_compare() {
+  local b_eval="$1" c_eval="$2" b_klaren="$3" c_klaren="$4"
+  # Nothing meaningful to compare semantically.
+  [[ -s "$c_eval" || -s "$c_klaren" ]] || return 0
+
+  local PROMPT; PROMPT="$(mktemp)"
+  {
+    cat <<'PROMPT_HEADER'
+You are comparing two runs of an automated CI-fixing eval. Everything you need is
+provided inline below — DO NOT use any tools; just analyze the given text.
+
+Output ONLY a GitHub-flavored-markdown report (no preamble, no code fences around
+the whole thing). Use exactly these top-level sections and headings:
+
+## :robot_face: Eval Summary
+### Goal
+- State the goal of each run and whether it ACHIEVED the goal (✅/❌ with a one-line reason), baseline vs current.
+### Plan Steps
+- Present a SIDE-BY-SIDE comparison of the plan/steps each run took, as a markdown table with columns: Step | Baseline | Current.
+- Below the table, bullet the notable DIFFERENCES (steps added, dropped, reordered, or done differently).
+
+## :female-detective: Klaren
+### Score
+Compute a weighted score for EACH run using this rubric, identically:
+  - Points per issue by severity: Critical = 5, High = 4, Medium = 3, Low = 2.
+  - Frequency multiplier = how many times the issue manifested in the run (occurrences), minimum 1.
+  - Issue contribution = severity_points × frequency_multiplier.
+  - Final score = sum of all issue contributions. (Higher score = worse session.)
+Show a breakdown table for each run: Issue | Severity | Points | Frequency (×) | Contribution.
+Then state the Final score for baseline and current and the delta (and whether current improved, i.e. lower).
+If a severity or frequency is not explicit in the report, infer the most reasonable value and note the assumption.
+### Issues diff
+Categorize issues across the two reports:
+  - **Resolved (gone):** in baseline but not current.
+  - **New:** in current but not baseline.
+  - **Remaining:** present in both (note any change in severity/frequency).
+Match issues by their substance, not exact wording.
+
+Keep it tight and skimmable.
+PROMPT_HEADER
+    echo
+    echo "=== BASELINE — EVAL SUMMARY (eval-final) ==="
+    _sect "$b_eval"
+    echo
+    echo "=== CURRENT — EVAL SUMMARY (eval-final) ==="
+    _sect "$c_eval"
+    echo
+    echo "=== BASELINE — KLAREN REPORT (klaren-final) ==="
+    _sect "$b_klaren"
+    echo
+    echo "=== CURRENT — KLAREN REPORT (klaren-final) ==="
+    _sect "$c_klaren"
+  } > "$PROMPT"
+
+  local LOG; LOG="$(mktemp)"
+  local RESULT=""
+  if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+    if ANNOTATION_CONTEXT_PREFIX=compare \
+         "$SCRIPT_DIR/claude.sh" "$PROMPT" \
+         --output-format stream-json --verbose --allowedTools "Read" \
+         >"$LOG" 2>/dev/null; then
+      local rf; rf="$(sed -n 's/^CLAUDE_RESULT_FILE=//p' "$LOG" | tail -n1)"
+      [[ -s "$rf" ]] && RESULT="$(cat "$rf")"
+    fi
+  else
+    if claude -p "$(cat "$PROMPT")" \
+         --output-format stream-json --verbose --allowedTools "Read" \
+         >"$LOG" 2>/dev/null; then
+      RESULT="$(jq -r 'select(.type=="result") | .result // empty' "$LOG" 2>/dev/null)"
+    fi
+  fi
+  printf '%s' "$RESULT"
+}
+
+# ---------------------------------------------------------------------------
+# annotate CONTEXT TITLE MARKDOWN_STRING   -- collapsible markdown annotation
+annotate() {
+  local ctx="$1" title="$2" body="$3"
+  { printf '<details><summary>%s</summary>\n\n%s\n\n</details>\n' "$title" "$body"; } \
+    | buildkite-agent annotate --context "$ctx" --style info --priority 10 \
+    || echo "bk-eval-compare: WARNING failed to annotate '$ctx'" >&2
+}
+
+# annotate_file CONTEXT TITLE FILE
+annotate_file() {
+  local ctx="$1" title="$2" file="$3"
+  {
+    printf '<details><summary>%s</summary>\n\n' "$title"
+    if [[ -s "$file" ]]; then cat "$file"; else printf '_(empty comparison)_\n'; fi
+    printf '\n\n</details>\n'
+  } | buildkite-agent annotate --context "$ctx" --style info --priority 10 \
+    || echo "bk-eval-compare: WARNING failed to annotate '$ctx'" >&2
+}
+
+main "$@" || echo "bk-eval-compare: WARNING comparison aborted early" >&2
+exit 0

--- a/evals/scripts/bk-tool-audit-v2.sh
+++ b/evals/scripts/bk-tool-audit-v2.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# bk-tool-audit.sh — audit the MCP tool calls + parameters recorded in a
+# Claude Code session transcript. Useful for comparing which tools/params
+# get used before vs. after a code change.
+#
+# Transcripts live in:
+#   ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+# where <encoded-cwd> is the project path with every "/" replaced by "-".
+#
+# Usage:
+#   ./bk-tool-audit.sh                       # newest session for current project
+#   ./bk-tool-audit.sh <session.jsonl>       # a specific transcript
+#   ./bk-tool-audit.sh list                  # list this project's sessions (newest first)
+#   ./bk-tool-audit.sh diff <a.jsonl> <b.jsonl>   # diff tool/param calls between two sessions
+#   ./bk-tool-audit.sh metrics [session.jsonl]    # token totals, cost, tool counts, duration
+#
+# Options (before the positional args):
+#   --all        Include all tools, not just mcp__buildkite-mcp-server__*
+#   --names      Print only "<count> <tool>" summary instead of full params
+#   --results    Also show each call's tool_result (matched by tool_use_id)
+#   --project P  Use project dir for path P instead of the current directory
+#
+# Pricing for `metrics` (USD per million tokens) is overridable via env vars;
+# defaults are Claude Opus 4.8 rates:
+#   BK_PRICE_IN=5  BK_PRICE_OUT=25  BK_PRICE_CACHE_5M=6.25
+#   BK_PRICE_CACHE_1H=10  BK_PRICE_CACHE_READ=0.5
+#
+set -euo pipefail
+
+# Pricing (USD per 1M tokens) — override via env. Defaults: Claude Opus 4.8.
+BK_PRICE_IN="${BK_PRICE_IN:-5}"
+BK_PRICE_OUT="${BK_PRICE_OUT:-25}"
+BK_PRICE_CACHE_5M="${BK_PRICE_CACHE_5M:-6.25}"
+BK_PRICE_CACHE_1H="${BK_PRICE_CACHE_1H:-10}"
+BK_PRICE_CACHE_READ="${BK_PRICE_CACHE_READ:-0.5}"
+
+TOOL_FILTER='startswith("mcp__buildkite-mcp-server__")'
+NAMES_ONLY=0
+WITH_RESULTS=0
+PROJECT_PATH="$PWD"
+
+# --- parse options ---------------------------------------------------------
+while [[ "${1:-}" == -* ]]; do
+  case "$1" in
+    --all)     TOOL_FILTER='true'; shift ;;
+    --names)   NAMES_ONLY=1; shift ;;
+    --results) WITH_RESULTS=1; shift ;;
+    --project) PROJECT_PATH="${2:?--project needs a path}"; shift 2 ;;
+    -h|--help) sed -n '2,34p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+# Encode a directory path the way Claude Code names its project dir.
+encode_dir() {
+  local abs; abs="$(cd "$1" 2>/dev/null && pwd || echo "$1")"
+  printf '%s' "$abs" | sed 's:/:-:g'
+}
+
+PROJECT_DIR="$HOME/.claude/projects/$(encode_dir "$PROJECT_PATH")"
+
+newest_session() {
+  ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1
+}
+
+# Emit one compact JSON object per tool_use in a transcript.
+extract() {
+  local f="$1"
+  jq -c --argjson names "$NAMES_ONLY" '
+    select(.message.content) | .message.content[]?
+    | select(.type=="tool_use" and (.name | '"$TOOL_FILTER"'))
+    | if $names == 1 then {tool: .name}
+      else {id: .id, tool: .name, input: .input} end
+  ' "$f"
+}
+
+print_session() {
+  local f="$1"
+  [[ -f "$f" ]] || { echo "no such transcript: $f" >&2; exit 1; }
+  echo "# session: $f"
+
+  if [[ "$NAMES_ONLY" == 1 ]]; then
+    extract "$f" | jq -r '.tool' | sort | uniq -c | sort -rn
+    return
+  fi
+
+  if [[ "$WITH_RESULTS" == 1 ]]; then
+    # Map tool_use_id -> truncated result text.
+    local map; map="$(jq -cn '
+      [ inputs | (.message.content? // []) | select(type=="array") | .[]
+        | select(.type=="tool_result")
+        | {(.tool_use_id): ((.content // "")
+             | if type=="array" then (map(.text // "") | join("")) else tostring end
+             | gsub("\n";" ") | .[0:300])} ]
+      | add // {}' "$f")"
+    extract "$f" | jq -c --argjson map "$map" \
+      '. + {result: ($map[.id] // "(no result captured)")} | del(.id)'
+  else
+    extract "$f" | jq -c 'del(.id)'
+  fi
+}
+
+# Token totals, cost, tool counts, model mix, and duration for one session.
+# Dedupes usage by message.id (content blocks are split one-per-line, each
+# repeating the message-level usage) and reads from a stable snapshot copy to
+# avoid racing the live append of the current session.
+metrics() {
+  local f="$1"
+  [[ -f "$f" ]] || { echo "no such transcript: $f" >&2; exit 1; }
+
+  local snap; snap="$(mktemp -t bk-audit.XXXXXX)"
+  trap 'rm -f "$snap"' RETURN
+  cp "$f" "$snap"
+
+  local prices
+  prices="$(jq -n \
+    --arg in "$BK_PRICE_IN" --arg out "$BK_PRICE_OUT" \
+    --arg c5 "$BK_PRICE_CACHE_5M" --arg c1h "$BK_PRICE_CACHE_1H" \
+    --arg cr "$BK_PRICE_CACHE_READ" \
+    '{in: ($in|tonumber), out: ($out|tonumber), c5: ($c5|tonumber),
+      c1h: ($c1h|tonumber), cread: ($cr|tonumber)}')"
+
+  echo "# session: $f" >&2
+  jq -nr --argjson p "$prices" '
+    def n: . // 0;
+    [inputs] as $all
+    | ($all | map(select(.type=="assistant")) | group_by(.message.id) | map(.[0])) as $resp
+    | ($resp | map(.message.usage)) as $u
+    | ($all | [ .[] | (.message.content? // []) | select(type=="array") | .[]
+                | select(.type=="tool_use") | {id, name} ] | unique_by(.id)) as $tools
+    | ($all | map(.timestamp) | map(select(type=="string"))
+            | map(sub("\\.[0-9]+";"") | fromdateiso8601)) as $secs
+    # token sums
+    | ($u | map(.input_tokens|n)            | add | n) as $tin
+    | ($u | map(.output_tokens|n)           | add | n) as $tout
+    | ($u | map(.cache_read_input_tokens|n) | add | n) as $tread
+    | ($u | map(.cache_creation.ephemeral_5m_input_tokens|n) | add | n) as $c5raw
+    | ($u | map(.cache_creation.ephemeral_1h_input_tokens|n) | add | n) as $c1h
+    | ($u | map(.cache_creation_input_tokens|n) | add | n) as $ccTotal
+    # if the 5m/1h split is absent, attribute all cache-creation to 5m
+    | (if ($c5raw + $c1h) == 0 then $ccTotal else $c5raw end) as $c5
+    | (($tin*$p.in + $tout*$p.out + $c5*$p.c5 + $c1h*$p.c1h + $tread*$p.cread) / 1000000) as $cost
+    | {
+        user_messages: ($all|map(select(.type=="user"))|length),
+        assistant_responses: ($resp|length),
+        duration_min: (if ($secs|length) > 0 then ((($secs|max)-($secs|min))/60|floor) else null end),
+        models: ($resp | map(.message.model // "unknown") | group_by(.) | map({(.[0]): length}) | add),
+        tokens: {input: $tin, output: $tout, cache_write_5m: $c5, cache_write_1h: $c1h, cache_read: $tread},
+        tool_calls_total: ($tools|length),
+        tool_calls_by_name: ($tools | group_by(.name) | map("\(length) \(.[0].name)") | sort | reverse),
+        est_cost_usd: (($cost*100|round)/100)
+      }
+  ' "$snap"
+}
+
+# --- dispatch --------------------------------------------------------------
+case "${1:-}" in
+  list)
+    echo "# project dir: $PROJECT_DIR"
+    ls -lt "$PROJECT_DIR"/*.jsonl 2>/dev/null || echo "(no sessions found)"
+    ;;
+  diff)
+    a="${2:?diff needs two transcripts}"; b="${3:?diff needs two transcripts}"
+    echo "# diff: $a  <->  $b"
+    diff <(extract "$a" | jq -c 'del(.id)') <(extract "$b" | jq -c 'del(.id)') || true
+    ;;
+  metrics)
+    f="${2:-$(newest_session)}"
+    [[ -n "$f" ]] || { echo "no sessions in $PROJECT_DIR" >&2; exit 1; }
+    metrics "$f"
+    ;;
+  "")
+    f="$(newest_session)"
+    [[ -n "$f" ]] || { echo "no sessions in $PROJECT_DIR" >&2; exit 1; }
+    print_session "$f"
+    ;;
+  *)
+    print_session "$1"
+    ;;
+esac

--- a/evals/scripts/claude.sh
+++ b/evals/scripts/claude.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Resolve the harness location from this script's own path, so the parser, MCP
+# config and system prompt keep resolving even when the caller has cd'd into a
+# separate git checkout (the subject under test) as the working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Run as non-root user if currently root
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Running as root, switching to non-root user..."
+
+    # Create a non-root user if it doesn't exist
+    if ! id -u agent >/dev/null 2>&1; then
+        useradd -m -s /bin/bash agent
+    fi
+
+    # Give agent ownership of the current directory
+    chown -R agent:agent "$(pwd)"
+
+    # Switch to agent and re-run this script
+    exec su agent -c "$0 $*"
+fi
+
+# Set up Buildkite Hosted Models
+export ANTHROPIC_BASE_URL="$BUILDKITE_AGENT_ENDPOINT/ai/anthropic"
+export ANTHROPIC_API_KEY="$BUILDKITE_AGENT_ACCESS_TOKEN"
+
+# Configure GitHub authentication using gh CLI if GITHUB_TOKEN is available
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Configuring GitHub authentication with gh CLI..."
+    echo "$GITHUB_TOKEN" | gh auth login --with-token || {
+        echo "Warning: Failed to authenticate with gh CLI, falling back to git token authentication"
+    }
+
+    # Verify gh authentication and setup git integration
+    if gh auth status >/dev/null 2>&1; then
+        echo "Successfully authenticated with GitHub via gh CLI"
+        gh auth setup-git || {
+            echo "Warning: Failed to setup git integration with gh CLI"
+        }
+    else
+        echo "Warning: gh CLI authentication verification failed"
+    fi
+fi
+
+# Parse arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <prompt_file> [KEY=VALUE ...]"
+    echo
+    echo "Arguments:"
+    echo "  prompt_file    Path to the prompt markdown file"
+    echo "  KEY=VALUE      Optional key-value pairs for token replacement"
+    echo
+    echo "Example:"
+    echo "  $0 prompts/user.md BuildURL=https://example.com/build/123"
+    exit 1
+fi
+
+PROMPT_FILE="$1"
+shift
+
+# Verify prompt file exists
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "Error: Prompt file not found: $PROMPT_FILE"
+    exit 1
+fi
+
+# Load a system prompt to append
+SYSTEM_PROMPT=$(cat "$ROOT_DIR/prompts/system.md") || {
+    echo "Failed to read system.md file"
+    exit 1
+}
+
+# Read prompt content
+prompt_content=$(cat "$PROMPT_FILE") || {
+    echo "Failed to read prompt file: $PROMPT_FILE"
+    exit 1
+}
+
+echo "--- :scroll: Processing prompt: $PROMPT_FILE"
+
+# Split the remaining arguments: KEY=VALUE pairs substitute {{.KEY}} in the
+# prompt, while everything else (flags such as --output-format, --verbose,
+# --allowedTools, ...) is forwarded verbatim to the claude CLI.
+CLAUDE_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" =~ ^([A-Za-z0-9_]+)=(.*)$ ]]; then
+        key="${BASH_REMATCH[1]}"
+        value="${BASH_REMATCH[2]}"
+        echo "Replacing {{.$key}} with: $value"
+        prompt_content="${prompt_content//\{\{.$key\}\}/$value}"
+    else
+        CLAUDE_ARGS+=("$arg")
+    fi
+done
+
+echo "--- :robot_face: Starting Claude agent"
+
+# Tee the raw stream-json output so we can recover the session id after the run,
+# while still piping it through the parser for human-readable rendering.
+# NOTE: the parser requires --output-format=stream-json --verbose; the caller is
+# responsible for passing those (babystand.sh does).
+RAW_LOG="$(mktemp)"
+echo "$prompt_content" | claude \
+    --mcp-config "$ROOT_DIR/mcp_in_ci.json" \
+    --strict-mcp-config \
+    -p \
+    --permission-mode bypassPermissions \
+    --append-system-prompt "$SYSTEM_PROMPT" \
+    ${CLAUDE_ARGS[@]+"${CLAUDE_ARGS[@]}"} \
+    | tee "$RAW_LOG" \
+    | node "$ROOT_DIR/dist/parser" -
+
+# Emit machine-readable pointers to the Claude session transcript for the caller.
+# Resolved here (in the agent's user context) so $HOME matches where Claude wrote it.
+SESSION_ID=$(jq -r 'select(.type == "system" and .subtype == "init") | .session_id' "$RAW_LOG" | head -n1)
+TRANSCRIPT="$HOME/.claude/projects/$(pwd | sed -e 's/[\/.]/-/g')/$SESSION_ID.jsonl"
+echo "CLAUDE_SESSION_ID=$SESSION_ID"
+echo "CLAUDE_TRANSCRIPT=$TRANSCRIPT"
+
+# Extract the run's final assistant text (the stream-json "result" event) into a
+# file so the caller can surface just the final output (e.g. as an annotation).
+RESULT_FILE="$(mktemp)"
+jq -r 'select(.type == "result") | .result // empty' "$RAW_LOG" > "$RESULT_FILE" 2>/dev/null || true
+echo "CLAUDE_RESULT_FILE=$RESULT_FILE"

--- a/evals/scripts/parser.ts
+++ b/evals/scripts/parser.ts
@@ -1,0 +1,711 @@
+import { execSync } from "child_process";
+import { createInterface } from "readline";
+import { createReadStream } from "fs";
+import { writeFileSync } from "fs";
+
+// ANSI color codes
+const ColorReset = "\x1b[0m";
+const ColorBold = "\x1b[1m";
+const ColorDim = "\x1b[2m";
+const ColorRed = "\x1b[31m";
+const ColorGreen = "\x1b[32m";
+const ColorYellow = "\x1b[33m";
+const ColorBlue = "\x1b[34m";
+const ColorMagenta = "\x1b[35m";
+const ColorCyan = "\x1b[36m";
+const ColorWhite = "\x1b[37m";
+const ColorGray = "\x1b[90m";
+
+let staticLineNum = 0;
+let startTime: Date;
+
+// Message interfaces
+interface ContentItem {
+    type: string;
+    text?: string;
+    id?: string;
+    name?: string;
+    input?: any;
+    tool_use_id?: string;
+    content?: any;
+    is_error?: boolean;
+}
+
+interface Message {
+    type: string;
+    subtype?: string;
+    message?: {
+        id: string;
+        type: string;
+        role: string;
+        model?: string;
+        content: ContentItem[];
+        usage?: {
+            input_tokens: number;
+            output_tokens: number;
+        };
+    };
+    session_id?: string;
+    tools?: string[];
+    model?: string;
+}
+
+interface ChatEntry {
+    lineNumber: number;
+    speaker: string;
+    content: string;
+    timestamp: string;
+    isJSON: boolean;
+    rawLine: string;
+}
+
+// formatRelativeTime formats duration since start as MM:SS or HH:MM:SS
+function formatRelativeTime(elapsed: number): string {
+    const totalSeconds = Math.floor(elapsed / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+        return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+    }
+    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+// createBuildkiteAnnotation creates a Buildkite annotation by parsing the raw JSON line
+function createBuildkiteAnnotation(
+    rawJSONLine: string,
+    lineNumber: number,
+    timestamp: string,
+): void {
+    // Per-message annotations are on by default (chronological, collapsible view).
+    // Set ANNOTATE_MESSAGES=false to suppress them (e.g. rely only on the curated
+    // summary annotations created by babystand.sh).
+    if (process.env.ANNOTATE_MESSAGES === "false") {
+        return;
+    }
+
+    // Skip empty lines
+    rawJSONLine = rawJSONLine.trim();
+    if (rawJSONLine === "") {
+        return;
+    }
+
+    // Create markdown content for the annotation
+    let markdownContent = "";
+    let speaker = "";
+    let content = "";
+    let hasError = false;
+    let style = "info"; // default style
+
+    // Add timestamp and line number
+    markdownContent += `**Message ${lineNumber}** - \`${timestamp}\`\n\n`;
+
+    // Try to parse as JSON to extract clean content
+    if (rawJSONLine.startsWith("{")) {
+        try {
+            const msg: Message = JSON.parse(rawJSONLine);
+            // Extract clean content from JSON without ANSI codes and check for errors
+            const result = extractCleanJSONContentWithErrorCheck(msg);
+            speaker = result.speaker;
+            content = result.content;
+            hasError = result.hasError;
+
+            // Skip annotation for unknown message types
+            if (content === "Unknown message type") {
+                return;
+            }
+        } catch (err) {
+            // Not valid JSON, treat as plain text
+            speaker = "SYSTEM";
+            content = rawJSONLine;
+        }
+    } else {
+        // Plain text line
+        speaker = "SYSTEM";
+        content = rawJSONLine;
+    }
+
+    // Add the speaker label. NOTE: all per-message annotations use a single,
+    // uniform style (below) on purpose. Buildkite groups/orders annotations by
+    // style severity, so varying the style per speaker scatters messages into
+    // separate buckets and breaks the chronological (creation-order) reading the
+    // user wants. Keep the speaker distinction (and any error marker) in the
+    // body instead.
+    switch (speaker) {
+        case "ASSISTANT":
+            markdownContent += "🤖 **ASSISTANT**:\n\n";
+            break;
+        case "USER":
+            markdownContent += hasError ? "👤 **USER** ❌:\n\n" : "👤 **USER**:\n\n";
+            break;
+        case "SYSTEM":
+            markdownContent += "⚙️ **SYSTEM**:\n\n";
+            break;
+        default:
+            markdownContent += `**${speaker}**:\n\n`;
+    }
+
+    // Uniform style keeps every message in one chronological list.
+    style = "info";
+
+    // Add clean content (no ANSI codes)
+    if (content !== "") {
+        markdownContent += content;
+    }
+
+    // Add raw JSON disclosure at the end with pretty formatting
+    markdownContent += "\n\n<details>\n<summary>Show JSON</summary>\n\n```json\n";
+
+    // Pretty-format the JSON if possible
+    if (rawJSONLine.startsWith("{")) {
+        try {
+            const jsonObj = JSON.parse(rawJSONLine);
+            markdownContent += JSON.stringify(jsonObj, null, 2);
+        } catch (err) {
+            // Fallback to raw JSON if parsing fails
+            markdownContent += rawJSONLine;
+        }
+    } else {
+        // Not JSON, just show as-is
+        markdownContent += rawJSONLine;
+    }
+
+    markdownContent += "\n```\n\n</details>";
+
+    // Create a context unique across the whole build. Several parser processes
+    // run per build (eval, klaren, compare), each restarting lineNumber at 1,
+    // and Buildkite REPLACES an annotation whose context is reused — without a
+    // per-run component, later sessions overwrite the start of earlier ones.
+    // The caller names the run via ANNOTATION_CONTEXT_PREFIX; fall back to the
+    // pid so unlabelled runs still cannot collide.
+    const runId = process.env.ANNOTATION_CONTEXT_PREFIX || `pid${process.pid}`;
+    const context = `chat-message-${runId}-${lineNumber}`;
+
+    // Execute buildkite-agent annotate command
+    try {
+        execSync(
+            "buildkite-agent annotate --style " + style + " --context " + context + " --priority 5",
+            {
+                input: markdownContent,
+                stdio: ["pipe", "inherit", "inherit"],
+            },
+        );
+    } catch (err) {
+        console.warn(`Warning: Failed to create Buildkite annotation: ${err}`);
+    }
+}
+
+// extractCleanJSONContentWithErrorCheck extracts clean content from JSON message without ANSI codes and detects errors
+function extractCleanJSONContentWithErrorCheck(msg: Message): {
+    speaker: string;
+    content: string;
+    hasError: boolean;
+} {
+    switch (msg.type) {
+        case "system":
+            if (msg.subtype === "init") {
+                return {
+                    speaker: "SYSTEM",
+                    content: `Session initialized (ID: ${msg.session_id}, Model: ${msg.model})`,
+                    hasError: false,
+                };
+            }
+            return { speaker: "SYSTEM", content: "System message", hasError: false };
+
+        case "assistant": {
+            const speaker = "ASSISTANT";
+            let content = "";
+            if (msg.message && msg.message.content.length > 0) {
+                const contentParts: string[] = [];
+                for (const contentItem of msg.message.content) {
+                    switch (contentItem.type) {
+                        case "text":
+                            if (contentItem.text) {
+                                contentParts.push(contentItem.text);
+                            }
+                            break;
+                        case "tool_use": {
+                            let toolInput = "";
+                            if (contentItem.input) {
+                                toolInput = JSON.stringify(contentItem.input, null, 2);
+                            }
+
+                            let toolDesc = `🔧 Using tool: ${contentItem.name}`;
+                            if (toolInput && toolInput !== "{}") {
+                                // Check if content needs progressive disclosure (multiple lines OR very long)
+                                const lines = toolInput.split("\n");
+                                const maxPreviewLength = 300;
+
+                                const needsDisclosure =
+                                    lines.length > 2 || toolInput.length > maxPreviewLength;
+
+                                if (!needsDisclosure) {
+                                    // Short input, show it all
+                                    toolDesc += ` with ${toolInput}`;
+                                } else {
+                                    // Long input, show preview and put rest in disclosure
+                                    let preview: string;
+                                    let remaining: string;
+
+                                    if (lines.length > 2) {
+                                        // Multiple lines: show first 2 lines
+                                        preview = lines.slice(0, 2).join("\n");
+                                        remaining = lines.slice(2).join("\n");
+                                    } else {
+                                        // Single long line: truncate at reasonable length
+                                        if (toolInput.length > maxPreviewLength) {
+                                            preview = toolInput.slice(0, maxPreviewLength) + "...";
+                                            remaining = toolInput.slice(maxPreviewLength);
+                                        } else {
+                                            preview = toolInput;
+                                            remaining = "";
+                                        }
+                                    }
+
+                                    if (remaining !== "") {
+                                        // Use HTML details/summary for collapsible content
+                                        toolDesc += ` with ${preview}\n\n<details>\n<summary>Show more input...</summary>\n\n\`\`\`json\n${remaining}\n\`\`\`\n\n</details>`;
+                                    } else {
+                                        toolDesc += ` with ${preview}`;
+                                    }
+                                }
+                            }
+                            contentParts.push(toolDesc);
+                            break;
+                        }
+                    }
+                }
+                content = contentParts.join("\n\n");
+            }
+            return { speaker, content, hasError: false };
+        }
+
+        case "user": {
+            const speaker = "USER";
+            let hasError = false;
+            let content = "";
+            if (msg.message && msg.message.content.length > 0) {
+                const contentParts: string[] = [];
+                for (const contentItem of msg.message.content) {
+                    if (contentItem.type === "tool_result") {
+                        // Check for errors in tool results
+                        if (contentItem.is_error) {
+                            hasError = true;
+                        }
+
+                        // Extract and display the actual tool result content
+                        let resultContent = "";
+                        if (contentItem.text) {
+                            resultContent = contentItem.text;
+                            // Try to pretty-format if it's JSON
+                            try {
+                                const jsonObj = JSON.parse(resultContent);
+                                resultContent = JSON.stringify(jsonObj, null, 2);
+                            } catch (err) {
+                                // Not JSON, keep as-is
+                            }
+                        } else if (contentItem.content) {
+                            // Try to extract content from the Content field
+                            resultContent = JSON.stringify(contentItem.content, null, 2);
+                        }
+
+                        if (resultContent !== "") {
+                            const errorIndicator = contentItem.is_error
+                                ? "❌ Tool error:"
+                                : "✅ Tool result:";
+
+                            // Check if content needs progressive disclosure (multiple lines OR very long)
+                            const lines = resultContent.split("\n");
+                            const maxPreviewLength = 400;
+
+                            const needsDisclosure =
+                                lines.length > 2 || resultContent.length > maxPreviewLength;
+
+                            if (!needsDisclosure) {
+                                // Short content, show it all
+                                contentParts.push(errorIndicator + "\n" + resultContent);
+                            } else {
+                                // Long content, show preview and put rest in disclosure
+                                let preview: string;
+                                let remaining: string;
+
+                                if (lines.length > 2) {
+                                    // Multiple lines: show first 2 lines
+                                    preview = lines.slice(0, 2).join("\n");
+                                    remaining = lines.slice(2).join("\n");
+                                } else {
+                                    // Single long line: truncate at reasonable length
+                                    if (resultContent.length > maxPreviewLength) {
+                                        preview = resultContent.slice(0, maxPreviewLength) + "...";
+                                        remaining = resultContent.slice(maxPreviewLength);
+                                    } else {
+                                        preview = resultContent;
+                                        remaining = "";
+                                    }
+                                }
+
+                                if (remaining !== "") {
+                                    // Use HTML details/summary for collapsible content
+                                    const disclosureContent = `${errorIndicator}\n${preview}\n\n<details>\n<summary>Show more...</summary>\n\n\`\`\`\n${remaining}\n\`\`\`\n\n</details>`;
+                                    contentParts.push(disclosureContent);
+                                } else {
+                                    contentParts.push(errorIndicator + "\n" + preview);
+                                }
+                            }
+                        } else {
+                            contentParts.push("✅ Tool result received");
+                        }
+                    } else if (contentItem.text) {
+                        contentParts.push(contentItem.text);
+                    }
+                }
+                content = contentParts.join("\n\n");
+            }
+            return { speaker, content, hasError };
+        }
+
+        default:
+            return {
+                speaker: msg.type.toUpperCase(),
+                content: "Unknown message type",
+                hasError: false,
+            };
+    }
+}
+
+function formatJSONMessage(msg: Message): { speaker: string; content: string } {
+    switch (msg.type) {
+        case "system":
+            if (msg.subtype === "init") {
+                return {
+                    speaker: "SYSTEM",
+                    content: `Session initialized (ID: ${msg.session_id}, Model: ${msg.model})`,
+                };
+            }
+            return { speaker: "SYSTEM", content: "System message" };
+
+        case "assistant": {
+            let speaker = "ASSISTANT";
+            let content = "";
+            if (msg.message && msg.message.content.length > 0) {
+                const contentParts: string[] = [];
+                for (const contentItem of msg.message.content) {
+                    switch (contentItem.type) {
+                        case "text":
+                            if (contentItem.text) {
+                                contentParts.push(contentItem.text);
+                            }
+                            break;
+                        case "tool_use": {
+                            let toolInput = "";
+                            if (contentItem.input) {
+                                toolInput = JSON.stringify(contentItem.input);
+                            }
+                            const withClause =
+                                toolInput && toolInput !== "{}" ? " with " + toolInput : "";
+                            contentParts.push(
+                                `${ColorGreen}🔧 Using tool: ${contentItem.name}${withClause}${ColorReset}`,
+                            );
+                            break;
+                        }
+                    }
+                }
+                content = contentParts.join("\n");
+            }
+            return { speaker, content };
+        }
+
+        case "user": {
+            let speaker = "USER";
+            let content = "";
+            if (msg.message && msg.message.content.length > 0) {
+                const contentParts: string[] = [];
+                for (const contentItem of msg.message.content) {
+                    if (contentItem.type === "tool_result") {
+                        // Extract and display the actual tool result content
+                        let resultContent = "";
+                        if (contentItem.text) {
+                            resultContent = contentItem.text;
+                            // Try to pretty-format if it's JSON
+                            try {
+                                const jsonObj = JSON.parse(resultContent);
+                                resultContent = JSON.stringify(jsonObj, null, 2);
+                            } catch (err) {
+                                // Not JSON, keep as-is
+                            }
+                        } else if (contentItem.content) {
+                            // Try to extract content from the Content field
+                            resultContent = JSON.stringify(contentItem.content, null, 2);
+                        }
+
+                        if (resultContent !== "") {
+                            const errorIndicator = contentItem.is_error
+                                ? ColorRed + "❌ Tool error:" + ColorReset
+                                : ColorMagenta + "✅ Tool result:" + ColorReset;
+                            contentParts.push(errorIndicator + "\n" + resultContent);
+                        } else {
+                            contentParts.push(
+                                ColorMagenta + "✅ Tool result received" + ColorReset,
+                            );
+                        }
+                    } else if (contentItem.text) {
+                        contentParts.push(contentItem.text);
+                    }
+                }
+                content = contentParts.join("\n");
+            }
+            return { speaker, content };
+        }
+
+        default:
+            return {
+                speaker: msg.type.toUpperCase(),
+                content: "Unknown message type",
+            };
+    }
+}
+
+function parseLine(line: string): ChatEntry | null {
+    line = line.trim();
+    if (line === "") {
+        return null;
+    }
+
+    // Use a static line counter since the file doesn't have line numbers
+    staticLineNum++;
+
+    const entry: ChatEntry = {
+        lineNumber: staticLineNum,
+        rawLine: line,
+        timestamp: formatRelativeTime(Date.now() - startTime.getTime()),
+        speaker: "",
+        content: "",
+        isJSON: false,
+    };
+
+    const content = line;
+
+    // Try to parse as JSON
+    if (content.startsWith("{")) {
+        try {
+            const msg: Message = JSON.parse(content);
+            entry.isJSON = true;
+            const result = formatJSONMessage(msg);
+            entry.speaker = result.speaker;
+            entry.content = result.content;
+        } catch (err) {
+            // Not valid JSON, treat as plain text
+            entry.speaker = "SYSTEM";
+            entry.content = content;
+        }
+    } else {
+        // Plain text line
+        entry.speaker = "SYSTEM";
+        entry.content = content;
+    }
+
+    return entry;
+}
+
+// printSingleEntry prints a single chat entry immediately (for streaming mode)
+function printSingleEntry(entry: ChatEntry): void {
+    if (entry.content === "") {
+        return;
+    }
+
+    // Choose color based on speaker
+    let speakerColor: string;
+    let contentColor: string;
+    switch (entry.speaker) {
+        case "ASSISTANT":
+            speakerColor = ColorGreen + ColorBold;
+            contentColor = ColorGreen;
+            break;
+        case "USER":
+            speakerColor = ColorBlue + ColorBold;
+            contentColor = ColorBlue;
+            break;
+        case "SYSTEM":
+            speakerColor = ColorYellow + ColorBold;
+            contentColor = ColorGray;
+            break;
+        default:
+            speakerColor = ColorWhite;
+            contentColor = ColorWhite;
+    }
+
+    // Format: [LINE:123] [MM:SS] SPEAKER: content
+    const prefix = `${ColorGray}[${String(entry.lineNumber).padStart(3, "0")}] ${ColorDim}[${entry.timestamp}]${ColorReset} ${speakerColor}${entry.speaker}:${ColorReset}`;
+
+    // Handle multi-line content
+    const lines = entry.content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        if (i === 0) {
+            console.log(`${prefix.padEnd(45)} ${contentColor}${lines[i]}${ColorReset}`);
+        } else {
+            console.log(`${contentColor}${lines[i]}${ColorReset}`);
+        }
+    }
+
+    // Add spacing between messages for readability
+    if (entry.isJSON) {
+        console.log();
+    }
+}
+
+function parseAndStreamOutput(rl: ReturnType<typeof createInterface>): Promise<void> {
+    return new Promise((resolve, reject) => {
+        rl.on("line", (line: string) => {
+            const entry = parseLine(line);
+            if (entry) {
+                printSingleEntry(entry);
+                createBuildkiteAnnotation(line, entry.lineNumber, entry.timestamp);
+            }
+        });
+
+        rl.on("close", () => {
+            resolve();
+        });
+
+        rl.on("error", err => {
+            reject(err);
+        });
+    });
+}
+
+function parseAndStreamOutputWithFile(
+    rl: ReturnType<typeof createInterface>,
+    outputFilename: string,
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const lines: string[] = [];
+
+        rl.on("line", (line: string) => {
+            // Store raw JSON line to file later
+            lines.push(line);
+
+            // Parse and display the line
+            const entry = parseLine(line);
+            if (entry) {
+                // Print to stdout with colors
+                printSingleEntry(entry);
+                // Create Buildkite annotation
+                createBuildkiteAnnotation(line, entry.lineNumber, entry.timestamp);
+            }
+        });
+
+        rl.on("close", () => {
+            // Write all lines to file
+            try {
+                writeFileSync(outputFilename, lines.join("\n") + "\n");
+                resolve();
+            } catch (err) {
+                reject(err);
+            }
+        });
+
+        rl.on("error", err => {
+            reject(err);
+        });
+    });
+}
+
+function printUsage(): void {
+    console.log("Usage: chat-parser <input-file>");
+    console.log("       cat <input-file> | chat-parser -");
+    console.log("       cat <input-file> | chat-parser - -o <output-file>");
+    console.log("");
+    console.log("Options:");
+    console.log("  -o <file>    Save output to file (only when streaming from stdin)");
+}
+
+async function main(): Promise<void> {
+    // Initialize start time for relative timestamps
+    startTime = new Date();
+
+    let outputFile = "";
+    let inputSource = "";
+
+    // Parse command line arguments
+    const args = process.argv.slice(2);
+    if (args.length === 0) {
+        printUsage();
+        process.exit(1);
+    }
+
+    for (let i = 0; i < args.length; i++) {
+        switch (args[i]) {
+            case "-o":
+                if (i + 1 >= args.length) {
+                    console.log("Error: -o requires a filename");
+                    printUsage();
+                    process.exit(1);
+                }
+                outputFile = args[i + 1];
+                i++; // Skip the next argument as it's the filename
+                break;
+            case "-":
+                inputSource = "-";
+                break;
+            default:
+                if (inputSource === "") {
+                    inputSource = args[i];
+                } else {
+                    console.log(`Error: unexpected argument '${args[i]}'`);
+                    printUsage();
+                    process.exit(1);
+                }
+        }
+    }
+
+    if (inputSource === "") {
+        printUsage();
+        process.exit(1);
+    }
+
+    let rl: ReturnType<typeof createInterface>;
+    let isStreaming = false;
+
+    if (inputSource === "-") {
+        // Read from stdin
+        rl = createInterface({
+            input: process.stdin,
+            crlfDelay: Infinity,
+        });
+        isStreaming = true;
+    } else {
+        // Read from file
+        rl = createInterface({
+            input: createReadStream(inputSource),
+            crlfDelay: Infinity,
+        });
+    }
+
+    // Validate -o option usage
+    if (outputFile !== "" && !isStreaming) {
+        console.log("Error: -o option can only be used when streaming from stdin");
+        process.exit(1);
+    }
+
+    // Print colorful header and process input line by line
+    console.log(`${ColorCyan}${ColorBold}=== Claude Code Chat Transcript ===${ColorReset}`);
+    console.log();
+
+    try {
+        if (outputFile !== "") {
+            await parseAndStreamOutputWithFile(rl, outputFile);
+        } else {
+            await parseAndStreamOutput(rl);
+        }
+    } catch (err) {
+        console.error(`Error: ${err}`);
+        process.exit(1);
+    }
+}
+
+// Run the main function
+main().catch(error => {
+    console.error("Error:", error.message);
+    process.exit(1);
+});

--- a/evals/tsconfig.json
+++ b/evals/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "outDir": "./dist",
+        "module": "nodenext",
+        "target": "esnext",
+        "declaration": true,
+        "declarationMap": true,
+        "strict": true,
+        "isolatedModules": true,
+        "noUncheckedSideEffectImports": true,
+        "moduleDetection": "force",
+        "skipLibCheck": true
+    }
+}


### PR DESCRIPTION
This is in the README.md

**What is this?**

Under certain conditions, e.g., branch being pushed/created in repo, PR created, etc., this pipeline will run, kicking-off a specified LLM agent backed by a specified model to exercise a specified buildkite-mcp-server against preset scenarios to evaluate the performance of the buildkite-mcp-server.

**What is the output?**

A set of artifacts, and annotations in the Buildkite build showing:
* LLM agent metrics
  * Tool calls, input/output tokens, input/output cache tokens, etc.
* Quantitative evaluation report
  * List of things order by criticality that the LLM agent could have done better, due to harness loop, tool call choices, etc.
* Comparison reports
  * LLM agent metrics
  * High-level steps taken by LLM agent to complete scenarios

**This branch**

All new code are mostly in `evals/` folder

* Add pipeline (.buildkite/pipeline.evals.yml) which run evals
* In 'evals/prompts/' folder:
  * klaren.md
    * Review LLM agent session log and complain loudly about what could've been better
* In 'evals/scripts/' folder:
  * babystand.sh
    * This script actually can be run locally as well for testing/debugging
      * `LOCAL_CI`: If false, then prompt specifically instructs LLM agent not to cheat by running local CI to uncover issues, but instead wait for CI to be red before attempting to turn it green
      * `DEBUG_PERMISSIONS`: If true, then prompt specifically instructs LLM agent to fail instead of trying to bypass. This is useful when you're trying to setup the env to run scenarios.
    * Setup various scenarios 
    * Calls LLM agent with prompts to evaluate scenarios
    * Calls klaren.md prompt to review LLM agent performance
  * bk-compare-eval.sh
    * Compare current eval result with previous 
  * bk-tool-audit-v2.sh
    * Retrieve stats about tool calls, read/write token/cache usage from LLM session logs
  * parser.ts
    * Parse LLM agent assistant/user convo into bk annotation
  * Dockerfile
    * Given an buildkite mcp version, build that buildkite mcp version into a docker image (not implemented yet, currently it just builds the buildkite mcp based on current code
  * mcp_in_ci.json
    * The mcp config used when `babystand.sh` is running in ci
  * mcp.json
    * The mcp config used when `babystand.sh` is running locally
  * package.json/package-lock.json
    * npm packages required
  * tsconfig.json
    * Typescript config

**On buildkite.com**

* Pipeline is set at - https://buildkite.com/buildkite/buildkite-mcp-server-evals-framework
  * This pipeline is set to:
    * Upload .buildkite/pipeline.evals.yml
    * Use buildkite-mcp-evals cluster (https://buildkite.com/organizations/buildkite/clusters/1295e59e-8fa9-4525-b873-f3a0ce2efe45/queues)
    * Secrets for
      * Github to access scenarios (read/write) in external repo
      * Buildkite for bk org to retrieve the last successful build (read) to compare
      * Buildkite for anothertest org where the external repo scenario pipelines (read) are (to monitor scenarios from red-to-green)