### PR TITLE
Make cursor agent a choice in evals framework

### DIFF
--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -52,6 +52,11 @@ steps:
             # evals/evals.yaml). Add one line here (and a secrets mapping
             # below) per additional org.
             - MCP_EVAL_FRAMEWORK_BUILDKITE_ORG_BUILDKITE_API_TOKEN
+            # Cursor CLI auth, for evals.yaml entries with `agent: cursor`.
+            # cursor-agent talks to Cursor's backend, so the Buildkite Hosted
+            # Models Anthropic proxy (BUILDKITE_AGENT_ENDPOINT above) cannot
+            # front it.
+            - CURSOR_API_KEY
             - BUILDKITE_BUILD_URL
             - BUILDKITE_ORGANIZATION_SLUG
             - BUILDKITE_PIPELINE_SLUG
@@ -84,3 +89,6 @@ steps:
       # MCP_EVAL_FRAMEWORK_<ORG>_ORG_BUILDKITE_API_TOKEN convention), so the
       # mapping is 1:1.
       MCP_EVAL_FRAMEWORK_BUILDKITE_ORG_BUILDKITE_API_TOKEN: MCP_EVAL_FRAMEWORK_BUILDKITE_ORG_BUILDKITE_API_TOKEN
+      # Cursor CLI API key (generate in the Cursor Dashboard). Maps into
+      # the CURSOR_API_KEY env line above.
+      CURSOR_API_KEY: MCP_EVAL_FRAMEWORK_CURSOR_API_KEY

--- a/evals/Dockerfile
+++ b/evals/Dockerfile
@@ -16,6 +16,7 @@ FROM ubuntu:22.04
 # Expected arguments for tool versions.
 ARG NODE_VERSION="24"
 ARG GITHUB_CLI_VERSION
+ARG YQ_VERSION="v4.47.1"
 
 # Install system dependencies.
 RUN apt-get update && apt-get install -y \
@@ -32,7 +33,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install yq (mikefarah) so babystand.sh can parse the eval matrix (evals.yaml).
-RUN curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+# Pinned like the other tools above: 'latest' would make image builds
+# unreproducible and is a supply-chain risk.
+RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 \
     -o /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 
 # Install the GitHub CLI.
@@ -69,6 +72,14 @@ RUN chown -R agent:agent /workspace
 
 # Switch to the non-root user.
 USER agent
+
+# Install the Cursor CLI (cursor-agent) for evals.yaml entries with
+# `agent: cursor`. Installed as the agent user because the installer targets
+# $HOME/.local. NOTE: unlike the pinned tools above, Cursor's installer has no
+# documented version pin — an unreproducibility/supply-chain trade-off we
+# accept for now; revisit if Cursor publishes pinned release artifacts.
+RUN curl -fsS https://cursor.com/install | bash
+ENV PATH="/home/agent/.local/bin:${PATH}"
 
 # Default command
 CMD ["/bin/bash"]

--- a/evals/README.md
+++ b/evals/README.md
@@ -13,9 +13,34 @@ A set of artifacts, and annotations in the Buildkite build showing:
   * LLM agent metrics
   * High-level steps taken by LLM agent to complete scenarios
 
+## Supported agents
+
+`evals.yaml` entries choose the agent per scenario (`agent:` key):
+
+* `claude` — Claude Code CLI, run via `scripts/claude.sh` in CI. Auth comes from Buildkite Hosted Models (`ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` derived from the agent endpoint), the MCP server is passed with `--mcp-config`, and the session transcript under `~/.claude/projects/` feeds the audit and klaren steps.
+* `cursor` — Cursor CLI (`cursor-agent`), run via `scripts/cursor.sh` in CI. Differences, all forced by the CLI surface:
+  * Auth is `CURSOR_API_KEY` (Cursor's own backend; the Hosted Models Anthropic proxy can't front it). Map the secret in `.buildkite/pipeline.evals.yml`; entries are skipped loudly while it's unset.
+  * `model` must be a Cursor model id (`composer-1`, `sonnet-4.5`, `gpt-5.2`, ... — `cursor-agent --list-models`).
+  * No `--mcp-config` flag: a `.cursor/mcp.json` is generated inside the throwaway eval-repo clone, referencing the entry token as `${env:BUILDKITE_API_TOKEN}` (Cursor's documented interpolation syntax — no secret is written to disk; the generated file is also kept off the scenario branch via `.git/info/exclude` as diff hygiene), and servers are auto-approved with `--approve-mcps`.
+  * No `--append-system-prompt`: `prompts/system.md` is prepended to the user prompt (it lands in the user turn, not the system turn — a fidelity caveat when comparing against claude runs).
+  * No on-disk transcript: the raw `stream-json` capture stands in for it. That stream records tool calls as `tool_call` started/completed events and carries NO token usage, so `bk-tool-audit-v2.sh --agent cursor` reports tokens/cost as `null` — compare cursor runs on tool calls, duration, and the klaren review instead.
+  * Locally, cursor entries require `LOCAL_BYPASS_PERMISSION=true` (`--force`); the restricted allowlist mode below is claude-only for now (cursor's `.cursor/cli.json` permissions are not wired up).
+
+The klaren reviewer always runs on claude regardless of the entry's agent — it's the judge, not the subject under test, and a fixed reviewer keeps reviews comparable across agents.
+
+### Cursor cloud agents (not implemented — options)
+
+Besides the CLI, Cursor exposes hosted "cloud agents" that could run scenarios without us managing the container/CLI at all, via its REST API (Bearer/Basic auth with a Cursor Dashboard API key):
+
+* `POST https://api.cursor.com/v1/agents` with `prompt.text`, `repos[]` (GitHub URL + `startingRef`), and optional `model.id` — the agent clones the repo, works, and pushes branches/PRs itself.
+* Poll `GET /v1/agents/{agentId}/runs/{runId}` for `status` (`RUNNING`/`FINISHED`/`ERROR`/...), or stream `GET .../stream` (SSE) for real-time tool calls and assistant text — that stream could feed the same parser/annotation pipeline.
+* Terminal runs return `result` (final reply), `durationMs`, and `git.branches` (pushed branches / PR URLs); `GET /v1/agents/{agentId}/usage` returns token usage (which the CLI's stream-json lacks).
+
+Fit with this harness: a `run_cursor_cloud()` would replace the clone + CLI invocation with create-agent → poll/stream → collect results. Three impedance mismatches to solve first: (1) MCP — cloud agents run in Cursor's environment and cannot spawn our locally-built `--read-only` stdio binary, so the scenario repo would need Buildkite's hosted HTTP MCP server configured in its `.cursor/mcp.json`, which changes what's under test from "this PR's source build" to a deployed server; (2) scenario setup (the branch push) still has to happen from CI before launching the agent; (3) containment shifts from our throwaway container to Cursor's sandbox plus the repo/token permissions granted to it. Cursor's Slack bot (`@Cursor`) and BugBot are further entry points, but they're interactive/review-oriented and a poor fit for a scripted matrix.
+
 ## Permission posture
 
-In CI the LLM agent runs with `--permission-mode bypassPermissions` and NO tool allowlist. This is deliberate: real users rarely restrict tools, so tool CHOICE is part of what the eval measures — an agent that reaches for `curl` against the Buildkite API instead of the MCP tools is signal that the tools aren't compelling. Check the `eval-tools` annotation on each build to see what was actually called.
+In CI the LLM agent runs with `--permission-mode bypassPermissions` (claude) / `--force --approve-mcps` (cursor) and NO tool allowlist. This is deliberate: real users rarely restrict tools, so tool CHOICE is part of what the eval measures — an agent that reaches for `curl` against the Buildkite API instead of the MCP tools is signal that the tools aren't compelling. Check the `eval-tools` annotation on each build to see what was actually called.
 
 Containment does not come from permissions; it comes from layers the agent cannot talk its way around:
 * The docker container sandbox (throwaway, non-root)
@@ -23,8 +48,8 @@ Containment does not come from permissions; it comes from layers the agent canno
 * The read-only Buildkite API token
 
 Locally there is no container sandbox, so the posture is a conscious choice via `LOCAL_BYPASS_PERMISSION` (required, deliberately NO default — the script fails loudly and points here):
-* `false`: restricted mode — the agent gets `Edit`, `go`/`make`/`git` Bash, and the MCP server's tools (server name derived from `mcp.json`, override with `MCP_SERVER_NAME`). Safe on a host machine, but NOT comparable to CI runs since the agent's tool choice is constrained.
-* `true`: CI parity — `bypassPermissions`, i.e. the agent has unrestricted Bash ON YOUR MACHINE. Use with care.
+* `false`: restricted mode — the agent gets `Edit`, `go`/`make`/`git` Bash, and the MCP server's tools (server name derived from `mcp.json`, override with `MCP_SERVER_NAME`). Safe on a host machine, but NOT comparable to CI runs since the agent's tool choice is constrained. Claude-only: cursor entries are skipped in this mode (see "Supported agents").
+* `true`: CI parity — `bypassPermissions` / `--force`, i.e. the agent has unrestricted Bash ON YOUR MACHINE. Use with care.
 
 ## Setup
 

--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -5,10 +5,19 @@
 #                 Buildkite annotations, and is the key used to match this entry
 #                 against the same entry in a previous build for comparison.
 #                 Keep it stable across builds; keep it unique within this file.
-#   agent         Which LLM agent runs the prompt. Only 'claude' is implemented;
-#                 other values are skipped with a loud warning (codex/opencode
-#                 land in a later stage).
-#   model         Passed to the agent as --model.
+#   agent         Which LLM agent runs the prompt: 'claude' (Claude Code CLI)
+#                 or 'cursor' (Cursor CLI, cursor-agent). Other values are
+#                 skipped with a loud warning (codex/opencode land in a later
+#                 stage). Cursor entries additionally need CURSOR_API_KEY (see
+#                 .buildkite/pipeline.evals.yml) and are skipped loudly when it
+#                 is unset; their metrics are partial (cursor-agent's
+#                 stream-json emits no token usage, so tokens/cost are null)
+#                 and prompts/system.md is prepended to the prompt rather than
+#                 appended as a system prompt (no cursor-agent equivalent).
+#   model         Passed to the agent as --model. Model ids are per-agent
+#                 namespaces: claude-* ids for claude; Cursor ids (composer-1,
+#                 sonnet-4.5, gpt-5.2, ... — see `cursor-agent --list-models`)
+#                 for cursor. Defaults: claude-opus-4-8 / composer-1.
 #   prompt        Name of a template under prompts/<prompt>.md. Rendered with the
 #                 substitution vars below (Go-style {{.KEY}} placeholders).
 #   scenario:
@@ -72,8 +81,27 @@ matrix:
         # Hand the generated branch name to the prompt template.
         echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
     mcp_version: source
-    # compare_base defaults to the last successful `main` build for this id.
     # compare_target defaults to this run.
+
+  # The same scenario driven by the Cursor CLI instead of Claude Code — lets a
+  # build compare how two different agents fare against the same MCP server.
+  # Requires CURSOR_API_KEY (uncomment its env + secrets lines in
+  # .buildkite/pipeline.evals.yml); skipped loudly while unset. NOTE: metrics
+  # are partial for cursor runs (no token usage in its stream-json), so
+  # comparisons should lean on tool calls, duration, and the klaren review.
+  #- id: red-to-green-complete-cursor
+  #  agent: cursor
+  #  model: claude-opus-4-8-thinking-high
+  #  prompt: red-to-green-complete
+  #  scenario:
+  #    setup: |
+  #      SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
+  #      git fetch
+  #      git checkout -b "$SCENARIO_BRANCH" origin/test-broken-and-failed-jobs
+  #      git push -u origin HEAD
+  #      echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
+  #  compare_base: build:94
+  #  mcp_version: source
 
   # Diagnosis-only variant: point at ANY existing red build — including one on a
   # pipeline we don't own and must not mutate — and produce a written diagnosis.
@@ -95,7 +123,8 @@ matrix:
   # A no-build scenario: analyze an existing build and propose speedups. Produces
   # only a written proposal — no git push, no new Buildkite build — so it is
   # compared purely via its runs/ bundle.
-  # NOTE: Tweak and uncomment to run this
+  # UNCOMMENT: This is an example of eval using analyze-build prompt. Uncomment to
+  #            test
   # - id: analyze-build-speed
   #   agent: claude
   #   model: claude-opus-4-8

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -27,6 +27,11 @@ command -v yq >/dev/null || { echo "babystand: yq is required to parse $EVALS_CO
 # would resolve to a different file or none at all.
 EVALS_CONFIG="$(cd "$(dirname "$EVALS_CONFIG")" && pwd)/$(basename "$EVALS_CONFIG")"
 
+# Both are required (no default), like LOCAL_BYPASS_PERMISSION below; fail with
+# a clear message instead of set -u's bare "unbound variable".
+: "${LOCAL_CI:?must be set to true or false — see evals/README.md}"
+: "${DEBUG_PERMISSIONS:?must be set to true or false — see evals/README.md}"
+
 if [[ "${LOCAL_CI}" == "true" ]]; then
   WAIT_STATUS_STRING="(perform local CI)"
 else
@@ -166,6 +171,19 @@ annotate_codeblock() {
         || echo "WARNING: failed to annotate '$context'" >&2
 }
 
+# run_agent <agent> <rendered_prompt_file> <model> <log_file> -- dispatch to
+# the per-agent runner. Every runner shares one contract: stream the run to the
+# build log (via tee) and set the caller's SESSION_ID / TRANSCRIPT /
+# EVAL_RESULT_FILE variables (bash dynamic scoping: the caller declares them
+# `local` before calling). Unknown agents were already skipped in run_entry.
+run_agent() {
+    local agent="$1"; shift
+    case "$agent" in
+        claude) run_claude "$@" ;;
+        cursor) run_cursor "$@" ;;
+    esac
+}
+
 # run_claude <rendered_prompt_file> <model> <log_file>  -- runs the agent,
 # streaming its output to the build log (via tee), and sets the caller's
 # SESSION_ID / TRANSCRIPT / EVAL_RESULT_FILE variables (bash dynamic scoping: the
@@ -216,18 +234,94 @@ run_claude() {
     fi
 }
 
-# run_entry <entry_json> -- execute one matrix entry end to end. A failure in
-# one entry must not abort the rest of the matrix, so the driver invokes this on
-# the left of `||` — which also disables errexit throughout this function, so
-# any failure that should fail the entry needs an explicit check + return here
-# (a mis-configured entry is a skip: warn + return 0; a failed scenario setup
-# or agent run is a failure: return non-zero, counted by the driver).
+# run_cursor <rendered_prompt_file> <model> <log_file> -- the Cursor CLI
+# (cursor-agent) analogue of run_claude, same contract. Cursor-specific
+# differences (details in scripts/cursor.sh):
+#   - auth is CURSOR_API_KEY (no Buildkite Hosted Models path); entries are
+#     skipped in run_entry when it is unset
+#   - no --mcp-config flag: a .cursor/mcp.json is generated in the working
+#     copy (cwd), referencing the entry token as ${env:BUILDKITE_API_TOKEN}
+#     (no secret on disk; cursor resolves it at server spawn)
+#   - no --append-system-prompt: prompts/system.md is prepended to the prompt
+#   - no on-disk transcript: the raw stream-json capture IS the transcript,
+#     and it carries no token usage (metrics are partial for cursor runs)
+#   - permission posture is --force only; the restricted local allowlist
+#     (cursor's .cursor/cli.json permissions) is NOT wired up, so restricted
+#     local cursor entries are skipped in run_entry
+# Like run_claude, returns non-zero when the agent pipeline fails, and the
+# pipeline must be checked explicitly: errexit is dead in here (run_entry is
+# invoked on the left of `||`), so an unguarded failure would fall through the
+# pointer extraction and read as success.
+run_cursor() {
+    local prompt_file="$1" model="$2" log="$3"
+    local args=( --output-format stream-json --model "$model" )
+    if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+        # Sandboxed CI execution via cursor.sh (owns the generated
+        # .cursor/mcp.json, the prepended system prompt, and the parser).
+        if ! ANNOTATION_CONTEXT_PREFIX="eval-$ENTRY_ID" \
+            "$SCRIPT_DIR/cursor.sh" "$prompt_file" "${args[@]}" | tee "$log"; then
+            return 1
+        fi
+        SESSION_ID=$(sed -n 's/^CURSOR_SESSION_ID=//p' "$log" | tail -n1)
+        TRANSCRIPT=$(sed -n 's/^CURSOR_TRANSCRIPT=//p' "$log" | tail -n1)
+        EVAL_RESULT_FILE=$(sed -n 's/^CURSOR_RESULT_FILE=//p' "$log" | tail -n1)
+    else
+        # Local execution (LOCAL_BYPASS_PERMISSION=true only; run_entry skips
+        # otherwise). Generate the project MCP config in the clone (cwd) from
+        # the harness mcp.json, making the server command absolute (cwd is the
+        # clone, but don't depend on cursor's relative-path resolution). No
+        # secret is materialized: the token is referenced as
+        # ${env:BUILDKITE_API_TOKEN} (Cursor's documented mcp.json
+        # interpolation syntax), resolved at server-spawn time from this
+        # process's environment — run_entry exports the entry token on the
+        # run_agent call.
+        command -v cursor-agent >/dev/null || {
+            echo "ERROR: cursor-agent not found on PATH (install: curl -fsS https://cursor.com/install | bash)" >&2
+            return 1
+        }
+        mkdir -p .cursor
+        jq --arg cwd "$PWD" \
+            '.mcpServers |= with_entries(
+               .value.env.BUILDKITE_API_TOKEN = "${env:BUILDKITE_API_TOKEN}"
+               | .value.command |= (if startswith("./") then $cwd + ltrimstr(".") else . end))' \
+            "$ROOT_DIR/mcp.json" > .cursor/mcp.json
+        # Diff hygiene, not a security control (the file holds no secret):
+        # keep the generated config off the scenario branch the agent commits
+        # and pushes to (see cursor.sh for the full rationale). The clone is
+        # always a git repo here.
+        local git_dir; git_dir="$(git rev-parse --git-dir)"
+        mkdir -p "$git_dir/info"
+        echo ".cursor/" >> "$git_dir/info/exclude"
+        if ! cursor-agent -p "$(cat "$ROOT_DIR/prompts/system.md")
+
+$(cat "$prompt_file")" --force --approve-mcps "${args[@]}" | tee "$log"; then
+            return 1
+        fi
+        SESSION_ID=$(jq -r 'select(.type == "system" and .subtype == "init") | .session_id' "$log" | head -n1)
+        # cursor-agent's stdout is pure stream-json locally, so the log IS the
+        # transcript.
+        TRANSCRIPT="$log"
+        EVAL_RESULT_FILE="$(mktemp)"
+        jq -r 'select(.type == "result") | .result // empty' "$log" > "$EVAL_RESULT_FILE" 2>/dev/null || true
+    fi
+}
+
+# run_entry <entry_json> -- execute one matrix entry end to end. Best-effort: a
+# failure in one entry logs and returns without aborting the rest of the matrix.
 run_entry() {
     local entry="$1"
     local ENTRY_ID AGENT MODEL PROMPT_NAME MCP_VERSION SETUP COMPARE_BASE COMPARE_TARGET TOKEN_ENV
     ENTRY_ID=$(jq -r '.id'                    <<<"$entry")
     AGENT=$(jq -r '.agent // "claude"'        <<<"$entry")
-    MODEL=$(jq -r '.model // "claude-opus-4-8"' <<<"$entry")
+    MODEL=$(jq -r '.model // ""'              <<<"$entry")
+    # Model ids are per-agent namespaces (cursor rejects claude-* ids; see
+    # `cursor-agent --list-models`), so the default is agent-aware.
+    if [[ -z "$MODEL" ]]; then
+        case "$AGENT" in
+            cursor) MODEL="composer-1" ;;
+            *)      MODEL="claude-opus-4-8" ;;
+        esac
+    fi
     PROMPT_NAME=$(jq -r '.prompt'             <<<"$entry")
     MCP_VERSION=$(jq -r '.mcp_version // "source"' <<<"$entry")
     SETUP=$(jq -r '.scenario.setup // ""'     <<<"$entry")
@@ -237,10 +331,25 @@ run_entry() {
 
     echo "+++ :robot_face: Eval entry: $ENTRY_ID"
 
-    if [[ "$AGENT" != "claude" ]]; then
-        echo "WARNING: entry '$ENTRY_ID' uses agent '$AGENT' which is not implemented yet; skipping." >&2
-        return 0
-    fi
+    case "$AGENT" in
+        claude) ;;
+        cursor)
+            # Cursor preflight: skip (loudly, like token_env below) rather than
+            # fail mid-run — the failure modes are all environmental.
+            if [[ -z "${CURSOR_API_KEY:-}" ]]; then
+                echo "WARNING: entry '$ENTRY_ID' uses agent 'cursor' but CURSOR_API_KEY is unset (see .buildkite/pipeline.evals.yml); skipping." >&2
+                return 0
+            fi
+            if [[ "${RUN_IN_CI:-false}" != "true" && "$LOCAL_BYPASS_PERMISSION" != "true" ]]; then
+                echo "WARNING: entry '$ENTRY_ID': local cursor runs require LOCAL_BYPASS_PERMISSION=true (cursor-agent's restricted allowlist — .cursor/cli.json permissions — is not wired up); skipping." >&2
+                return 0
+            fi
+            ;;
+        *)
+            echo "WARNING: entry '$ENTRY_ID' uses agent '$AGENT' which is not implemented yet; skipping." >&2
+            return 0
+            ;;
+    esac
     if [[ -n "$MCP_VERSION" && "$MCP_VERSION" != "source" ]]; then
         echo "NOTICE: entry '$ENTRY_ID' requests mcp_version '$MCP_VERSION', which is not yet wired into the image build (follow-up); running the in-image 'source' binary." >&2
     fi
@@ -313,7 +422,6 @@ run_entry() {
     fi
     local RENDERED; RENDERED="$(mktemp)"
     render_prompt "$TEMPLATE" "$VARS_FILE" > "$RENDERED"
-    # Any {{.KEY}} the vars didn't supply survives verbatim into the prompt —
     # the agent would silently receive a literal placeholder. Surface it.
     local UNRESOLVED
     UNRESOLVED="$(grep -oE '\{\{\.[A-Za-z_][A-Za-z0-9_]*\}\}' "$RENDERED" | sort -u | tr '\n' ' ' || true)"
@@ -325,9 +433,9 @@ run_entry() {
 
     # --- Run the agent ------------------------------------------------------
     local LOG="/tmp/babystand-$RUN_KEY.log"
-    local SESSION_ID="" TRANSCRIPT="" EVAL_RESULT_FILE=""   # set by run_claude (dynamic scope)
+    local SESSION_ID="" TRANSCRIPT="" EVAL_RESULT_FILE=""   # set by the runner (dynamic scope)
     local EVAL_START; EVAL_START=$(date +%s)
-    if ! BUILDKITE_API_TOKEN="$ENTRY_TOKEN" run_claude "$RENDERED" "$MODEL" "$LOG"; then
+    if ! BUILDKITE_API_TOKEN="$ENTRY_TOKEN" run_agent "$AGENT" "$RENDERED" "$MODEL" "$LOG"; then
         echo "ERROR: [$ENTRY_ID] agent run failed; skipping audit/bundle/compare for this entry (log: $LOG)" >&2
         return 1
     fi
@@ -338,12 +446,19 @@ run_entry() {
     # --- Audit: tools + metrics --------------------------------------------
     local AUDIT_TOOLS_FILE AUDIT_METRICS_FILE
     AUDIT_TOOLS_FILE="$(mktemp)"; AUDIT_METRICS_FILE="$(mktemp)"
+    # --agent switches the transcript dialect: cursor's stream-json records
+    # tool calls as standalone tool_call events, not Claude-style tool_use
+    # content blocks, and emits no token usage (metrics come back partial).
     echo "--- :hammer_and_wrench: [$ENTRY_ID] tool calls"
-    "$SCRIPT_DIR/bk-tool-audit-v2.sh" --all "$TRANSCRIPT" | tee "$AUDIT_TOOLS_FILE" || true
+    "$SCRIPT_DIR/bk-tool-audit-v2.sh" --agent "$AGENT" --all "$TRANSCRIPT" | tee "$AUDIT_TOOLS_FILE" || true
     echo "--- :bar_chart: [$ENTRY_ID] session metrics"
-    "$SCRIPT_DIR/bk-tool-audit-v2.sh" metrics "$TRANSCRIPT" | tee "$AUDIT_METRICS_FILE" || true
+    "$SCRIPT_DIR/bk-tool-audit-v2.sh" --agent "$AGENT" metrics "$TRANSCRIPT" | tee "$AUDIT_METRICS_FILE" || true
 
     # --- Klaren review (best-effort) ---------------------------------------
+    # Klaren always runs on claude regardless of the entry's agent: it is the
+    # judge, not the subject under test, and holding the reviewer fixed keeps
+    # reviews comparable across agents. It only reads the transcript file, so
+    # cursor's stream-json capture works as input too.
     # Use the harness copy of the prompt, not the checked-out subject-under-test
     # copy.
     echo "--- :female-detective: [$ENTRY_ID] klaren review"

--- a/evals/scripts/bk-eval-compare.sh
+++ b/evals/scripts/bk-eval-compare.sh
@@ -119,10 +119,15 @@ resolve_src() {
 metrics_table() {
     jq -rn --slurpfile b "$1" --slurpfile c "$2" --arg bl "$3" --arg cl "$4" '
         ($b[0] // {}) as $B | ($c[0] // {}) as $C |
-        def num(x): (x // 0);
         def rnd(x): ((x*100|round)/100);
         def sign(x): (rnd(x)) as $y | (if $y > 0 then "+\($y)" elif $y < 0 then "\($y)" else "0" end);
-        def r(lbl; bv; cv): "| \(lbl) | \(num(bv)) | \(num(cv)) | \(sign(num(cv)-num(bv))) |";
+        # null means "not reported" (cursor runs deliberately emit tokens/cost
+        # as null — cursor-agent provides no usage data): render N/A and skip
+        # the delta rather than coercing to 0, which would read as a free,
+        # zero-token run with a misleading delta.
+        def cell(x): if x == null then "N/A" else x end;
+        def delta(bv; cv): if bv == null or cv == null then "N/A" else sign(cv - bv) end;
+        def r(lbl; bv; cv): "| \(lbl) | \(cell(bv)) | \(cell(cv)) | \(delta(bv; cv)) |";
         [
           "| Metric | Base (\($bl)) | Target (\($cl)) | Δ |",
           "|---|---:|---:|---:|",

--- a/evals/scripts/bk-tool-audit-v2.sh
+++ b/evals/scripts/bk-tool-audit-v2.sh
@@ -20,6 +20,11 @@
 #   --names      Print only "<count> <tool>" summary instead of full params
 #   --results    Also show each call's tool_result (matched by tool_use_id)
 #   --project P  Use project dir for path P instead of the current directory
+#   --agent A    Transcript dialect: 'claude' (default; Claude Code session
+#                jsonl / stream-json — tool calls are tool_use content blocks)
+#                or 'cursor' (cursor-agent stream-json capture — tool calls are
+#                standalone tool_call started/completed events, and NO token
+#                usage is emitted, so `metrics` reports tokens/cost as null).
 #
 # Pricing for `metrics` (USD per million tokens) is overridable via env vars;
 # defaults are Claude Opus 4.8 rates:
@@ -35,10 +40,11 @@ BK_PRICE_CACHE_5M="${BK_PRICE_CACHE_5M:-6.25}"
 BK_PRICE_CACHE_1H="${BK_PRICE_CACHE_1H:-10}"
 BK_PRICE_CACHE_READ="${BK_PRICE_CACHE_READ:-0.5}"
 
-TOOL_FILTER='startswith("mcp__buildkite-mcp-server__")'
+TOOL_FILTER=''
 NAMES_ONLY=0
 WITH_RESULTS=0
 PROJECT_PATH="$PWD"
+AGENT="claude"
 
 # --- parse options ---------------------------------------------------------
 while [[ "${1:-}" == -* ]]; do
@@ -47,10 +53,21 @@ while [[ "${1:-}" == -* ]]; do
     --names)   NAMES_ONLY=1; shift ;;
     --results) WITH_RESULTS=1; shift ;;
     --project) PROJECT_PATH="${2:?--project needs a path}"; shift 2 ;;
-    -h|--help) sed -n '2,34p' "$0"; exit 0 ;;
+    --agent)   AGENT="${2:?--agent needs claude or cursor}"; shift 2 ;;
+    -h|--help) sed -n '2,39p' "$0"; exit 0 ;;
     *) echo "unknown option: $1" >&2; exit 2 ;;
   esac
 done
+case "$AGENT" in claude|cursor) ;; *) echo "unsupported --agent: $AGENT" >&2; exit 2 ;; esac
+
+# Default tool filter (without --all): claude MCP tool names carry the
+# mcp__<server>__ prefix; cursor's tool_call event keys are per-tool camelCase
+# names (readToolCall, mcpToolCall, ...) with no comparable server prefix, so
+# no default narrowing is possible there — everything is included.
+if [[ -z "$TOOL_FILTER" ]]; then
+  if [[ "$AGENT" == "cursor" ]]; then TOOL_FILTER='true'
+  else TOOL_FILTER='startswith("mcp__buildkite-mcp-server__")'; fi
+fi
 
 command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 
@@ -66,15 +83,47 @@ newest_session() {
   ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1
 }
 
-# Emit one compact JSON object per tool_use in a transcript.
+# Emit one compact JSON object per tool call in a transcript.
+# claude: tool_use content blocks inside assistant messages.
+# cursor: standalone {"type":"tool_call","subtype":"started",...} events whose
+#   .tool_call object has exactly one key naming the tool KIND (readToolCall,
+#   shellToolCall, ...), with the call's arguments under that key's .args.
+#   MCP invocations are wrapped: mcpToolCall's real identity lives at
+#   .args.toolName + .args.serverIdentifier and the real tool arguments nest
+#   at .args.args (observed schema — eval build 98). Normalize those to
+#   claude-style mcp__<server>__<tool> so cross-agent tool tables line up;
+#   getMcpToolsToolCall (schema fetch) stays as-is — it is a distinct
+#   tool-discovery step worth seeing in audits. function.name is a defensive
+#   fallback for the OpenAI-style shape other cursor versions may emit.
+CURSOR_TOOL_NAME_JQ='
+  def cursor_tool_name($t):
+    ($t.value.args // {}) as $a
+    | if $t.key == "mcpToolCall" and (($a.toolName // $a.name) != null) then
+        "mcp__\($a.serverIdentifier // $a.providerIdentifier // "mcp")__\($a.toolName // $a.name)"
+      elif (($a.function? | type) == "object") and ($a.function.name != null) then
+        $a.function.name
+      else $t.key end;'
 extract() {
   local f="$1"
-  jq -c --argjson names "$NAMES_ONLY" '
-    select(.message.content) | .message.content[]?
-    | select(.type=="tool_use" and (.name | '"$TOOL_FILTER"'))
-    | if $names == 1 then {tool: .name}
-      else {id: .id, tool: .name, input: .input} end
-  ' "$f"
+  if [[ "$AGENT" == "cursor" ]]; then
+    jq -c --argjson names "$NAMES_ONLY" "$CURSOR_TOOL_NAME_JQ"'
+      select(.type=="tool_call" and .subtype=="started" and (.tool_call|type=="object"))
+      | (.tool_call | to_entries[0]) as $t
+      | ($t.value.args // {}) as $a
+      | cursor_tool_name($t) as $name
+      | (if $t.key == "mcpToolCall" then ($a.args // {}) else $a end) as $input
+      | select($name | '"$TOOL_FILTER"')
+      | if $names == 1 then {tool: $name}
+        else {id: (.call_id // null), tool: $name, input: $input} end
+    ' "$f"
+  else
+    jq -c --argjson names "$NAMES_ONLY" '
+      select(.message.content) | .message.content[]?
+      | select(.type=="tool_use" and (.name | '"$TOOL_FILTER"'))
+      | if $names == 1 then {tool: .name}
+        else {id: .id, tool: .name, input: .input} end
+    ' "$f"
+  fi
 }
 
 print_session() {
@@ -88,14 +137,26 @@ print_session() {
   fi
 
   if [[ "$WITH_RESULTS" == 1 ]]; then
-    # Map tool_use_id -> truncated result text.
-    local map; map="$(jq -cn '
-      [ inputs | (.message.content? // []) | select(type=="array") | .[]
-        | select(.type=="tool_result")
-        | {(.tool_use_id): ((.content // "")
-             | if type=="array" then (map(.text // "") | join("")) else tostring end
-             | gsub("\n";" ") | .[0:300])} ]
-      | add // {}' "$f")"
+    # Map call id -> truncated result text (claude: tool_use_id on tool_result
+    # blocks; cursor: call_id on tool_call completed events, result under the
+    # tool key's .result — .success on success, the whole object otherwise).
+    local map
+    if [[ "$AGENT" == "cursor" ]]; then
+      map="$(jq -cn '
+        [ inputs
+          | select(.type=="tool_call" and .subtype=="completed" and .call_id and (.tool_call|type=="object"))
+          | (.tool_call | to_entries[0].value.result // {}) as $r
+          | {(.call_id): (($r.success // $r) | tostring | gsub("\n";" ") | .[0:300])} ]
+        | add // {}' "$f")"
+    else
+      map="$(jq -cn '
+        [ inputs | (.message.content? // []) | select(type=="array") | .[]
+          | select(.type=="tool_result")
+          | {(.tool_use_id): ((.content // "")
+               | if type=="array" then (map(.text // "") | join("")) else tostring end
+               | gsub("\n";" ") | .[0:300])} ]
+        | add // {}' "$f")"
+    fi
     extract "$f" | jq -c --argjson map "$map" \
       '. + {result: ($map[.id] // "(no result captured)")} | del(.id)'
   else
@@ -114,6 +175,36 @@ metrics() {
   local snap; snap="$(mktemp -t bk-audit.XXXXXX)"
   trap 'rm -f "$snap"' RETURN
   cp "$f" "$snap"
+
+  # cursor-agent's stream-json emits no token usage and no per-event
+  # timestamps, so the cursor dialect reports what IS available — message and
+  # tool-call counts, the init event's model, and the result event's
+  # duration_ms — with tokens/cost explicitly null (comparisons must not read
+  # them as zero-cost runs). Keys match the claude output where the meaning
+  # matches, so bk-eval-compare.sh diffs stay line-comparable.
+  if [[ "$AGENT" == "cursor" ]]; then
+    echo "# session: $f" >&2
+    # Tool names use the same normalization as extract() (mcpToolCall ->
+    # mcp__<server>__<tool>), so metrics and tool listings agree.
+    jq -nr "$CURSOR_TOOL_NAME_JQ"'
+      [inputs | select(type=="object")] as $all
+      | ($all | map(select(.type=="tool_call" and .subtype=="started" and (.tool_call|type=="object"))
+                    | (.tool_call | to_entries[0]) as $t | cursor_tool_name($t))) as $tools
+      | ($all | map(select(.type=="result")) | last) as $res
+      | ($all | map(select(.type=="system" and .subtype=="init")) | first) as $init
+      | {
+          user_messages: ($all | map(select(.type=="user")) | length),
+          assistant_responses: ($all | map(select(.type=="assistant")) | length),
+          duration_min: (if ($res.duration_ms? // null) != null then ($res.duration_ms/60000|floor) else null end),
+          models: {(($init.model? // "unknown")): 1},
+          tokens: null,
+          tool_calls_total: ($tools | length),
+          tool_calls_by_name: ($tools | group_by(.) | map("\(length) \(.[0])") | sort | reverse),
+          est_cost_usd: null
+        }
+    ' "$snap"
+    return
+  fi
 
   local prices
   prices="$(jq -n \

--- a/evals/scripts/cursor.sh
+++ b/evals/scripts/cursor.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+#
+# cursor.sh — CI wrapper for the Cursor CLI (cursor-agent), the `agent: cursor`
+# analogue of claude.sh. Same contract: <prompt_file> [KEY=VALUE ...] [flags],
+# streams the run to stdout via the parser, and emits CURSOR_SESSION_ID /
+# CURSOR_TRANSCRIPT / CURSOR_RESULT_FILE pointers for the caller (babystand.sh).
+#
+# Differences from claude.sh, all forced by the cursor-agent CLI surface:
+#   - Auth is CURSOR_API_KEY. There is no Buildkite Hosted Models path: the
+#     hosted proxy fronts the Anthropic API only, and cursor-agent talks to
+#     Cursor's own backend.
+#   - No --mcp-config flag: cursor-agent discovers .cursor/mcp.json in the
+#     project (cwd). We generate it from the harness mcp_in_ci.json with the
+#     token referenced as ${env:BUILDKITE_API_TOKEN} (Cursor's documented
+#     interpolation syntax), so no secret is ever written to disk.
+#   - No --append-system-prompt: prompts/system.md is prepended to the user
+#     prompt instead. Fidelity caveat: it lands in the user turn, not the
+#     system turn.
+#   - No on-disk transcript in a documented location: the raw stream-json
+#     capture IS the transcript (and it carries no token usage — metrics are
+#     partial for cursor runs; see bk-tool-audit-v2.sh).
+
+set -euo pipefail
+
+# Resolve the harness location from this script's own path, so the parser, MCP
+# config and system prompt keep resolving even when the caller has cd'd into a
+# separate git checkout (the subject under test) as the working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Run as non-root user if currently root
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Running as root, switching to non-root user..."
+
+    # Create a non-root user if it doesn't exist
+    if ! id -u agent >/dev/null 2>&1; then
+        useradd -m -s /bin/bash agent
+    fi
+
+    # Give agent ownership of the current directory
+    chown -R agent:agent "$(pwd)"
+
+    # Switch to agent and re-run this script
+    exec su agent -c "$0 $*"
+fi
+
+command -v cursor-agent >/dev/null || {
+    echo "Error: cursor-agent not found on PATH (install: curl -fsS https://cursor.com/install | bash)"
+    exit 1
+}
+
+# Cursor authenticates with its own API key (see header). babystand.sh skips
+# cursor entries when this is unset, so this is a backstop for direct callers.
+: "${CURSOR_API_KEY:?cursor.sh requires CURSOR_API_KEY — map the secret in .buildkite/pipeline.evals.yml}"
+
+# Configure GitHub authentication using gh CLI if GITHUB_TOKEN is available
+if [ -n "$GITHUB_TOKEN" ]; then
+    echo "Configuring GitHub authentication with gh CLI..."
+    echo "$GITHUB_TOKEN" | gh auth login --with-token || {
+        echo "Warning: Failed to authenticate with gh CLI, falling back to git token authentication"
+    }
+
+    # Verify gh authentication and setup git integration
+    if gh auth status >/dev/null 2>&1; then
+        echo "Successfully authenticated with GitHub via gh CLI"
+        gh auth setup-git || {
+            echo "Warning: Failed to setup git integration with gh CLI"
+        }
+    else
+        echo "Warning: gh CLI authentication verification failed"
+    fi
+fi
+
+# Parse arguments
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <prompt_file> [KEY=VALUE ...]"
+    echo
+    echo "Arguments:"
+    echo "  prompt_file    Path to the prompt markdown file"
+    echo "  KEY=VALUE      Optional key-value pairs for token replacement"
+    echo
+    echo "Example:"
+    echo "  $0 prompts/user.md BuildURL=https://example.com/build/123"
+    exit 1
+fi
+
+PROMPT_FILE="$1"
+shift
+
+# Verify prompt file exists
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "Error: Prompt file not found: $PROMPT_FILE"
+    exit 1
+fi
+
+# Load the system prompt — prepended below (no --append-system-prompt in
+# cursor-agent; see header).
+SYSTEM_PROMPT=$(cat "$ROOT_DIR/prompts/system.md") || {
+    echo "Failed to read system.md file"
+    exit 1
+}
+
+# Read prompt content
+prompt_content=$(cat "$PROMPT_FILE") || {
+    echo "Failed to read prompt file: $PROMPT_FILE"
+    exit 1
+}
+
+echo "--- :scroll: Processing prompt: $PROMPT_FILE"
+
+# Split the remaining arguments: KEY=VALUE pairs substitute {{.KEY}} in the
+# prompt, while everything else (flags such as --output-format, --model, ...)
+# is forwarded verbatim to the cursor-agent CLI.
+CURSOR_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" =~ ^([A-Za-z0-9_]+)=(.*)$ ]]; then
+        key="${BASH_REMATCH[1]}"
+        value="${BASH_REMATCH[2]}"
+        echo "Replacing {{.$key}} with: $value"
+        prompt_content="${prompt_content//\{\{.$key\}\}/$value}"
+    else
+        CURSOR_ARGS+=("$arg")
+    fi
+done
+
+prompt_content="$SYSTEM_PROMPT
+
+$prompt_content"
+
+# Generate the project MCP config in cwd (the eval-repo clone) from the
+# harness config. No secret is materialized: the token is referenced as
+# ${env:BUILDKITE_API_TOKEN} — Cursor's documented mcp.json interpolation
+# syntax (distinct from Claude's ${VAR}) — and cursor-agent resolves it at
+# server-spawn time from this process's environment. Fail-safe: a cursor
+# version that failed to resolve it would hand the server the literal
+# placeholder and 401 loudly — a visible failure, not a leak.
+mkdir -p .cursor
+jq '.mcpServers |= with_entries(.value.env.BUILDKITE_API_TOKEN = "${env:BUILDKITE_API_TOKEN}")' \
+    "$ROOT_DIR/mcp_in_ci.json" > .cursor/mcp.json
+# Diff hygiene, not a security control (the file holds no secret): the agent
+# is told to commit and push its fixes, and a plain `git add -A` would drag
+# this generated file onto the scenario branch. info/exclude is local-only
+# (never committed), so the scenario diff stays clean. No git dir means
+# nothing can be committed; skipping is safe there.
+if git_dir="$(git rev-parse --git-dir 2>/dev/null)"; then
+    mkdir -p "$git_dir/info"
+    echo ".cursor/" >> "$git_dir/info/exclude"
+fi
+
+echo "--- :robot_face: Starting Cursor agent"
+
+# Tee the raw stream-json output so we can recover the session id after the
+# run, while still piping it through the parser for human-readable rendering.
+# NOTE: the parser requires --output-format=stream-json; the caller is
+# responsible for passing it (babystand.sh does).
+# Permission posture matches claude.sh's bypassPermissions: --force allows all
+# commands, --approve-mcps skips the MCP server approval prompt (headless runs
+# would otherwise hang or silently drop the server). Containment comes from
+# the container sandbox + --read-only MCP server + read-only API token, not
+# from CLI permissions (see evals/README.md).
+RAW_LOG="$(mktemp)"
+cursor-agent -p "$prompt_content" \
+    --force \
+    --approve-mcps \
+    ${CURSOR_ARGS[@]+"${CURSOR_ARGS[@]}"} \
+    | tee "$RAW_LOG" \
+    | node "$ROOT_DIR/dist/parser" -
+
+# Emit machine-readable pointers for the caller. The raw stream-json capture
+# stands in for the transcript (cursor-agent keeps no documented on-disk one).
+SESSION_ID=$(jq -r 'select(.type == "system" and .subtype == "init") | .session_id' "$RAW_LOG" | head -n1)
+echo "CURSOR_SESSION_ID=$SESSION_ID"
+echo "CURSOR_TRANSCRIPT=$RAW_LOG"
+
+# Extract the run's final assistant text (the stream-json "result" event) into
+# a file so the caller can surface just the final output (e.g. as an annotation).
+RESULT_FILE="$(mktemp)"
+jq -r 'select(.type == "result") | .result // empty' "$RAW_LOG" > "$RESULT_FILE" 2>/dev/null || true
+echo "CURSOR_RESULT_FILE=$RESULT_FILE"

--- a/evals/scripts/parser.ts
+++ b/evals/scripts/parser.ts
@@ -48,6 +48,12 @@ interface Message {
     session_id?: string;
     tools?: string[];
     model?: string;
+    // Cursor CLI stream-json only: tool calls are standalone events keyed by
+    // tool name ({"type":"tool_call","subtype":"started"|"completed",
+    // "call_id":..., "tool_call":{"<tool>ToolCall":{args,result}}}), unlike
+    // Claude's tool_use/tool_result content blocks.
+    call_id?: string;
+    tool_call?: Record<string, { args?: any; result?: any }>;
 }
 
 interface ChatEntry {
@@ -196,6 +202,58 @@ function createBuildkiteAnnotation(
     }
 }
 
+// formatCursorToolCall renders a Cursor CLI tool_call event (see the Message
+// interface). started events read as the assistant invoking a tool; completed
+// events read as the tool result coming back — mirroring how Claude's
+// tool_use/tool_result pairs are labelled so the two dialects render alike.
+function formatCursorToolCall(msg: Message): {
+    speaker: string;
+    content: string;
+    hasError: boolean;
+} {
+    const tc = msg.tool_call ?? {};
+    const outer = Object.keys(tc)[0] ?? "unknown";
+    const payload = tc[outer] ?? {};
+    const args: any =
+        payload.args && typeof payload.args === "object" ? payload.args : {};
+
+    // The outer key names the tool KIND. MCP invocations are wrapped: the
+    // real identity is args.toolName + args.serverIdentifier and the real
+    // tool arguments nest at args.args (observed schema — eval build 98).
+    // Normalize to claude-style mcp__<server>__<tool> so annotations read
+    // alike across agents; keep bk-tool-audit-v2.sh's cursor_tool_name in
+    // sync with this. function.name is a defensive fallback for the
+    // OpenAI-style shape other cursor versions may emit.
+    let name = outer;
+    let shownArgs: any = args;
+    if (outer === "mcpToolCall" && (args.toolName || args.name)) {
+        const server = args.serverIdentifier ?? args.providerIdentifier ?? "mcp";
+        name = `mcp__${server}__${args.toolName ?? args.name}`;
+        shownArgs = args.args && typeof args.args === "object" ? args.args : {};
+    } else if (args.function && typeof args.function === "object" && args.function.name) {
+        name = args.function.name;
+    }
+
+    if (msg.subtype === "completed") {
+        const result = payload.result;
+        // Cursor reports success under result.success; anything else (error
+        // key, or no result at all) is treated as a failure.
+        const hasError = !(result && typeof result === "object" && "success" in result);
+        const body = JSON.stringify(hasError ? (result ?? {}) : result.success, null, 2) ?? "";
+        const indicator = hasError ? "❌ Tool error:" : "✅ Tool result:";
+        const trimmed = body.length > 400 ? body.slice(0, 400) + "..." : body;
+        return { speaker: "USER", content: `${indicator} ${name}\n${trimmed}`, hasError };
+    }
+
+    // started (and any future subtypes) — show the invocation.
+    let content = `🔧 Using tool: ${name}`;
+    if (shownArgs && Object.keys(shownArgs).length > 0) {
+        const argsStr = JSON.stringify(shownArgs);
+        content += ` with ${argsStr.length > 300 ? argsStr.slice(0, 300) + "..." : argsStr}`;
+    }
+    return { speaker: "ASSISTANT", content, hasError: false };
+}
+
 // extractCleanJSONContentWithErrorCheck extracts clean content from JSON message without ANSI codes and detects errors
 function extractCleanJSONContentWithErrorCheck(msg: Message): {
     speaker: string;
@@ -212,6 +270,9 @@ function extractCleanJSONContentWithErrorCheck(msg: Message): {
                 };
             }
             return { speaker: "SYSTEM", content: "System message", hasError: false };
+
+        case "tool_call":
+            return formatCursorToolCall(msg);
 
         case "assistant": {
             const speaker = "ASSISTANT";
@@ -384,6 +445,11 @@ function formatJSONMessage(msg: Message): { speaker: string; content: string } {
                 };
             }
             return { speaker: "SYSTEM", content: "System message" };
+
+        case "tool_call": {
+            const { speaker, content } = formatCursorToolCall(msg);
+            return { speaker, content };
+        }
 
         case "assistant": {
             let speaker = "ASSISTANT";


### PR DESCRIPTION
### Description

The evals framework (#351) drives scenario evals from a config matrix (`evals.yaml`), but `agent: claude` was the only implemented runner. This PR makes the agent a real choice by adding `agent: cursor` (Cursor CLI / `cursor-agent`), so the same scenarios can be run through a second agent against the same MCP server — tool *choice* across agents is part of what the eval measures.

Alternatives considered: Cursor **cloud agents** (REST API) were evaluated and documented in the README but not implemented — cloud agents run in Cursor's environment and can't exercise the PR's source-built `--read-only` server binary, which would change what's under test. For MCP auth, materializing the token into `.cursor/mcp.json` was replaced with Cursor's documented `${env:BUILDKITE_API_TOKEN}` interpolation, so no secret is ever written to disk.

### Context

- Linear: https://linear.app/buildkite/issue/PB-2412
- Predecessor: #351 (evals config matrix)

### Changes

- `evals/scripts/cursor.sh` (new): CI runner, the `claude.sh` analogue — `CURSOR_API_KEY` auth (Hosted Models can't proxy Cursor's backend), generated `.cursor/mcp.json` referencing `${env:BUILDKITE_API_TOKEN}` (kept off the scenario branch via `.git/info/exclude`), `prompts/system.md` prepended (no `--append-system-prompt`), raw stream-json capture standing in for the transcript.
- `evals/scripts/babystand.sh`: `run_agent` dispatch + `run_cursor` (CI and local); agent-aware model default; loud skips when `CURSOR_API_KEY` is unset or in restricted local mode; explicit failure guards on both cursor pipelines (errexit is dead inside `run_entry`).
- `evals/scripts/bk-eval-compare.sh`: handle peculiarity of agent cursor session logs; tool calls are recorded as `mcpToolCall`, which lacks clarity, parse deeper to extract the `mcp__<server>__<tool>` (matching claude naming so cross-agent tables align); no token usage in cursor's stream-json, so tokens/cost are `null`.
- `evals/scripts/bk-tool-audit-v2.sh`: null metrics render `N/A` and skip delta arithmetic instead of coercing to 0 - token costs for cursor appears as 'N/A' instead of misleading 0
- `evals/scripts/parser.ts`: renders cursor `tool_call` started/completed events like claude `tool_use`/`tool_result` pairs, with the same MCP name normalization.
- `evals/Dockerfile`: installs `cursor-agent` (unpinned — no pinned artifacts published; trade-off noted inline).
- `.buildkite/pipeline.evals.yml`: `CURSOR_API_KEY` env + secret mapping.
- `evals/evals.yaml` + README: `agent`/`model` docs, cursor caveats, cloud-agent options.

### Verification

- Example run with cursor invoked (this was prior to most recent committed changes to `evals/scripts/bk-tool-audit-v2.sh`)
  * [Build 98](https://buildkite.com/buildkite/buildkite-mcp-server-evals-framework/builds/98): cursor agent ran the `red-to-green-complete` scenario end to end in CI — discovered MCP tools, called `mcp__buildkite` tools, pushed a fix, drove the scenario build green.
- [Build 102](https://buildkite.com/buildkite/buildkite-mcp-server-evals-framework/builds/102) (current HEAD lineage): matrix run passed.

### Deployment

Low risk: eval harness only — no MCP server (Go) code is touched, nothing ships to users. Cursor entries require the `MCP_EVAL_FRAMEWORK_CURSOR_API_KEY` secret in the cluster; while unset, entries skip loudly and the build stays green. `cursor-agent` is installed unpinned in the eval image, so upstream CLI changes surface in eval builds first (and now fail loudly, not silently). No migrations, no deployment ordering.

### Rollback

Safe to revert at any time: a single self-contained commit touching only the eval harness. Reverting restores claude-only evals; no data, state, or production path depends on it. The `CURSOR_API_KEY` secret can be left in place harmlessly or removed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
