### PR TITLE
Add list_tests MCP tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.16.0
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.10.0
+	github.com/buildkite/go-buildkite/v5 v5.11.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.10.0 h1:XYSUuFJhVJZrZJNEc+Rvd7jJxyJMy21iMuCcvz5jFMM=
-github.com/buildkite/go-buildkite/v5 v5.10.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.11.0 h1:shbdlP1Qo85mJn9iQ2vFyxQ3O/T/UVG5ReM4LILi56I=
+github.com/buildkite/go-buildkite/v5 v5.11.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -236,6 +236,7 @@ func TestListTestsArgsSchema(t *testing.T) {
 	require.Contains(t, s.Properties["min_timestamp"].Description, "RFC3339")
 	require.Contains(t, s.Properties["max_timestamp"].Description, "RFC3339")
 	require.Contains(t, s.Properties["period"].Description, "Cannot be combined")
+	require.Contains(t, s.Properties["period"].Description, "cannot exceed the organization's maximum")
 	require.Contains(t, s.Properties["state"].Description, "enabled")
 	require.Contains(t, s.Properties["sort_by"].Description, "reliability")
 	require.Contains(t, s.Properties["order"].Description, "asc")

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -218,6 +218,29 @@ func TestGetTestArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"org_slug", "test_id", "test_suite_slug"}, req)
 }
 
+func TestListTestsArgsSchema(t *testing.T) {
+	s := schemaFor[ListTestsArgs](t)
+	require.Equal(t, []string{"org_slug", "test_suite_slug"}, sortedRequired[ListTestsArgs](t))
+
+	optional := []string{
+		"page", "per_page", "period", "min_timestamp", "max_timestamp", "labels",
+		"branch", "owners", "state", "tags", "sort_by", "order",
+	}
+	for _, property := range optional {
+		require.Contains(t, s.Properties, property)
+		require.NotContains(t, s.Required, property, "%s should be optional", property)
+	}
+
+	require.Equal(t, "string", s.Properties["min_timestamp"].Type)
+	require.Equal(t, "string", s.Properties["max_timestamp"].Type)
+	require.Contains(t, s.Properties["min_timestamp"].Description, "RFC3339")
+	require.Contains(t, s.Properties["max_timestamp"].Description, "RFC3339")
+	require.Contains(t, s.Properties["period"].Description, "Cannot be combined")
+	require.Contains(t, s.Properties["state"].Description, "enabled")
+	require.Contains(t, s.Properties["sort_by"].Description, "reliability")
+	require.Contains(t, s.Properties["order"].Description, "asc")
+}
+
 func TestListTestRunsArgsSchema(t *testing.T) {
 	s := schemaFor[ListTestRunsArgs](t)
 	req := slices.Clone(s.Required)

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"context"
+	"time"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/go-buildkite/v5"
@@ -11,12 +12,99 @@ import (
 
 type TestsClient interface {
 	Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
+	List(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
+}
+
+type ListTestsArgs struct {
+	OrgSlug       string    `json:"org_slug"`
+	TestSuiteSlug string    `json:"test_suite_slug"`
+	Page          int       `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
+	PerPage       int       `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+	Period        string    `json:"period,omitempty" jsonschema:"Relative aggregation window, such as '7days' or '28days'. Available periods depend on the organization's maximum Test Engine window. Cannot be combined with min_timestamp or max_timestamp."`
+	MinTimestamp  time.Time `json:"min_timestamp,omitempty" jsonschema:"Start of the aggregation window in RFC3339 format. When omitted, defaults to the organization's default Test Engine period before the current time."`
+	MaxTimestamp  time.Time `json:"max_timestamp,omitempty" jsonschema:"End of the aggregation window in RFC3339 format. Defaults to the current time when omitted."`
+	Labels        string    `json:"labels,omitempty" jsonschema:"Filter by comma-separated test labels. Prefix a label with '!' to exclude it, for example 'flaky,!slow'."`
+	Branch        string    `json:"branch,omitempty" jsonschema:"Filter executions included in the metrics by branch. Prefix with '!' to exclude an exact branch or suffix with '*' to match by prefix, for example '!main' or 'feature*'. Use at most one operator."`
+	Owners        string    `json:"owners,omitempty" jsonschema:"Filter by comma-separated test owner slugs. Prefix an owner with '!' to exclude it, for example 'payments,!platform'."`
+	State         string    `json:"state,omitempty" jsonschema:"Filter by test state: 'enabled', 'muted', or 'skipped'."`
+	Tags          string    `json:"tags,omitempty" jsonschema:"Filter by comma-separated execution tags in key:value form. Values support '!' for exclusion and '*' for prefix matching. Result values additionally support '~' for any matching execution and '^' for every execution matching, for example 'framework:!rspec,scm.branch:feature*,result:^passed'."`
+	SortBy        string    `json:"sort_by,omitempty" jsonschema:"Metric used to sort results: 'duration_avg', 'duration_sum', 'duration_min', 'duration_max', or 'reliability'. Defaults to 'duration_avg'. Metrics cover only executions in the selected window."`
+	Order         string    `json:"order,omitempty" jsonschema:"Sort direction: 'asc' or 'desc'. Defaults to 'desc'."`
 }
 
 type GetTestArgs struct {
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	TestID        string `json:"test_id"`
+}
+
+func ListTests() (mcp.Tool, mcp.ToolHandlerFor[ListTestsArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_tests",
+			Description: "List tests in a Buildkite Test Engine suite with execution metrics aggregated over a selected time window. Supports filtering, metric sorting, and pagination.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Tests",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args ListTestsArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListTests")
+			defer span.End()
+
+			paginationParams := paginationFromArgs(args.Page, args.PerPage)
+			options := &buildkite.TestsListOptions{
+				ListOptions:  paginationParams,
+				Period:       args.Period,
+				MinTimestamp: args.MinTimestamp,
+				MaxTimestamp: args.MaxTimestamp,
+				Labels:       args.Labels,
+				Branch:       args.Branch,
+				Owners:       args.Owners,
+				State:        args.State,
+				Tags:         args.Tags,
+				SortBy:       args.SortBy,
+				Order:        args.Order,
+			}
+
+			attributes := []attribute.KeyValue{
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("test_suite_slug", args.TestSuiteSlug),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+				attribute.String("period", args.Period),
+				attribute.String("labels", args.Labels),
+				attribute.String("branch", args.Branch),
+				attribute.String("owners", args.Owners),
+				attribute.String("state", args.State),
+				attribute.String("tags", args.Tags),
+				attribute.String("sort_by", args.SortBy),
+				attribute.String("order", args.Order),
+			}
+			if !args.MinTimestamp.IsZero() {
+				attributes = append(attributes, attribute.String("min_timestamp", args.MinTimestamp.Format(time.RFC3339)))
+			}
+			if !args.MaxTimestamp.IsZero() {
+				attributes = append(attributes, attribute.String("max_timestamp", args.MaxTimestamp.Format(time.RFC3339)))
+			}
+			span.SetAttributes(attributes...)
+
+			deps := DepsFromContext(ctx)
+			tests, resp, err := deps.TestsClient.List(ctx, args.OrgSlug, args.TestSuiteSlug, options)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			result := PaginatedResult[buildkite.TestWithMetrics]{
+				Items: tests,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			span.SetAttributes(attribute.Int("item_count", len(tests)))
+
+			return mcpTextResult(span, &result)
+		}, []string{"read_suites"}
 }
 
 func GetTest() (mcp.Tool, mcp.ToolHandlerFor[GetTestArgs, any], []string) {

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -20,7 +20,7 @@ type ListTestsArgs struct {
 	TestSuiteSlug string    `json:"test_suite_slug"`
 	Page          int       `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
 	PerPage       int       `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
-	Period        string    `json:"period,omitempty" jsonschema:"Relative aggregation window, such as '7days' or '28days'. Available periods depend on the organization's maximum Test Engine window. Cannot be combined with min_timestamp or max_timestamp."`
+	Period        string    `json:"period,omitempty" jsonschema:"Relative aggregation window, such as '7days' or '28days'. Whether selected by period or timestamps, the aggregation window cannot exceed the organization's maximum Test Engine window. Cannot be combined with min_timestamp or max_timestamp."`
 	MinTimestamp  time.Time `json:"min_timestamp,omitempty" jsonschema:"Start of the aggregation window in RFC3339 format. When omitted, defaults to the organization's default Test Engine period before the current time."`
 	MaxTimestamp  time.Time `json:"max_timestamp,omitempty" jsonschema:"End of the aggregation window in RFC3339 format. Defaults to the current time when omitted."`
 	Labels        string    `json:"labels,omitempty" jsonschema:"Filter by comma-separated test labels. Prefix a label with '!' to exclude it, for example 'flaky,!slow'."`

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -44,7 +44,6 @@ func TestListTests(t *testing.T) {
 			require.Equal(t, "org", org)
 			require.Equal(t, "suite1", slug)
 			require.Equal(t, buildkite.ListOptions{Page: 2, PerPage: 50}, opt.ListOptions)
-			require.Equal(t, "7days", opt.Period)
 			require.Equal(t, minTimestamp, opt.MinTimestamp)
 			require.Equal(t, maxTimestamp, opt.MaxTimestamp)
 			require.Equal(t, "flaky,!slow", opt.Labels)
@@ -108,7 +107,6 @@ func TestListTests(t *testing.T) {
 		TestSuiteSlug: "suite1",
 		Page:          2,
 		PerPage:       50,
-		Period:        "7days",
 		MinTimestamp:  minTimestamp,
 		MaxTimestamp:  maxTimestamp,
 		Labels:        "flaky,!slow",
@@ -152,6 +150,9 @@ func TestListTestsUsesDefaultPagination(t *testing.T) {
 	client := &MockTestsClient{
 		ListFunc: func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
 			require.Equal(t, buildkite.ListOptions{Page: 1, PerPage: 100}, opt.ListOptions)
+			require.Equal(t, "7days", opt.Period)
+			require.True(t, opt.MinTimestamp.IsZero())
+			require.True(t, opt.MaxTimestamp.IsZero())
 			return []buildkite.TestWithMetrics{}, &buildkite.Response{Response: &http.Response{Header: http.Header{}}}, nil
 		},
 	}
@@ -161,6 +162,7 @@ func TestListTestsUsesDefaultPagination(t *testing.T) {
 	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListTestsArgs{
 		OrgSlug:       "org",
 		TestSuiteSlug: "suite1",
+		Period:        "7days",
 	})
 	require.NoError(t, err)
 	require.False(t, result.IsError)
@@ -187,6 +189,7 @@ func TestListTestsReturnsAPIError(t *testing.T) {
 		OrgSlug:       "org",
 		TestSuiteSlug: "suite1",
 		Period:        "7days",
+		MinTimestamp:  time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
 	})
 	require.NoError(t, err)
 	require.True(t, result.IsError)

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -2,17 +2,20 @@ package buildkite
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/stretchr/testify/require"
 )
 
 type MockTestsClient struct {
-	GetFunc func(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
+	GetFunc  func(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
+	ListFunc func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
 }
 
 func (m *MockTestsClient) Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error) {
@@ -22,7 +25,173 @@ func (m *MockTestsClient) Get(ctx context.Context, org, slug, testID string) (bu
 	return buildkite.Test{}, nil, nil
 }
 
+func (m *MockTestsClient) List(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx, org, slug, opt)
+	}
+	return nil, nil, nil
+}
+
 var _ TestsClient = (*MockTestsClient)(nil)
+
+func TestListTests(t *testing.T) {
+	minTimestamp := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	maxTimestamp := time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC)
+	reliability := 0.97
+
+	client := &MockTestsClient{
+		ListFunc: func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "suite1", slug)
+			require.Equal(t, buildkite.ListOptions{Page: 2, PerPage: 50}, opt.ListOptions)
+			require.Equal(t, "7days", opt.Period)
+			require.Equal(t, minTimestamp, opt.MinTimestamp)
+			require.Equal(t, maxTimestamp, opt.MaxTimestamp)
+			require.Equal(t, "flaky,!slow", opt.Labels)
+			require.Equal(t, "main*", opt.Branch)
+			require.Equal(t, "payments,!platform", opt.Owners)
+			require.Equal(t, "enabled", opt.State)
+			require.Equal(t, "framework:rspec,result:^failed", opt.Tags)
+			require.Equal(t, "reliability", opt.SortBy)
+			require.Equal(t, "asc", opt.Order)
+
+			return []buildkite.TestWithMetrics{
+					{
+						Test: buildkite.Test{
+							ID:       "test-123",
+							Name:     "Example Test",
+							Location: "spec/example_test.rb:42",
+							FileName: "spec/example_test.rb",
+							Labels:   []string{"flaky"},
+						},
+						Reliability:     &reliability,
+						DurationAverage: 1.4,
+						DurationTotal:   140,
+						DurationMinimum: 0.5,
+						DurationMaximum: 4.2,
+						ExecutionsCount: 100,
+						ExecutionsCountByResult: map[string]int{
+							"passed": 97,
+							"failed": 3,
+						},
+					},
+					{
+						Test:            buildkite.Test{ID: "test-456", Name: "Skipped Test"},
+						Reliability:     nil,
+						ExecutionsCount: 1,
+						ExecutionsCountByResult: map[string]int{
+							"passed":  0,
+							"failed":  0,
+							"skipped": 1,
+						},
+					},
+				}, &buildkite.Response{Response: &http.Response{
+					StatusCode: http.StatusOK,
+					Header: http.Header{
+						"Link": []string{`<https://api.buildkite.com/v2/analytics/organizations/org/suites/suite1/tests?page=3>; rel="next"`},
+					},
+				}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	tool, handler, scopes := ListTests()
+
+	require.Equal(t, "list_tests", tool.Name)
+	require.Equal(t, "List Tests", tool.Annotations.Title)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Contains(t, tool.Description, "execution metrics")
+	require.Equal(t, []string{"read_suites"}, scopes)
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListTestsArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+		Page:          2,
+		PerPage:       50,
+		Period:        "7days",
+		MinTimestamp:  minTimestamp,
+		MaxTimestamp:  maxTimestamp,
+		Labels:        "flaky,!slow",
+		Branch:        "main*",
+		Owners:        "payments,!platform",
+		State:         "enabled",
+		Tags:          "framework:rspec,result:^failed",
+		SortBy:        "reliability",
+		Order:         "asc",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	resultText := getTextResult(t, result).Text
+	var rawResponse struct {
+		Items []map[string]any `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText), &rawResponse))
+	reliabilityValue, reliabilityPresent := rawResponse.Items[1]["reliability"]
+	require.True(t, reliabilityPresent)
+	require.Nil(t, reliabilityValue)
+
+	var response PaginatedResult[buildkite.TestWithMetrics]
+	require.NoError(t, json.Unmarshal([]byte(resultText), &response))
+	require.Equal(t, `<https://api.buildkite.com/v2/analytics/organizations/org/suites/suite1/tests?page=3>; rel="next"`, response.Headers["Link"])
+	require.Len(t, response.Items, 2)
+	require.Equal(t, "test-123", response.Items[0].ID)
+	require.Equal(t, []string{"flaky"}, response.Items[0].Labels)
+	require.NotNil(t, response.Items[0].Reliability)
+	require.InDelta(t, reliability, *response.Items[0].Reliability, 0.0001)
+	require.InDelta(t, 1.4, response.Items[0].DurationAverage, 0.0001)
+	require.InDelta(t, 140.0, response.Items[0].DurationTotal, 0.0001)
+	require.InDelta(t, 0.5, response.Items[0].DurationMinimum, 0.0001)
+	require.InDelta(t, 4.2, response.Items[0].DurationMaximum, 0.0001)
+	require.Equal(t, 100, response.Items[0].ExecutionsCount)
+	require.Equal(t, map[string]int{"passed": 97, "failed": 3}, response.Items[0].ExecutionsCountByResult)
+	require.Nil(t, response.Items[1].Reliability)
+}
+
+func TestListTestsUsesDefaultPagination(t *testing.T) {
+	client := &MockTestsClient{
+		ListFunc: func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, buildkite.ListOptions{Page: 1, PerPage: 100}, opt.ListOptions)
+			return []buildkite.TestWithMetrics{}, &buildkite.Response{Response: &http.Response{Header: http.Header{}}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	_, handler, _ := ListTests()
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListTestsArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+}
+
+func TestListTestsReturnsAPIError(t *testing.T) {
+	response := &http.Response{
+		Request:    &http.Request{Method: http.MethodGet},
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       io.NopCloser(strings.NewReader(`{"message":"period cannot be combined with min_timestamp"}`)),
+	}
+	client := &MockTestsClient{
+		ListFunc: func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			return nil, &buildkite.Response{Response: response}, &buildkite.ErrorResponse{
+				Response: response,
+				Message:  "period cannot be combined with min_timestamp",
+			}
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	_, handler, _ := ListTests()
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListTestsArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+		Period:        "7days",
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, getTextResult(t, result).Text, "period cannot be combined with min_timestamp")
+}
 
 func TestGetTest(t *testing.T) {
 	assert := require.New(t)

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -376,6 +376,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 			Name:        "Test Engine",
 			Description: "Tools for managing test runs and test results",
 			Tools: []ToolDefinition{
+				newToolDef(buildkite.ListTests),
 				newToolDef(buildkite.ListTestRuns),
 				newToolDef(buildkite.GetTestRun),
 				newToolDef(buildkite.GetFailedTestExecutions),

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -666,4 +666,27 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	assert.Len(investigations.Tools, 1)
 	assert.Equal("get_build_failure_summary", investigations.Tools[0].Tool.Name)
 	assert.Equal([]string{"read_build_logs", "read_builds", "read_suites"}, investigations.GetRequiredScopes())
+
+	tests, exists := registry.Get(ToolsetTests)
+	assert.True(exists)
+	var listTests *ToolDefinition
+	for i := range tests.Tools {
+		if tests.Tools[i].Tool.Name == "list_tests" {
+			listTests = &tests.Tools[i]
+			break
+		}
+	}
+	assert.NotNil(listTests)
+	assert.True(listTests.IsReadOnly())
+	assert.Equal([]string{"read_suites"}, listTests.RequiredScopes)
+
+	readOnlyTests := registry.GetEnabledTools([]string{ToolsetTests}, true)
+	retainedInReadOnlyMode := false
+	for _, tool := range readOnlyTests {
+		if tool.Tool.Name == "list_tests" {
+			retainedInReadOnlyMode = true
+			break
+		}
+	}
+	assert.True(retainedInReadOnlyMode)
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -669,24 +669,9 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 
 	tests, exists := registry.Get(ToolsetTests)
 	assert.True(exists)
-	var listTests *ToolDefinition
-	for i := range tests.Tools {
-		if tests.Tools[i].Tool.Name == "list_tests" {
-			listTests = &tests.Tools[i]
-			break
-		}
+	toolNames := make([]string, 0, len(tests.Tools))
+	for _, tool := range tests.Tools {
+		toolNames = append(toolNames, tool.Tool.Name)
 	}
-	assert.NotNil(listTests)
-	assert.True(listTests.IsReadOnly())
-	assert.Equal([]string{"read_suites"}, listTests.RequiredScopes)
-
-	readOnlyTests := registry.GetEnabledTools([]string{ToolsetTests}, true)
-	retainedInReadOnlyMode := false
-	for _, tool := range readOnlyTests {
-		if tool.Tool.Name == "list_tests" {
-			retainedInReadOnlyMode = true
-			break
-		}
-	}
-	assert.True(retainedInReadOnlyMode)
+	assert.Contains(toolNames, "list_tests")
 }


### PR DESCRIPTION
## Description

Adds a `list_tests` MCP tool for listing tests in a Buildkite Test Engine suite with execution metrics aggregated over a selected time window.

Closes [TE-6556](https://linear.app/buildkite/issue/TE-6556/add-a-new-list-tests-mcp-tool).

## Changes

- Upgrade `go-buildkite` to v5.11.0 and extend `TestsClient` with the new list endpoint
- Expose pagination, period/timestamp windows, filters, metric sorting, and ordering
- Return test metrics with pagination links
- Register the tool in the Test Engine toolset with read-only routing and the `read_suites` scope
- Add handler, schema, registration, pagination, serialization, and error-path tests

## Verification

- `go test ./pkg/buildkite/... ./pkg/toolsets/...`

## Deployment

Low risk. This adds a read-only tool and upgrades the Buildkite SDK by one minor version. No migrations or configuration changes are required.

## Rollback

Revert the commits in this PR to remove the tool registration and restore the previous SDK version.
