### PR TITLE
fix: decode Job.Signal as a signal name, not an int

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.7.0
+	github.com/buildkite/go-buildkite/v5 v5.10.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.7.0 h1:UY2vlF5AceV7zqWUN+uU7bjEXgEFdKrwayvZ8bZgcj0=
-github.com/buildkite/go-buildkite/v5 v5.7.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.10.0 h1:XYSUuFJhVJZrZJNEc+Rvd7jJxyJMy21iMuCcvz5jFMM=
+github.com/buildkite/go-buildkite/v5 v5.10.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -65,7 +65,7 @@ type JobDetail struct {
 	Type               string               `json:"type,omitempty"`
 	Label              string               `json:"label,omitempty"`
 	GroupKey           string               `json:"group_key,omitempty"`
-	Signal             *int                 `json:"signal,omitempty"`
+	Signal             string               `json:"signal,omitempty"`
 	CreatedAt          *buildkite.Timestamp `json:"created_at,omitempty"`
 	StartedAt          *buildkite.Timestamp `json:"started_at,omitempty"`
 	FinishedAt         *buildkite.Timestamp `json:"finished_at,omitempty"`

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -422,7 +422,7 @@ func TestListJobs(t *testing.T) {
 					Items: []buildkite.Job{{
 						ID: "job-1", Name: "test", State: "failed", Command: "go test ./...",
 						CreatedAt: timestamp, StartedAt: timestamp, FinishedAt: timestamp,
-						Signal: intPtr(9), SignalReason: "agent_stop", Retried: true,
+						Signal: "SIGKILL", SignalReason: "agent_stop", Retried: true,
 						RetriedInJobID: "job-2", RetriesCount: 1,
 						RetrySource:        &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"},
 						SoftFailed:         true,
@@ -452,7 +452,7 @@ func TestListJobs(t *testing.T) {
 		assert.Equal(t, timestamp, job.CreatedAt)
 		assert.Equal(t, timestamp, job.StartedAt)
 		assert.Equal(t, timestamp, job.FinishedAt)
-		assert.Equal(t, intPtr(9), job.Signal)
+		assert.Equal(t, "SIGKILL", job.Signal)
 		assert.Equal(t, "agent_stop", job.SignalReason)
 		assert.True(t, job.Retried)
 		assert.Equal(t, "job-2", job.RetriedInJobID)
@@ -806,4 +806,52 @@ func TestGetJob(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, getTextResult(t, result).Text, "provide both")
 	})
+}
+
+// TestJobSignalDecodesFromWire guards against the Signal field drifting back to a
+// numeric type. The REST API sends the symbolic signal name (the agent sets it via
+// process.SignalString), so a *int typed field fails the whole response with
+// "cannot unmarshal string into Go struct field Job.items.signal of type int" —
+// one signal-killed job in a large build takes out every other job with it.
+//
+// The other tests in this file build buildkite.Job values directly through the
+// mock, which never exercises JSON decoding; this one starts from wire bytes.
+func TestJobSignalDecodesFromWire(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{"items":[
+		{"id":"job-1","state":"timed_out","signal":"SIGKILL","signal_reason":"timed_out"},
+		{"id":"job-2","state":"failed","signal":"SIGTERM","signal_reason":"agent_stop"},
+		{"id":"job-3","state":"passed","signal":null},
+		{"id":"job-4","state":"passed"}
+	]}`
+
+	var list buildkite.JobsList
+	require.NoError(t, json.Unmarshal([]byte(payload), &list))
+	require.Len(t, list.Items, 4)
+	assert.Equal(t, "SIGKILL", list.Items[0].Signal)
+	assert.Equal(t, "SIGTERM", list.Items[1].Signal)
+	assert.Empty(t, list.Items[2].Signal, "explicit null should decode to the zero value")
+	assert.Empty(t, list.Items[3].Signal, "absent signal should decode to the zero value")
+
+	// And that the decoded name survives the passthrough into the tool response.
+	mockJobs := &MockJobsClient{
+		ListByBuildFunc: func(ctx context.Context, org string, pipeline string, buildNumber string, opt *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return list, &buildkite.Response{}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{JobsClient: mockJobs})
+	_, handler, _ := ListJobs()
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListJobsArgs{
+		OrgSlug: "test-org", PipelineSlug: "test-pipeline", BuildNumber: "123", DetailLevel: "detailed",
+	})
+	require.NoError(t, err)
+
+	var jobs JobListResult[JobDetail]
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &jobs))
+	require.Len(t, jobs.Items, 4)
+	assert.Equal(t, "SIGKILL", jobs.Items[0].Signal)
+	assert.Equal(t, "SIGTERM", jobs.Items[1].Signal)
+	assert.Empty(t, jobs.Items[2].Signal)
 }


### PR DESCRIPTION
Job listing and job fetching fail outright for any job killed by a signal. The REST API returns the symbolic signal name — the agent sets it via [`process.SignalString`](https://github.com/buildkite/agent/blob/main/agent/run_job.go) — but `go-buildkite` v5.7.0, which we pin, typed `Job.Signal` as `*int`:

```
json: cannot unmarshal string into Go struct field Job.items.signal of type int
```

The SDK discards the entire response on a decode error, so one signal-killed job takes out every other job in the build. Timed-out jobs get SIGKILL'd, which means any build with a mass timeout — a 90-shard suite hitting its limit, say — returns nothing at all rather than 89 usable jobs.

- bump `go-buildkite/v5` v5.7.0 → v5.10.0; the field was corrected to `string` upstream in v5.8.0 ([buildkite/go-buildkite#350](https://github.com/buildkite/go-buildkite/pull/350))
- follow the type through `JobDetail.Signal`, which mirrored the same wrong `*int` and passed it straight through from `detailJob`
- add `TestJobSignalDecodesFromWire`, covering a signal name, an explicit `null`, and an absent field

## Behaviour change

`JobDetail.signal` in `list_jobs` / `get_job` output changes from a number to a string — `9` becomes `"SIGKILL"`. This is the field's real wire type; it has never successfully returned a number, since any response that would have populated it failed to decode first. Nothing downstream can be relying on the old shape.

## Why our tests missed this

Every existing job test constructs `buildkite.Job` values directly through `MockJobsClient`, so none of them exercise JSON decoding — the mock hands back an already-built struct and the wire format is never parsed. A `*int` field looks fine under that setup right up until it meets a real API response.

The added test starts from wire bytes instead. Worth noting it only closes the hole for this one field: the same blind spot covers the whole mocked tool surface, so wire-type drift in builds, artifacts, or annotations would land exactly the same way. Broader wire-level fixtures are worth doing separately.

## Verification

- one compile error across the 76-commit SDK jump, the expected `Signal` one; the `backoff` → `roko` dependency swap didn't move `go.sum`
- `go build ./...` clean, `golangci-lint run ./...` 0 issues, full suite green
- confirmed the new test fails against the broken version rather than merely passing: its payload unmarshalled with v5.7.0 reproduces the reported error verbatim

## Disclosures/Credits
- Claude generated the code changes and descriptions, reviewed by moi.
