### PR TITLE
Middleware adjustments for v1.7.0

### DIFF
--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -2,9 +2,7 @@ package trace
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rs/zerolog"
@@ -75,45 +73,20 @@ func NewMiddleware() mcp.Middleware {
 	}
 }
 
+// clientInfoRequest matches the SDK's typed ServerRequest.ClientInfo
+// accessor, which is defined for every ServerRequest[P] instantiation but not
+// exposed on the generic mcp.Request interface.
+type clientInfoRequest interface {
+	ClientInfo() *mcp.Implementation
+}
+
 // clientInfo returns the client identity for a request. Clients speaking
 // protocol >= 2026-07-28 carry it in each request's _meta (there is no
 // initialize handshake); older clients fall back to the session-level
-// InitializeParams. This mirrors the SDK's typed ServerRequest.ClientInfo
-// accessor, which is not reachable from generic middleware.
+// InitializeParams. The SDK accessor handles both, plus nil params.
 func clientInfo(req mcp.Request) *mcp.Implementation {
-	if m := requestMeta(req); m != nil {
-		if raw, ok := m[mcp.MetaKeyClientInfo]; ok && raw != nil {
-			if impl, ok := raw.(*mcp.Implementation); ok {
-				return impl
-			}
-			// After wire transit the value is a generic JSON map; remarshal
-			// it into the typed form.
-			if b, err := json.Marshal(raw); err == nil {
-				var impl mcp.Implementation
-				if json.Unmarshal(b, &impl) == nil {
-					return &impl
-				}
-			}
-		}
-	}
-	if ss, ok := req.GetSession().(*mcp.ServerSession); ok {
-		if ip := ss.InitializeParams(); ip != nil {
-			return ip.ClientInfo
-		}
+	if r, ok := req.(clientInfoRequest); ok {
+		return r.ClientInfo()
 	}
 	return nil
-}
-
-// requestMeta returns the request params' _meta map, or nil. Params
-// implementations promote GetMeta from an embedded map field, so a typed-nil
-// pointer inside the interface must be guarded before calling it.
-func requestMeta(req mcp.Request) map[string]any {
-	params := req.GetParams()
-	if params == nil {
-		return nil
-	}
-	if v := reflect.ValueOf(params); v.Kind() == reflect.Pointer && v.IsNil() {
-		return nil
-	}
-	return params.GetMeta()
 }

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -21,9 +21,9 @@ func NewMiddleware() mcp.Middleware {
 				attribute.String("mcp.method", method),
 			}
 
-			// Session IDs only exist for stdio and legacy HTTP clients. The
-			// 2026-07-28 protocol is stateless and has no sessions, so ID()
-			// returns "" there; use the OTel trace/span IDs for correlation.
+			// Only legacy stateful Streamable HTTP sessions expose an ID.
+			// Stateless HTTP, stdio, and in-memory transports return ""; use the
+			// OTel trace/span IDs for correlation when no session ID is available.
 			sessionID := req.GetSession().ID()
 			if sessionID != "" {
 				attrs = append(attrs, attribute.String("mcp.session_id", sessionID))

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -50,6 +50,9 @@ func NewMiddleware() mcp.Middleware {
 				if sessionID != "" {
 					e = e.Str("mcp.session_id", sessionID)
 				}
+				if sc := span.SpanContext(); sc.IsValid() {
+					e = e.Str("trace_id", sc.TraceID().String()).Str("span_id", sc.SpanID().String())
+				}
 				if clientName != "" {
 					e = e.Str("mcp.client.name", clientName).Str("mcp.client.version", clientVersion)
 				}

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -2,9 +2,12 @@ package trace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -16,10 +19,16 @@ func NewMiddleware() mcp.Middleware {
 			ctx, span := Start(ctx, fmt.Sprintf("mcp.%s", method))
 			defer span.End()
 
-			sessionID := req.GetSession().ID()
 			attrs := []attribute.KeyValue{
 				attribute.String("mcp.method", method),
-				attribute.String("mcp.session_id", sessionID),
+			}
+
+			// Session IDs only exist for stdio and legacy HTTP clients. The
+			// 2026-07-28 protocol is stateless and has no sessions, so ID()
+			// returns "" there; use the OTel trace/span IDs for correlation.
+			sessionID := req.GetSession().ID()
+			if sessionID != "" {
+				attrs = append(attrs, attribute.String("mcp.session_id", sessionID))
 			}
 
 			if params, ok := req.GetParams().(*mcp.CallToolParamsRaw); ok && params != nil {
@@ -27,44 +36,84 @@ func NewMiddleware() mcp.Middleware {
 			}
 
 			var clientName, clientVersion string
-			if ss, ok := req.GetSession().(*mcp.ServerSession); ok {
-				if ip := ss.InitializeParams(); ip != nil && ip.ClientInfo != nil && ip.ClientInfo.Name != "" {
-					clientName = ip.ClientInfo.Name
-					clientVersion = ip.ClientInfo.Version
-					attrs = append(attrs,
-						attribute.String("mcp.client.name", clientName),
-						attribute.String("mcp.client.version", clientVersion),
-					)
-				}
+			if ci := clientInfo(req); ci != nil && ci.Name != "" {
+				clientName = ci.Name
+				clientVersion = ci.Version
+				attrs = append(attrs,
+					attribute.String("mcp.client.name", clientName),
+					attribute.String("mcp.client.version", clientVersion),
+				)
 			}
 
 			span.SetAttributes(attrs...)
 
-			baseLog := log.Debug().Str("mcp.method", method).Str("mcp.session_id", sessionID)
-			if clientName != "" {
-				baseLog = baseLog.Str("mcp.client.name", clientName).Str("mcp.client.version", clientVersion)
+			logFields := func(e *zerolog.Event) *zerolog.Event {
+				e = e.Str("mcp.method", method)
+				if sessionID != "" {
+					e = e.Str("mcp.session_id", sessionID)
+				}
+				if clientName != "" {
+					e = e.Str("mcp.client.name", clientName).Str("mcp.client.version", clientVersion)
+				}
+				return e
 			}
-			baseLog.Msg("Handling MCP request")
+
+			logFields(log.Debug()).Msg("Handling MCP request")
 
 			res, err := next(ctx, method, req)
 			if err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
-				errLog := log.Error().Err(err).Str("mcp.method", method).Str("mcp.session_id", sessionID)
-				if clientName != "" {
-					errLog = errLog.Str("mcp.client.name", clientName).Str("mcp.client.version", clientVersion)
-				}
-				errLog.Msg("Error in MCP request")
+				logFields(log.Error().Err(err)).Msg("Error in MCP request")
 			} else {
 				span.SetStatus(codes.Ok, "OK")
-				completedLog := log.Debug().Str("mcp.method", method).Str("mcp.session_id", sessionID)
-				if clientName != "" {
-					completedLog = completedLog.Str("mcp.client.name", clientName).Str("mcp.client.version", clientVersion)
-				}
-				completedLog.Msg("Completed MCP request successfully")
+				logFields(log.Debug()).Msg("Completed MCP request successfully")
 			}
 
 			return res, err
 		}
 	}
+}
+
+// clientInfo returns the client identity for a request. Clients speaking
+// protocol >= 2026-07-28 carry it in each request's _meta (there is no
+// initialize handshake); older clients fall back to the session-level
+// InitializeParams. This mirrors the SDK's typed ServerRequest.ClientInfo
+// accessor, which is not reachable from generic middleware.
+func clientInfo(req mcp.Request) *mcp.Implementation {
+	if m := requestMeta(req); m != nil {
+		if raw, ok := m[mcp.MetaKeyClientInfo]; ok && raw != nil {
+			if impl, ok := raw.(*mcp.Implementation); ok {
+				return impl
+			}
+			// After wire transit the value is a generic JSON map; remarshal
+			// it into the typed form.
+			if b, err := json.Marshal(raw); err == nil {
+				var impl mcp.Implementation
+				if json.Unmarshal(b, &impl) == nil {
+					return &impl
+				}
+			}
+		}
+	}
+	if ss, ok := req.GetSession().(*mcp.ServerSession); ok {
+		if ip := ss.InitializeParams(); ip != nil {
+			return ip.ClientInfo
+		}
+	}
+	return nil
+}
+
+// requestMeta returns the request params' _meta map, or nil. Params
+// implementations promote GetMeta from an embedded map field, so a typed-nil
+// pointer inside the interface must be guarded before calling it.
+func requestMeta(req mcp.Request) map[string]any {
+	params := req.GetParams()
+	if params == nil {
+		return nil
+	}
+	if v := reflect.ValueOf(params); v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
+	return params.GetMeta()
 }

--- a/pkg/trace/middleware_test.go
+++ b/pkg/trace/middleware_test.go
@@ -1,12 +1,17 @@
 package trace
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -81,6 +86,80 @@ func TestNewMiddleware(t *testing.T) {
 	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from per-request _meta")
 	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from per-request _meta")
 	assert.Equal("ping", attrs["mcp.tool_name"], "mcp.tool_name should be set for tools/call requests")
+}
+
+// captureLogs redirects the global zerolog logger to a buffer for the
+// duration of the test and returns it.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := log.Logger
+	log.Logger = zerolog.New(&buf)
+	t.Cleanup(func() { log.Logger = orig })
+	return &buf
+}
+
+// logLines decodes each JSON log line in buf whose mcp.method matches.
+func logLines(t *testing.T, buf *bytes.Buffer, method string) []map[string]any {
+	t.Helper()
+	var lines []map[string]any
+	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if raw == "" {
+			continue
+		}
+		var line map[string]any
+		require.NoError(t, json.Unmarshal([]byte(raw), &line), "log line should be valid JSON: %s", raw)
+		if line["mcp.method"] == method {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// TestNewMiddlewareLogCorrelation verifies that on the sessionless
+// (2026-07-28) path the request log lines omit mcp.session_id but carry
+// matching trace_id/span_id fields so they can be correlated with each other
+// and with the emitted span.
+func TestNewMiddlewareLogCorrelation(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+
+	buf := captureLogs(t)
+	server, sr := setupMiddlewareServer(t)
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	_, err := server.Connect(ctx, t1, nil)
+	assert.NoError(err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	assert.NoError(err)
+	defer session.Close()
+
+	_, err = session.CallTool(ctx, &mcp.CallToolParams{Name: "ping"})
+	assert.NoError(err)
+
+	lines := logLines(t, buf, "tools/call")
+	assert.Len(lines, 2, "expected a handling and a completed log line for tools/call")
+
+	for _, line := range lines {
+		assert.NotContains(line, "mcp.session_id", "mcp.session_id should be omitted for sessionless requests")
+		assert.NotEmpty(line["trace_id"], "trace_id should be set for log correlation")
+		assert.NotEmpty(line["span_id"], "span_id should be set for log correlation")
+	}
+	assert.Equal(lines[0]["trace_id"], lines[1]["trace_id"], "both log lines should share a trace_id")
+	assert.Equal(lines[0]["span_id"], lines[1]["span_id"], "both log lines should share a span_id")
+
+	// The logged trace_id must match the span emitted for the request.
+	tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	assert.NoError(tp.ForceFlush(ctx))
+	for _, s := range sr.Ended() {
+		if s.Name() == "mcp.tools/call" {
+			assert.Equal(s.SpanContext().TraceID().String(), lines[0]["trace_id"], "logged trace_id should match the span's trace ID")
+			return
+		}
+	}
+	t.Fatal("expected a span named mcp.tools/call")
 }
 
 // TestNewMiddlewareHTTP covers the legacy (pre-2026-07-28) protocol path: a

--- a/pkg/trace/middleware_test.go
+++ b/pkg/trace/middleware_test.go
@@ -77,12 +77,15 @@ func TestNewMiddleware(t *testing.T) {
 	tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
 	attrs := spanAttrs(t, tp, sr, "mcp.tools/call")
 	assert.Equal("tools/call", attrs["mcp.method"], "mcp.method attribute should be set")
-	assert.Contains(attrs, "mcp.session_id", "mcp.session_id attribute should be set")
-	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from initialize handshake")
-	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from initialize handshake")
+	assert.NotContains(attrs, "mcp.session_id", "mcp.session_id should be omitted for sessionless (2026-07-28) requests")
+	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from per-request _meta")
+	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from per-request _meta")
 	assert.Equal("ping", attrs["mcp.tool_name"], "mcp.tool_name should be set for tools/call requests")
 }
 
+// TestNewMiddlewareHTTP covers the legacy (pre-2026-07-28) protocol path: a
+// stateful StreamableHTTP handler negotiates an initialize handshake and
+// assigns a session ID via the Mcp-Session-Id header.
 func TestNewMiddlewareHTTP(t *testing.T) {
 	assert := require.New(t)
 	ctx := context.Background()
@@ -107,8 +110,40 @@ func TestNewMiddlewareHTTP(t *testing.T) {
 	tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
 	attrs := spanAttrs(t, tp, sr, "mcp.tools/call")
 	assert.Equal("tools/call", attrs["mcp.method"], "mcp.method attribute should be set")
-	assert.NotEmpty(attrs["mcp.session_id"], "mcp.session_id should be non-empty over HTTP transport")
+	assert.NotEmpty(attrs["mcp.session_id"], "mcp.session_id should be non-empty over stateful HTTP transport")
 	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from initialize handshake")
 	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from initialize handshake")
+	assert.Equal("ping", attrs["mcp.tool_name"], "mcp.tool_name should be set for tools/call requests")
+}
+
+// TestNewMiddlewareHTTPStateless covers the 2026-07-28 protocol path used in
+// production (internal/commands/http.go): a stateless StreamableHTTP handler
+// with no sessions, where client identity travels in each request's _meta.
+func TestNewMiddlewareHTTPStateless(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+
+	server, sr := setupMiddlewareServer(t)
+
+	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return server
+	}, &mcp.StreamableHTTPOptions{Stateless: true})
+	httpServer := httptest.NewServer(handler)
+	defer httpServer.Close()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, &mcp.StreamableClientTransport{Endpoint: httpServer.URL}, nil)
+	assert.NoError(err)
+	defer session.Close()
+
+	_, err = session.CallTool(ctx, &mcp.CallToolParams{Name: "ping"})
+	assert.NoError(err)
+
+	tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	attrs := spanAttrs(t, tp, sr, "mcp.tools/call")
+	assert.Equal("tools/call", attrs["mcp.method"], "mcp.method attribute should be set")
+	assert.NotContains(attrs, "mcp.session_id", "mcp.session_id should be omitted over stateless HTTP transport")
+	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from per-request _meta")
+	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from per-request _meta")
 	assert.Equal("ping", attrs["mcp.tool_name"], "mcp.tool_name should be set for tools/call requests")
 }


### PR DESCRIPTION
## Description

`v1.7.0` of the MCP protocol makes some adjustments for session IDs (they no longer exist), due to its new stateless approach.

## Changes

- use client info for session attributions
