### PR TITLE
chore(api): cap potential fanout for failure summary

### DIFF
--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -33,7 +33,7 @@ var (
 		BaseURL               string            `help:"The base URL of the Buildkite API to use." env:"BUILDKITE_BASE_URL" default:"https://api.buildkite.com/"`
 		CacheURL              string            `help:"The blob storage URL for job logs cache." env:"BKLOG_CACHE_URL"`
 		MaxLogBytes           int64             `help:"Maximum log size in bytes. Set to 0 to disable the limit." env:"BKLOG_MAX_LOG_BYTES" default:"104857600"`
-		FailureSummaryMaxJobs int               `help:"Maximum number of problem jobs diagnosed by one failure summary request." name:"failure-summary-max-jobs" env:"BUILDKITE_FAILURE_SUMMARY_MAX_JOBS" default:"10"`
+		FailureSummaryMaxJobs int               `help:"Maximum number of problem jobs diagnosed by one failure summary request (default 10, hard max 50; the server may enforce a lower maximum)." name:"failure-summary-max-jobs" env:"BUILDKITE_FAILURE_SUMMARY_MAX_JOBS" default:"10"`
 		MaxLogLineBytes       int               `help:"Maximum log line length in bytes to parse." env:"BKLOG_MAX_LOG_LINE_BYTES" default:"1048576"`
 		Debug                 bool              `help:"Enable debug mode." env:"DEBUG"`
 		OTELExporter          string            `help:"OpenTelemetry exporter to enable. Options are 'http/protobuf', 'grpc', or 'noop'." enum:"http/protobuf, grpc, noop" env:"OTEL_EXPORTER_OTLP_PROTOCOL" default:"noop"`

--- a/cmd/buildkite-mcp-server/main.go
+++ b/cmd/buildkite-mcp-server/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildkite/buildkite-logs/logparser"
 	"github.com/buildkite/buildkite-mcp-server/internal/commands"
 	"github.com/buildkite/buildkite-mcp-server/internal/headerpassthrough"
+	mcpbuildkite "github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
 	"github.com/buildkite/buildkite-mcp-server/pkg/recording"
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	gobuildkite "github.com/buildkite/go-buildkite/v5"
@@ -32,6 +33,7 @@ var (
 		BaseURL               string            `help:"The base URL of the Buildkite API to use." env:"BUILDKITE_BASE_URL" default:"https://api.buildkite.com/"`
 		CacheURL              string            `help:"The blob storage URL for job logs cache." env:"BKLOG_CACHE_URL"`
 		MaxLogBytes           int64             `help:"Maximum log size in bytes. Set to 0 to disable the limit." env:"BKLOG_MAX_LOG_BYTES" default:"104857600"`
+		FailureSummaryMaxJobs int               `help:"Maximum number of problem jobs diagnosed by one failure summary request." name:"failure-summary-max-jobs" env:"BUILDKITE_FAILURE_SUMMARY_MAX_JOBS" default:"10"`
 		MaxLogLineBytes       int               `help:"Maximum log line length in bytes to parse." env:"BKLOG_MAX_LOG_LINE_BYTES" default:"1048576"`
 		Debug                 bool              `help:"Enable debug mode." env:"DEBUG"`
 		OTELExporter          string            `help:"OpenTelemetry exporter to enable. Options are 'http/protobuf', 'grpc', or 'noop'." enum:"http/protobuf, grpc, noop" env:"OTEL_EXPORTER_OTLP_PROTOCOL" default:"noop"`
@@ -139,7 +141,10 @@ func run(ctx context.Context, cmd *kong.Context) error {
 		Client:              client,
 		HTTPClient:          httpClient,
 		BuildkiteLogsClient: buildkiteLogsClient,
-		HeaderPassthrough:   passthrough,
+		FailureSummary: mcpbuildkite.FailureSummaryConfig{
+			MaxJobs: cli.FailureSummaryMaxJobs,
+		},
+		HeaderPassthrough: passthrough,
 	})
 }
 

--- a/internal/commands/command.go
+++ b/internal/commands/command.go
@@ -17,6 +17,7 @@ type Globals struct {
 	Client              *gobuildkite.Client
 	HTTPClient          *http.Client
 	BuildkiteLogsClient buildkite.BuildkiteLogsClient
+	FailureSummary      buildkite.FailureSummaryConfig
 	HeaderPassthrough   *headerpassthrough.Config
 	Version             string
 }

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -44,6 +44,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 		TestExecutionsClient:    globals.Client.TestRuns,
 		TestsClient:             globals.Client.Tests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,
+		FailureSummary:          globals.FailureSummary,
 	}
 
 	factory := server.NewPerRequestServerFactory(globals.Version, deps, c.EnabledToolsets, c.ReadOnly)

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -37,6 +37,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 		TestExecutionsClient:    globals.Client.TestRuns,
 		TestsClient:             globals.Client.Tests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,
+		FailureSummary:          globals.FailureSummary,
 	}
 
 	log.Info().Msg("Starting MCP server over stdio")

--- a/pkg/buildkite/dependencies.go
+++ b/pkg/buildkite/dependencies.go
@@ -6,6 +6,11 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// FailureSummaryConfig controls server-side resource limits for failure summaries.
+type FailureSummaryConfig struct {
+	MaxJobs int
+}
+
 // ToolDependencies holds all client interfaces needed by tool handlers.
 type ToolDependencies struct {
 	BuildsClient            BuildsClient
@@ -24,6 +29,7 @@ type ToolDependencies struct {
 	TestExecutionsClient    TestExecutionsClient
 	TestsClient             TestsClient
 	BuildkiteLogsClient     BuildkiteLogsClient
+	FailureSummary          FailureSummaryConfig
 }
 
 type contextKey struct{}

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -46,7 +46,7 @@ type GetBuildFailureSummaryArgs struct {
 	PipelineSlug           string `json:"pipeline_slug"`
 	BuildNumber            string `json:"build_number"`
 	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
-	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, max 50)"`
+	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, server may enforce a lower maximum, absolute max 50)"`
 	MaxAnnotations         int    `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
 	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to inspect (default 5, max 20)"`
 	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed test executions to return across all Test Engine runs (default 100, max 200)"`
@@ -106,6 +106,7 @@ type FailureSummaryTestRun struct {
 type BuildFailureSummary struct {
 	Build                BuildFailureSummaryBuild   `json:"build"`
 	Jobs                 []FailureSummaryJob        `json:"jobs"`
+	JobLimit             int                        `json:"job_limit"`
 	JobsTruncated        bool                       `json:"jobs_truncated,omitempty"`
 	Annotations          []FailureSummaryAnnotation `json:"annotations,omitempty"`
 	AnnotationsTruncated bool                       `json:"annotations_truncated,omitempty"`
@@ -127,6 +128,14 @@ func boundedValue(value, defaultValue, maxValue int) int {
 		return defaultValue
 	}
 	return min(value, maxValue)
+}
+
+func boundedFailureSummaryJobs(value, configuredMax int) int {
+	if configuredMax <= 0 {
+		configuredMax = defaultFailureSummaryJobs
+	}
+	configuredMax = min(configuredMax, maxFailureSummaryJobs)
+	return boundedValue(value, min(defaultFailureSummaryJobs, configuredMax), configuredMax)
 }
 
 func failureSummaryBuild(build buildkite.Build) BuildFailureSummaryBuild {
@@ -716,8 +725,9 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
 			defer span.End()
 
+			deps := DepsFromContext(ctx)
 			logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
-			maxJobs := boundedValue(args.MaxJobs, defaultFailureSummaryJobs, maxFailureSummaryJobs)
+			maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
 			maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
 			maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
 			maxFailedTestsPerRun := boundedValue(args.MaxFailedTestsPerRun, defaultFailureSummaryTestsPerRun, maxFailureSummaryTestsPerRun)
@@ -736,7 +746,6 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
 			)
 
-			deps := DepsFromContext(ctx)
 			build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
 				BuildsListOptions: buildkite.BuildsListOptions{
 					ExcludeJobs:     true,
@@ -748,7 +757,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				return handleBuildkiteError(err)
 			}
 
-			result := BuildFailureSummary{Build: failureSummaryBuild(build)}
+			result := BuildFailureSummary{Build: failureSummaryBuild(build), JobLimit: maxJobs}
 
 			includeRetriedJobs := false
 			primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
@@ -777,44 +786,48 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 
 			remainingJobs := maxJobs - len(sourceJobs)
-			canceledJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"canceled"},
-				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            remainingJobs + 1,
-			})
-			if err != nil {
-				return handleBuildkiteError(err)
-			}
-			jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
-			for _, job := range canceledJobsList.Items {
-				if !isCanceledFailureSummaryJob(job) {
-					continue
+			if remainingJobs > 0 || !jobsTruncated {
+				canceledJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+					State:              []string{"canceled"},
+					IncludeRetriedJobs: &includeRetriedJobs,
+					PerPage:            remainingJobs + 1,
+				})
+				if listErr != nil {
+					return handleBuildkiteError(listErr)
 				}
-				if len(sourceJobs) < maxJobs {
-					sourceJobs = append(sourceJobs, job)
-				} else {
-					jobsTruncated = true
+				jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
+				for _, job := range canceledJobsList.Items {
+					if !isCanceledFailureSummaryJob(job) {
+						continue
+					}
+					if len(sourceJobs) < maxJobs {
+						sourceJobs = append(sourceJobs, job)
+					} else {
+						jobsTruncated = true
+					}
 				}
 			}
 
 			remainingJobs = maxJobs - len(sourceJobs)
-			downstreamJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
-				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            remainingJobs + 1,
-			})
-			if err != nil {
-				return handleBuildkiteError(err)
-			}
-			jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
-			for _, job := range downstreamJobsList.Items {
-				if !isDownstreamFailureSummaryJob(job) {
-					continue
+			if remainingJobs > 0 || !jobsTruncated {
+				downstreamJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+					State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
+					IncludeRetriedJobs: &includeRetriedJobs,
+					PerPage:            remainingJobs + 1,
+				})
+				if listErr != nil {
+					return handleBuildkiteError(listErr)
 				}
-				if len(sourceJobs) < maxJobs {
-					sourceJobs = append(sourceJobs, job)
-				} else {
-					jobsTruncated = true
+				jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
+				for _, job := range downstreamJobsList.Items {
+					if !isDownstreamFailureSummaryJob(job) {
+						continue
+					}
+					if len(sourceJobs) < maxJobs {
+						sourceJobs = append(sourceJobs, job)
+					} else {
+						jobsTruncated = true
+					}
 				}
 			}
 			result.Jobs = make([]FailureSummaryJob, len(sourceJobs))

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -264,6 +264,64 @@ func TestGetBuildFailureSummaryPrioritizesFailuresAndCanceledJobsBeforeDownstrea
 	require.True(t, summary.JobsTruncated)
 }
 
+func TestGetBuildFailureSummaryEnforcesServerJobLimit(t *testing.T) {
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{Number: 1, State: "failed"}, &buildkite.Response{}, nil
+		},
+	}
+
+	jobs := make([]buildkite.Job, 6)
+	for i := range jobs {
+		jobs[i] = buildkite.Job{ID: fmt.Sprintf("job-%d", i+1), State: "failed"}
+	}
+	jobListCalls := 0
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			jobListCalls++
+			require.Equal(t, []string{"failed", "timed_out", "expired"}, options.State)
+			require.Equal(t, 6, options.PerPage)
+			return buildkite.JobsList{Items: jobs}, &buildkite.Response{}, nil
+		},
+	}
+
+	var logCallsMu sync.Mutex
+	logCalls := 0
+	logsClient := &MockBuildkiteLogsClient{
+		NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+			logCallsMu.Lock()
+			logCalls++
+			logCallsMu.Unlock()
+			return nil, errors.New("log unavailable")
+		},
+	}
+
+	include := false
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:        buildsClient,
+		JobsClient:          jobsClient,
+		BuildkiteLogsClient: logsClient,
+		FailureSummary:      FailureSummaryConfig{MaxJobs: 5},
+	})
+
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 50,
+		IncludeAnnotations: &include, IncludeFailedTests: &include,
+	})
+	require.NoError(t, err)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Equal(t, 5, summary.JobLimit)
+	require.Len(t, summary.Jobs, 5)
+	require.True(t, summary.JobsTruncated)
+	require.Equal(t, 1, jobListCalls)
+	logCallsMu.Lock()
+	require.Equal(t, 5, logCalls)
+	logCallsMu.Unlock()
+}
+
 func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
 	logPath := t.TempDir() + "/timed-out.parquet"
 	writeTestParquetFile(t, logPath, []string{"running", "job timed out"})
@@ -926,6 +984,21 @@ func TestApplyFailureSummaryContentLimitsPreservesWarnings(t *testing.T) {
 	require.Equal(t, "annotations unavailable after partial scan: request failed", result.Warnings[0])
 	require.True(t, result.ContentTruncated)
 	require.True(t, result.Annotations[len(result.Annotations)-1].BodyTruncated)
+}
+
+func TestFailureSummaryAnnotationsBoundsLargeBodies(t *testing.T) {
+	body := strings.Repeat("annotation line\n", 100_000)
+
+	annotations, truncated := failureSummaryAnnotations([]buildkite.Annotation{{
+		Style:    "error",
+		BodyHTML: body,
+	}}, 1)
+
+	require.False(t, truncated)
+	require.Len(t, annotations, 1)
+	require.LessOrEqual(t, len(annotations[0].BodyHTML), failureSummaryEntryContentByteLimit)
+	require.True(t, annotations[0].BodyTruncated)
+	require.NotEqual(t, body, annotations[0].BodyHTML)
 }
 
 func TestLoadFailureAnnotationsStopsAtScanLimit(t *testing.T) {


### PR DESCRIPTION
## Description

Adds in some safety for potential fanout of `get_build_failure_summary` where builds with > 10 failing jobs, for example, could see significant fanout.

## Changes

- implements a default of `10` for job logs to get, which is adjustable
    - adds a maximum of `50` which cannot be overridden
- supports a `--flag` and `ENVIRONMENT_VARIABLE` for setting the value of `max_jobs`
- added an explicit regression coverage showing a 100,000-line annotation is truncated to the existing 4 KiB per-annotation limit before being returned
- added instructions on increasing the job count

## Caveats

This is likely going to be adjusted as we get feedback on its implementation, for now `10` feels like a safe default, with `50` max feeling like it enables the user to explore larger builds.
