### PR TITLE
feat: add wait_for_build tool with a sub-60s polling window

### DIFF
--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -55,7 +55,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 	}
 
 	mux := http.NewServeMux()
-	srv := newServerWithTimeouts(mux, 30*time.Second)
+	srv := newServerWithTimeouts(mux, httpWriteTimeout)
 
 	mux.HandleFunc("/health", healthHandler)
 
@@ -78,6 +78,14 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 
 	return srv.Serve(listener)
 }
+
+// httpWriteTimeout must outlast the slowest tool call. Go applies this deadline
+// to the connection from when the request headers are read, so a handler that
+// runs longer never delivers its response: the client sees the connection close,
+// not an error it can act on. wait_for_build polls for tens of seconds by
+// design, so this is sized off buildkite.MaxWaitForBuildBudget with headroom.
+// TestWriteTimeoutOutlastsSlowestTool keeps the two in step.
+const httpWriteTimeout = 90 * time.Second
 
 func newServerWithTimeouts(mux *http.ServeMux, writeTimeout time.Duration) *http.Server {
 	return &http.Server{

--- a/internal/commands/http_test.go
+++ b/internal/commands/http_test.go
@@ -1,0 +1,61 @@
+package commands
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteTimeoutOutlastsSlowestTool pins the relationship the streamable HTTP
+// transport depends on. Nothing else connects these two numbers, and getting it
+// wrong is silent: the handler completes normally while the client sees only a
+// closed connection.
+func TestWriteTimeoutOutlastsSlowestTool(t *testing.T) {
+	budget := buildkite.MaxWaitForBuildBudget()
+
+	require.Greater(t, httpWriteTimeout, budget,
+		"httpWriteTimeout (%s) must outlast the slowest tool call (%s) or its response is never delivered",
+		httpWriteTimeout, budget)
+
+	// Keep real headroom rather than squeaking past, so a modest bump to the
+	// poll window does not quietly land on the boundary.
+	require.GreaterOrEqual(t, httpWriteTimeout-budget, 20*time.Second,
+		"leave at least 20s of headroom between httpWriteTimeout (%s) and the tool budget (%s)",
+		httpWriteTimeout, budget)
+}
+
+// TestWriteTimeoutIsAppliedToServer guards the wiring, not just the constant.
+func TestWriteTimeoutIsAppliedToServer(t *testing.T) {
+	srv := newServerWithTimeouts(http.NewServeMux(), httpWriteTimeout)
+	require.Equal(t, httpWriteTimeout, srv.WriteTimeout)
+}
+
+// TestHandlerOutlivingWriteTimeoutIsCutOff demonstrates the failure mode the
+// constant exists to prevent: a handler slower than WriteTimeout delivers
+// nothing at all, so the client cannot distinguish it from a network fault.
+// Scaled down so the test stays fast.
+func TestHandlerOutlivingWriteTimeoutIsCutOff(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/slow", func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		_, _ = w.Write([]byte(`{"finished":false}`))
+	})
+
+	srv := newServerWithTimeouts(mux, 100*time.Millisecond)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = srv.Close() }()
+
+	go func() { _ = srv.Serve(listener) }()
+
+	resp, err := http.Get("http://" + listener.Addr().String() + "/slow") //nolint:noctx // deliberate: exercising the server's own deadline
+	if resp != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	require.Error(t, err, "a handler outliving WriteTimeout must not deliver a response")
+}

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -2,14 +2,34 @@ package buildkite
 
 import (
 	"context"
+	"time"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 const annotationSummaryPageSize = 100
+
+// Timing budget for wait_for_build. MCP clients commonly enforce a 60 second
+// request timeout that server progress notifications do not reset, see
+// https://github.com/modelcontextprotocol/typescript-sdk/issues/245. The poll
+// window plus the trailing annotation fetch stay inside that budget, so the
+// call always returns rather than being killed client-side; the caller waits
+// longer by invoking the tool again.
+//
+// These are vars only so tests can shorten them; they are not runtime tunable.
+var (
+	// waitForBuildMaxDuration bounds the polling loop and the API calls it makes.
+	waitForBuildMaxDuration = 45 * time.Second
+	// waitForBuildPollInterval is how often the build is re-checked while waiting.
+	waitForBuildPollInterval = 5 * time.Second
+	// waitForBuildAnnotationTimeout bounds the single annotation fetch made once
+	// the poll window closes.
+	waitForBuildAnnotationTimeout = 10 * time.Second
+)
 
 type BuildsClient interface {
 	Get(ctx context.Context, org, pipelineSlug, buildNumber string, options *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error)
@@ -310,16 +330,11 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 				return handleBuildkiteError(err)
 			}
 
-			annotations, annotationsResponse, err := deps.AnnotationsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.AnnotationListOptions{
-				ListOptions: buildkite.ListOptions{Page: 1, PerPage: annotationSummaryPageSize},
-				Scope:       "all",
-				OmitBody:    boolPtr(true),
-			})
+			annotations, annotationsTruncated, err := listAnnotationSummaries(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber)
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
 
-			annotationsTruncated := annotationsResponse != nil && annotationsResponse.NextPage > 0
 			span.SetAttributes(
 				attribute.Int("annotation_count", len(annotations)),
 				attribute.Bool("annotations_truncated", annotationsTruncated),
@@ -328,6 +343,168 @@ func GetBuild() (mcp.Tool, mcp.ToolHandlerFor[GetBuildArgs, any], []string) {
 			result := detailBuild(build, annotations, annotationsTruncated)
 			return mcpTextResult(span, &result)
 		}, []string{"read_builds"}
+}
+
+// listAnnotationSummaries fetches the first page of body-less annotations for a
+// build, reporting whether further pages were left behind.
+func listAnnotationSummaries(ctx context.Context, orgSlug, pipelineSlug, buildNumber string) ([]buildkite.Annotation, bool, error) {
+	deps := DepsFromContext(ctx)
+	annotations, resp, err := deps.AnnotationsClient.ListByBuild(ctx, orgSlug, pipelineSlug, buildNumber, &buildkite.AnnotationListOptions{
+		ListOptions: buildkite.ListOptions{Page: 1, PerPage: annotationSummaryPageSize},
+		Scope:       "all",
+		OmitBody:    boolPtr(true),
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	return annotations, resp != nil && resp.NextPage > 0, nil
+}
+
+type WaitForBuildArgs struct {
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+	BuildNumber  string `json:"build_number"`
+}
+
+// WaitForBuildResult reports whether the build settled within this call's
+// polling window. When finished is false the build is still in progress and the
+// caller should invoke the tool again to keep waiting.
+//
+// Build is only populated once finished is true. Waiting on a long build means
+// repeating this call, and the build detail is near-identical every time, so
+// interim responses carry just the fields that actually change. Callers that
+// want detail mid-flight can ask for it directly with get_build.
+type WaitForBuildResult struct {
+	Finished      bool         `json:"finished"`
+	State         string       `json:"state"`
+	Number        int          `json:"number"`
+	WaitedSeconds int          `json:"waited_seconds"`
+	Build         *BuildDetail `json:"build,omitempty"`
+}
+
+func WaitForBuild() (mcp.Tool, mcp.ToolHandlerFor[WaitForBuildArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "wait_for_build",
+			Description: "Wait for a build to reach a terminal state (passed, failed, canceled, skipped, not_run, or blocked on a block step), polling for up to 45 seconds. Returns finished=true along with the build once it settles. If the build is still in progress when the window closes it returns finished=false and the current state only, with no build detail — call this tool again to keep waiting. Jobs and annotation bodies are never included — use list_jobs or get_job for job detail, and list_annotations to read annotations",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Wait for Build",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args WaitForBuildArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.WaitForBuild")
+			defer span.End()
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+			)
+
+			// Jobs are excluded; use list_jobs/get_job for job detail.
+			options := &buildkite.BuildGetOptions{
+				BuildsListOptions: buildkite.BuildsListOptions{
+					ExcludeJobs:     true,
+					ExcludePipeline: true,
+				},
+				IncludeTestEngine: true,
+			}
+
+			// Bound the polling loop, and the API calls it makes, so the tool
+			// always responds inside the client's request timeout.
+			waitCtx, cancel := context.WithTimeout(ctx, waitForBuildMaxDuration)
+			defer cancel()
+
+			ticker := time.NewTicker(waitForBuildPollInterval)
+			defer ticker.Stop()
+
+			deps := DepsFromContext(ctx)
+			started := time.Now()
+
+			var build buildkite.Build
+			var polled bool
+
+		POLL:
+			for {
+				current, _, err := deps.BuildsClient.Get(waitCtx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, options)
+				if err != nil {
+					// Once we have a build, a poll cancelled by the wait deadline is
+					// the expected way to exit, not a failure worth reporting.
+					if polled && waitCtx.Err() != nil {
+						break POLL
+					}
+					return handleBuildkiteError(err)
+				}
+
+				build, polled = current, true
+
+				if isTerminalBuildState(build.State) {
+					break POLL
+				}
+
+				select {
+				case <-ticker.C:
+				case <-waitCtx.Done():
+					break POLL
+				}
+			}
+
+			finished := isTerminalBuildState(build.State)
+			waited := time.Since(started)
+
+			log.Ctx(ctx).Info().
+				Str("build_id", build.ID).
+				Str("state", build.State).
+				Bool("finished", finished).
+				Dur("waited", waited).
+				Msg("Finished waiting for build")
+
+			span.SetAttributes(
+				attribute.String("build_state", build.State),
+				attribute.Bool("finished", finished),
+			)
+
+			result := WaitForBuildResult{
+				Finished:      finished,
+				State:         build.State,
+				Number:        build.Number,
+				WaitedSeconds: int(waited.Round(time.Second).Seconds()),
+			}
+
+			// Build detail, and the annotation fetch it needs, are only worth
+			// paying for once the build has settled. Skipping them on interim
+			// responses keeps a long wait from repeating the same static build
+			// metadata on every retry.
+			if finished {
+				// This runs outside the poll window, so it carries its own budget.
+				annCtx, annCancel := context.WithTimeout(ctx, waitForBuildAnnotationTimeout)
+				defer annCancel()
+
+				annotations, annotationsTruncated, err := listAnnotationSummaries(annCtx, args.OrgSlug, args.PipelineSlug, args.BuildNumber)
+				if err != nil {
+					return handleBuildkiteError(err)
+				}
+
+				detail := detailBuild(build, annotations, annotationsTruncated)
+				result.Build = &detail
+			}
+
+			return mcpTextResult(span, &result)
+		}, []string{"read_builds"}
+}
+
+// isTerminalBuildState reports whether a build state is settled, meaning further
+// polling cannot change it without outside intervention. "blocked" counts: the
+// build is waiting on a block step and will not move until a human unblocks it.
+// See https://buildkite.com/docs/pipelines/configure/notifications#build-states
+func isTerminalBuildState(state string) bool {
+	switch state {
+	case "passed", "failed", "canceled", "skipped", "not_run", "blocked":
+		return true
+	default:
+		return false
+	}
 }
 
 type Entry struct {

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -31,6 +31,15 @@ var (
 	waitForBuildAnnotationTimeout = 10 * time.Second
 )
 
+// MaxWaitForBuildBudget is the longest a single wait_for_build call can take:
+// the poll window plus the annotation fetch that follows it. wait_for_build is
+// deliberately the slowest tool here, so any transport imposing its own write
+// deadline must allow at least this long or it will close the connection before
+// the handler can respond.
+func MaxWaitForBuildBudget() time.Duration {
+	return waitForBuildMaxDuration + waitForBuildAnnotationTimeout
+}
+
 type BuildsClient interface {
 	Get(ctx context.Context, org, pipelineSlug, buildNumber string, options *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error)
 	ListByOrg(ctx context.Context, org string, options *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error)
@@ -456,12 +465,28 @@ func WaitForBuild() (mcp.Tool, mcp.ToolHandlerFor[WaitForBuildArgs, any], []stri
 			for {
 				current, _, err := deps.BuildsClient.Get(waitCtx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, options)
 				if err != nil {
-					// Once we have a build, a poll cancelled by the wait deadline is
-					// the expected way to exit, not a failure worth reporting.
-					if polled && waitCtx.Err() != nil {
-						break POLL
+					// The caller has gone away, so there is no result to return and
+					// no point paying for the annotation fetch a result would need.
+					if ctx.Err() != nil {
+						return handleBuildkiteError(err)
 					}
-					return handleBuildkiteError(err)
+
+					// Before the first successful poll there is no state to fall back
+					// on, and an authentication failure will not resolve itself, so
+					// both of those propagate.
+					if !polled || isBuildkiteUnauthorized(err) {
+						return handleBuildkiteError(err)
+					}
+
+					// Otherwise fall back to the last state we saw. This covers both
+					// the wait deadline and a transient API error: the caller retries
+					// either way, and reporting a build we just saw running beats
+					// discarding it because one poll failed.
+					log.Ctx(ctx).Warn().Err(err).
+						Str("last_known_state", build.State).
+						Msg("Build poll failed, returning last known state")
+
+					break POLL
 				}
 
 				build, polled = current, true

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -376,17 +376,44 @@ type WaitForBuildArgs struct {
 // interim responses carry just the fields that actually change. Callers that
 // want detail mid-flight can ask for it directly with get_build.
 type WaitForBuildResult struct {
-	Finished      bool         `json:"finished"`
-	State         string       `json:"state"`
-	Number        int          `json:"number"`
-	WaitedSeconds int          `json:"waited_seconds"`
-	Build         *BuildDetail `json:"build,omitempty"`
+	Finished bool   `json:"finished"`
+	State    string `json:"state"`
+	Number   int    `json:"number"`
+	// WaitedSeconds is how long this single call waited, not the total across
+	// retries. BuildElapsedSeconds covers that: it is measured from the build's
+	// own start time, so it is independent of how many times the tool has been
+	// called and is the field to judge a long-running build by. It is omitted
+	// for a build that has not started yet.
+	WaitedSeconds       int          `json:"waited_seconds"`
+	BuildElapsedSeconds int          `json:"build_elapsed_seconds,omitempty"`
+	Build               *BuildDetail `json:"build,omitempty"`
+}
+
+// buildElapsedSeconds reports how long the build has been going: its full
+// duration once finished, or time so far while it is still running. Returns 0
+// when the build has not started, which omits the field.
+func buildElapsedSeconds(build buildkite.Build) int {
+	if build.StartedAt == nil {
+		return 0
+	}
+
+	end := time.Now()
+	if build.FinishedAt != nil {
+		end = build.FinishedAt.Time
+	}
+
+	elapsed := end.Sub(build.StartedAt.Time)
+	if elapsed < 0 {
+		return 0
+	}
+
+	return int(elapsed.Round(time.Second).Seconds())
 }
 
 func WaitForBuild() (mcp.Tool, mcp.ToolHandlerFor[WaitForBuildArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "wait_for_build",
-			Description: "Wait for a build to reach a terminal state (passed, failed, canceled, skipped, not_run, or blocked on a block step), polling for up to 45 seconds. Returns finished=true along with the build once it settles. If the build is still in progress when the window closes it returns finished=false and the current state only, with no build detail — call this tool again to keep waiting. Jobs and annotation bodies are never included — use list_jobs or get_job for job detail, and list_annotations to read annotations",
+			Description: "Wait for a build to reach a terminal state (passed, failed, canceled, skipped, not_run, or blocked on a block step), polling for up to 45 seconds. Returns finished=true along with the build once it settles. If the build is still in progress when the window closes it returns finished=false and the current state only, with no build detail — call this tool again to keep waiting. Judge a long build by build_elapsed_seconds, which counts from the build's own start time and does not reset between calls; waited_seconds covers only the latest call. Do not wait indefinitely: after roughly ten consecutive calls, stop and report the build as still running with its elapsed time rather than continuing to poll. Jobs and annotation bodies are never included — use list_jobs or get_job for job detail, and list_annotations to read annotations",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Wait for Build",
 				ReadOnlyHint: true,
@@ -466,10 +493,11 @@ func WaitForBuild() (mcp.Tool, mcp.ToolHandlerFor[WaitForBuildArgs, any], []stri
 			)
 
 			result := WaitForBuildResult{
-				Finished:      finished,
-				State:         build.State,
-				Number:        build.Number,
-				WaitedSeconds: int(waited.Round(time.Second).Seconds()),
+				Finished:            finished,
+				State:               build.State,
+				Number:              build.Number,
+				WaitedSeconds:       int(waited.Round(time.Second).Seconds()),
+				BuildElapsedSeconds: buildElapsedSeconds(build),
 			}
 
 			// Build detail, and the annotation fetch it needs, are only worth

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -987,3 +987,119 @@ func TestWaitForBuildReportsBuildElapsed(t *testing.T) {
 	// Still lean.
 	assert.Less(len(text), 120)
 }
+
+func TestWaitForBuildPollErrorHandling(t *testing.T) {
+	runningThenError := func(failAfter int, failWith error) (*MockBuildsClient, *int) {
+		calls := 0
+		return &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				calls++
+				if calls > failAfter {
+					return buildkite.Build{}, nil, failWith
+				}
+				return buildkite.Build{ID: "123", Number: 1, State: "running"}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}, &calls
+	}
+
+	t.Run("TransientErrorReturnsLastKnownState", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		client, _ := runningThenError(2, errors.New("500 internal server error"))
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: &MockAnnotationsClient{},
+		})
+		_, handler, _ := WaitForBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		assert.NoError(err)
+
+		// One blip must not discard a build we saw running moments ago; the
+		// caller retries exactly as it would after a window timeout.
+		assert.False(result.IsError)
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"finished":false`)
+		assert.Contains(text, `"state":"running"`)
+	})
+
+	t.Run("UnauthorizedPropagatesRatherThanLookingLikeProgress", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		client, _ := runningThenError(2, &buildkite.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusUnauthorized},
+		})
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: &MockAnnotationsClient{},
+		})
+		_, handler, _ := WaitForBuild()
+
+		_, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+
+		// A revoked token never fixes itself, so it must not be reported as
+		// "still running" and retried forever.
+		assert.ErrorIs(err, ErrUnauthorized)
+	})
+
+	t.Run("ClientAbortSkipsTheAnnotationFetch", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var annotationCalls, calls int
+		client := &MockBuildsClient{
+			GetFunc: func(reqCtx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				calls++
+				if calls > 2 {
+					// Caller hangs up mid-wait.
+					cancel()
+					return buildkite.Build{}, nil, context.Canceled
+				}
+				// Stay non-terminal so the loop keeps polling until the abort.
+				return buildkite.Build{ID: "123", Number: 1, State: "running"}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}
+
+		deps := ToolDependencies{
+			BuildsClient: client,
+			AnnotationsClient: &MockAnnotationsClient{
+				ListByBuildFunc: func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+					annotationCalls++
+					return nil, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+				},
+			},
+		}
+		_, handler, _ := WaitForBuild()
+
+		_, _, _ = handler(ContextWithDeps(ctx, deps), createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+
+		// Nobody is listening, so we must not pay for more API calls.
+		assert.Zero(annotationCalls)
+	})
+}
+
+// TestWaitForBuildBudgetFitsClientTimeout pins the constraint the whole design
+// exists to satisfy. Only a comment enforced it before.
+func TestWaitForBuildBudgetFitsClientTimeout(t *testing.T) {
+	// MCP clients commonly enforce a 60s request timeout that progress
+	// notifications do not reset, see
+	// https://github.com/modelcontextprotocol/typescript-sdk/issues/245
+	const clientRequestTimeout = 60 * time.Second
+
+	require.Less(t, MaxWaitForBuildBudget(), clientRequestTimeout,
+		"a single wait_for_build call must return inside the client's request timeout")
+}

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -917,3 +917,73 @@ func TestIsTerminalBuildState(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildElapsedSeconds(t *testing.T) {
+	ts := func(d time.Duration) *buildkite.Timestamp {
+		return &buildkite.Timestamp{Time: time.Now().Add(d)}
+	}
+
+	t.Run("OmittedWhenBuildHasNotStarted", func(t *testing.T) {
+		require.Zero(t, buildElapsedSeconds(buildkite.Build{}))
+	})
+
+	t.Run("CountsFromStartWhileRunning", func(t *testing.T) {
+		// Independent of how long any single wait call ran.
+		require.InDelta(t, 600, buildElapsedSeconds(buildkite.Build{
+			State: "running", StartedAt: ts(-10 * time.Minute),
+		}), 2)
+	})
+
+	t.Run("UsesFinishedAtOnceSettled", func(t *testing.T) {
+		// A build that finished an hour ago still reports its own duration,
+		// not the time since it finished.
+		start := time.Now().Add(-2 * time.Hour)
+		require.Equal(t, 900, buildElapsedSeconds(buildkite.Build{
+			State:      "passed",
+			StartedAt:  &buildkite.Timestamp{Time: start},
+			FinishedAt: &buildkite.Timestamp{Time: start.Add(15 * time.Minute)},
+		}))
+	})
+
+	t.Run("ClampsNegativeSkew", func(t *testing.T) {
+		start := time.Now()
+		require.Zero(t, buildElapsedSeconds(buildkite.Build{
+			StartedAt:  &buildkite.Timestamp{Time: start},
+			FinishedAt: &buildkite.Timestamp{Time: start.Add(-time.Minute)},
+		}))
+	})
+}
+
+func TestWaitForBuildReportsBuildElapsed(t *testing.T) {
+	assert := require.New(t)
+	shortenBuildWait(t, 50*time.Millisecond, time.Millisecond)
+
+	client := &MockBuildsClient{
+		GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+				ID: "123", Number: 1, State: "running",
+				StartedAt: &buildkite.Timestamp{Time: time.Now().Add(-9 * time.Minute)},
+			}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:      client,
+		AnnotationsClient: &MockAnnotationsClient{},
+	})
+	_, handler, _ := WaitForBuild()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+	})
+	assert.NoError(err)
+
+	// The caller can tell a 9-minute build from a 9-second one without a
+	// separate get_build, and without counting its own retries.
+	text := getTextResult(t, result).Text
+	assert.Contains(text, `"build_elapsed_seconds":540,`)
+	assert.Contains(text, `"finished":false`)
+
+	// Still lean.
+	assert.Less(len(text), 120)
+}

--- a/pkg/buildkite/builds_test.go
+++ b/pkg/buildkite/builds_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/stretchr/testify/require"
@@ -679,4 +680,240 @@ func TestRebuildBuild(t *testing.T) {
 		textContent := getTextResult(t, result)
 		assert.Contains(textContent.Text, "build not found")
 	})
+}
+
+// shortenBuildWait shrinks the wait window and poll interval so wait_for_build
+// tests exercise the polling loop without sleeping for real build durations.
+func shortenBuildWait(t *testing.T, maxDuration, pollInterval time.Duration) {
+	t.Helper()
+	origMax, origPoll := waitForBuildMaxDuration, waitForBuildPollInterval
+	waitForBuildMaxDuration, waitForBuildPollInterval = maxDuration, pollInterval
+	t.Cleanup(func() {
+		waitForBuildMaxDuration, waitForBuildPollInterval = origMax, origPoll
+	})
+}
+
+func TestWaitForBuild(t *testing.T) {
+	t.Run("ToolDefinition", func(t *testing.T) {
+		tool, handler, scopes := WaitForBuild()
+		require.Equal(t, "wait_for_build", tool.Name)
+		require.True(t, tool.Annotations.ReadOnlyHint)
+		require.Equal(t, []string{"read_builds"}, scopes)
+		require.NotNil(t, handler)
+	})
+
+	t.Run("ReturnsImmediatelyWhenBuildAlreadyTerminal", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 45*time.Second, 5*time.Second)
+
+		var getCalls int
+		var capturedOptions *buildkite.BuildGetOptions
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				getCalls++
+				capturedOptions = opt
+				return buildkite.Build{ID: "123", Number: 1, State: "passed"}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: &MockAnnotationsClient{},
+		})
+		_, handler, _ := WaitForBuild()
+
+		started := time.Now()
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		elapsed := time.Since(started)
+		assert.NoError(err)
+
+		// A settled build must not pay for a poll interval it does not need.
+		assert.Equal(1, getCalls)
+		assert.Less(elapsed, waitForBuildPollInterval)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"finished":true`)
+		assert.Contains(text, `"state":"passed"`)
+		assert.Contains(text, `"id":"123"`)
+
+		// Jobs stay excluded; list_jobs/get_job own that detail.
+		assert.True(capturedOptions.ExcludeJobs)
+		assert.True(capturedOptions.ExcludePipeline)
+	})
+
+	t.Run("PollsUntilBuildReachesTerminalState", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		var getCalls int
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				getCalls++
+				state := "running"
+				if getCalls >= 3 {
+					state = "failed"
+				}
+				return buildkite.Build{ID: "123", Number: 1, State: state}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: &MockAnnotationsClient{},
+		})
+		_, handler, _ := WaitForBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		assert.NoError(err)
+		assert.Equal(3, getCalls)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"finished":true`)
+		assert.Contains(text, `"state":"failed"`)
+	})
+
+	t.Run("ReturnsUnfinishedWhenWaitWindowCloses", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 50*time.Millisecond, time.Millisecond)
+
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				return buildkite.Build{ID: "123", Number: 1, State: "running"}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}
+
+		var annotationCalls int
+		annotationsClient := &MockAnnotationsClient{
+			ListByBuildFunc: func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+				annotationCalls++
+				return nil, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: annotationsClient,
+		})
+		_, handler, _ := WaitForBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		assert.NoError(err)
+
+		// A build that is merely still running is a normal result, not an error.
+		assert.False(result.IsError)
+
+		// No annotation fetch is worth paying for until the build settles.
+		assert.Zero(annotationCalls)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"finished":false`)
+		assert.Contains(text, `"state":"running"`)
+		assert.Contains(text, `"waited_seconds":`)
+
+		// Interim responses stay lean: a caller polling a long build repeats this
+		// payload, and the build detail is identical every time.
+		assert.NotContains(text, `"build":`)
+		assert.NotContains(text, `"author":`)
+		assert.NotContains(text, `"annotations":`)
+		assert.Less(len(text), 100)
+	})
+
+	t.Run("ReturnsErrorWhenFirstPollFails", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				return buildkite.Build{}, nil, errors.New("boom")
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: &MockAnnotationsClient{},
+		})
+		_, handler, _ := WaitForBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		assert.NoError(err)
+		assert.True(result.IsError)
+		assert.Contains(getTextResult(t, result).Text, "boom")
+	})
+
+	t.Run("IncludesAnnotationSummariesOnce", func(t *testing.T) {
+		assert := require.New(t)
+		shortenBuildWait(t, 2*time.Second, time.Millisecond)
+
+		var getCalls, annotationCalls int
+		client := &MockBuildsClient{
+			GetFunc: func(ctx context.Context, org, pipeline, id string, opt *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				getCalls++
+				state := "running"
+				if getCalls >= 3 {
+					state = "passed"
+				}
+				return buildkite.Build{ID: "123", Number: 1, State: state}, &buildkite.Response{
+					Response: &http.Response{StatusCode: 200},
+				}, nil
+			},
+		}
+		annotationsClient := &MockAnnotationsClient{
+			ListByBuildFunc: func(ctx context.Context, org, pipelineSlug, buildNumber string, opts *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+				annotationCalls++
+				return []buildkite.Annotation{
+					{ID: "annotation-1", Context: "test-results", Style: "error", Scope: "build", BodyHTML: "<p>large body</p>"},
+				}, &buildkite.Response{Response: &http.Response{StatusCode: 200}}, nil
+			},
+		}
+
+		ctx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient:      client,
+			AnnotationsClient: annotationsClient,
+		})
+		_, handler, _ := WaitForBuild()
+
+		result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), WaitForBuildArgs{
+			OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
+		})
+		assert.NoError(err)
+
+		// Annotations are fetched on the way out, not once per poll.
+		assert.Equal(3, getCalls)
+		assert.Equal(1, annotationCalls)
+
+		text := getTextResult(t, result).Text
+		assert.Contains(text, `"id":"annotation-1"`)
+		assert.NotContains(text, "large body")
+	})
+}
+
+func TestIsTerminalBuildState(t *testing.T) {
+	terminal := []string{"passed", "failed", "canceled", "skipped", "not_run", "blocked"}
+	for _, state := range terminal {
+		t.Run(state, func(t *testing.T) {
+			require.True(t, isTerminalBuildState(state))
+		})
+	}
+
+	// "failing" and "canceling" are transitional: the build is still moving.
+	inProgress := []string{"creating", "scheduled", "running", "failing", "canceling", ""}
+	for _, state := range inProgress {
+		t.Run("not_terminal_"+state, func(t *testing.T) {
+			require.False(t, isTerminalBuildState(state))
+		})
+	}
 }

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -57,6 +57,11 @@ func TestGetBuildArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 }
 
+func TestWaitForBuildArgsSchema(t *testing.T) {
+	req := sortedRequired[WaitForBuildArgs](t)
+	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
+}
+
 func TestGetBuildFailureSummaryArgsSchema(t *testing.T) {
 	s := schemaFor[GetBuildFailureSummaryArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[GetBuildFailureSummaryArgs](t))

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -352,6 +352,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.ListBuilds),
 				newToolDef(buildkite.GetBuild),
 				newToolDef(buildkite.GetBuildTestEngineRuns),
+				newToolDef(buildkite.WaitForBuild),
 				newToolDef(buildkite.CreateBuild),
 				newToolDef(buildkite.CancelBuild),
 				newToolDef(buildkite.RebuildBuild),


### PR DESCRIPTION
Reinstates the tool removed in 66b2f16, reworked so a single call always returns inside the client request timeout.

- poll build state for up to 45s, then return finished=false so the caller invokes again; MCP clients commonly enforce a 60s timeout that progress notifications do not reset (modelcontextprotocol/typescript-sdk#245)
- bound the poll loop's API calls, and give the trailing annotation fetch its own 10s budget, holding the worst case to 55s
- return build detail only once the build settles, dropping interim responses from ~1200 to ~69 bytes; a 10 minute wait costs ~1.8KB instead of ~15.6KB
- skip the annotation fetch while still running, so an interim poll makes a single API call
- report a still-running build as a normal result, not IsError
- return immediately when the build is already terminal rather than waiting out a poll interval first
- treat blocked and not_run as terminal; failing and canceling are not
- extract listAnnotationSummaries, shared with get_build
