### PR TITLE
chore(deps): bump the sdk version to 1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27
-	github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/rs/zerolog v1.35.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3 h1:SEAY9IduDif4iApnZgpFkjFIdo3askSGZVbZIYyTy6I=
-github.com/modelcontextprotocol/go-sdk v1.7.0-pre.3/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/nikolaydubina/go-cover-treemap v1.5.1 h1:BGlCMkj78RlodldP4QFDyY6jhBQSJzbxGmOzrfMaEQg=
 github.com/nikolaydubina/go-cover-treemap v1.5.1/go.mod h1:EoFAQvIpPVfiqL8cNjcVTiREtlBkJmATrZM2p/erRAw=
 github.com/nikolaydubina/treemap v1.2.5 h1:oSC5z/qnsGLbkU2IihSrh2pS7uDjUq7ipGj8aw8bfII=

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -138,6 +138,11 @@ func NewMCPServer(version string, deps buildkite.ToolDependencies, opts ...Tools
 		Version: version,
 	}, &mcp.ServerOptions{
 		Instructions: BuildkiteServerInstructions(cfg.EnabledToolsets, cfg.ReadOnly),
+		// A non-nil empty Capabilities stops the SDK from advertising the
+		// deprecated (as of MCP 2026-07-28) logging capability by default.
+		// Tool, prompt, and resource capabilities are still inferred as they
+		// are registered.
+		Capabilities: &mcp.ServerCapabilities{},
 	})
 
 	log.Info().Str("version", version).Msg("Starting Buildkite MCP server")


### PR DESCRIPTION
## Description

Bumps the `go-sdk` version to `v1.7.0` and add fix for `Capabilities` with new spec.
