### PR TITLE
feat: add telemetry context to tool inputs

### DIFF
--- a/cmd/buildkite-mcp-server/main_test.go
+++ b/cmd/buildkite-mcp-server/main_test.go
@@ -148,7 +148,14 @@ func TestMCPToolCallPassesRequestHeaderToBuildkiteAPI(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = session.Close() })
 
-	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{Name: "current_user"})
+	result, err := session.CallTool(context.Background(), &mcp.CallToolParams{
+		Name: "current_user",
+		Arguments: map[string]any{
+			"telemetry": map[string]any{
+				"context": "Fetching the current Buildkite user to verify request header passthrough behavior during the authenticated integration test flow.",
+			},
+		},
+	})
 	require.NoError(t, err)
 	require.False(t, result.IsError)
 	require.NotEmpty(t, result.Content)

--- a/pkg/buildkite/access_token.go
+++ b/pkg/buildkite/access_token.go
@@ -12,7 +12,9 @@ type AccessTokenClient interface {
 	Get(ctx context.Context) (buildkite.AccessToken, *buildkite.Response, error)
 }
 
-type AccessTokenArgs struct{}
+type AccessTokenArgs struct {
+	ToolInput
+}
 
 func AccessToken() (mcp.Tool, mcp.ToolHandlerFor[AccessTokenArgs, any], []string) {
 	return mcp.Tool{

--- a/pkg/buildkite/agents.go
+++ b/pkg/buildkite/agents.go
@@ -16,6 +16,7 @@ type AgentsClient interface {
 }
 
 type ListAgentsArgs struct {
+	ToolInput
 	OrgSlug        string `json:"org_slug"`
 	Name           string `json:"name,omitempty"`
 	Hostname       string `json:"hostname,omitempty"`
@@ -27,6 +28,7 @@ type ListAgentsArgs struct {
 }
 
 type GetAgentArgs struct {
+	ToolInput
 	OrgSlug     string `json:"org_slug"`
 	AgentID     string `json:"agent_id"`
 	DetailLevel string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary', 'detailed', or 'full' (default)"`

--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -25,6 +25,7 @@ type AnnotationsClient interface {
 }
 
 type ListAnnotationsArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -35,6 +36,7 @@ type ListAnnotationsArgs struct {
 }
 
 type CreateAnnotationArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/artifacts.go
+++ b/pkg/buildkite/artifacts.go
@@ -233,6 +233,7 @@ func toArtifactListItems(artifacts []buildkite.Artifact) []artifactListItem {
 }
 
 type ListArtifactsForBuildArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -241,6 +242,7 @@ type ListArtifactsForBuildArgs struct {
 }
 
 type ListArtifactsForJobArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -250,6 +252,7 @@ type ListArtifactsForJobArgs struct {
 }
 
 type GetArtifactArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -24,10 +24,6 @@ type ToolInput struct {
 	Telemetry ToolTelemetry `json:"telemetry" jsonschema:"Analytics metadata describing the tool call's purpose"`
 }
 
-// TelemetryContextMaxLength is the maximum number of Unicode code points
-// accepted by the tool input schema.
-const TelemetryContextMaxLength = 512
-
 // ToolTelemetry describes why a tool is being called.
 type ToolTelemetry struct {
 	Context string `json:"context" jsonschema:"Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."`

--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -19,6 +19,16 @@ type PaginatedResult[T any] struct {
 	Items   []T               `json:"items"`
 }
 
+// ToolInput contains metadata common to every tool invocation.
+type ToolInput struct {
+	Telemetry ToolTelemetry `json:"telemetry" jsonschema:"Analytics metadata describing the tool call's purpose"`
+}
+
+// ToolTelemetry describes why a tool is being called.
+type ToolTelemetry struct {
+	Context string `json:"context" jsonschema:"Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""`
+}
+
 // PaginationParams is embedded in tool args structs to provide pagination fields.
 type PaginationParams struct {
 	Page    int `json:"page"`

--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -24,6 +24,10 @@ type ToolInput struct {
 	Telemetry ToolTelemetry `json:"telemetry" jsonschema:"Analytics metadata describing the tool call's purpose"`
 }
 
+// TelemetryContextMaxLength is the maximum number of Unicode code points
+// accepted by the tool input schema.
+const TelemetryContextMaxLength = 512
+
 // ToolTelemetry describes why a tool is being called.
 type ToolTelemetry struct {
 	Context string `json:"context" jsonschema:"Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."`

--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -26,7 +26,7 @@ type ToolInput struct {
 
 // ToolTelemetry describes why a tool is being called.
 type ToolTelemetry struct {
-	Context string `json:"context" jsonschema:"Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""`
+	Context string `json:"context" jsonschema:"Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."`
 }
 
 // PaginationParams is embedded in tool args structs to provide pagination fields.

--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -94,6 +94,7 @@ type BuildDetail struct {
 
 // ListBuildsArgs struct with enhanced filtering
 type ListBuildsArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Filter builds by pipeline. When omitted, lists builds across all pipelines in the organization"`
 	Branch       string `json:"branch,omitempty" jsonschema:"Filter builds by git branch name"`
@@ -106,6 +107,7 @@ type ListBuildsArgs struct {
 
 // GetBuildArgs struct
 type GetBuildArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -113,6 +115,7 @@ type GetBuildArgs struct {
 
 // GetBuildTestEngineRunsArgs struct
 type GetBuildTestEngineRunsArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -371,6 +374,7 @@ func listAnnotationSummaries(ctx context.Context, orgSlug, pipelineSlug, buildNu
 }
 
 type WaitForBuildArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -566,6 +570,7 @@ type Entry struct {
 }
 
 type CreateBuildArgs struct {
+	ToolInput
 	OrgSlug             string  `json:"org_slug"`
 	PipelineSlug        string  `json:"pipeline_slug"`
 	Commit              string  `json:"commit" jsonschema:"The commit SHA to build"`
@@ -615,6 +620,7 @@ func CreateBuild() (mcp.Tool, mcp.ToolHandlerFor[CreateBuildArgs, any], []string
 }
 
 type CancelBuildArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -650,6 +656,7 @@ func CancelBuild() (mcp.Tool, mcp.ToolHandlerFor[CancelBuildArgs, any], []string
 }
 
 type RebuildBuildArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/cluster_queue.go
+++ b/pkg/buildkite/cluster_queue.go
@@ -19,6 +19,7 @@ type ClusterQueuesClient interface {
 }
 
 type ListClusterQueuesArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
@@ -26,12 +27,14 @@ type ListClusterQueuesArgs struct {
 }
 
 type GetClusterQueueArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 	QueueID   string `json:"queue_id"`
 }
 
 type CreateClusterQueueArgs struct {
+	ToolInput
 	OrgSlug     string `json:"org_slug"`
 	ClusterID   string `json:"cluster_id"`
 	Key         string `json:"key"`
@@ -39,6 +42,7 @@ type CreateClusterQueueArgs struct {
 }
 
 type UpdateClusterQueueArgs struct {
+	ToolInput
 	OrgSlug            string  `json:"org_slug"`
 	ClusterID          string  `json:"cluster_id"`
 	QueueID            string  `json:"queue_id"`
@@ -47,6 +51,7 @@ type UpdateClusterQueueArgs struct {
 }
 
 type PauseClusterQueueDispatchArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 	QueueID   string `json:"queue_id"`
@@ -54,6 +59,7 @@ type PauseClusterQueueDispatchArgs struct {
 }
 
 type ResumeClusterQueueDispatchArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 	QueueID   string `json:"queue_id"`

--- a/pkg/buildkite/clusters.go
+++ b/pkg/buildkite/clusters.go
@@ -17,17 +17,20 @@ type ClustersClient interface {
 }
 
 type ListClustersArgs struct {
+	ToolInput
 	OrgSlug string `json:"org_slug"`
 	Page    int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
 	PerPage int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
 }
 
 type GetClusterArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
 }
 
 type CreateClusterArgs struct {
+	ToolInput
 	OrgSlug     string `json:"org_slug"`
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty" jsonschema:"Description of the cluster"`
@@ -36,6 +39,7 @@ type CreateClusterArgs struct {
 }
 
 type UpdateClusterArgs struct {
+	ToolInput
 	OrgSlug        string  `json:"org_slug"`
 	ClusterID      string  `json:"cluster_id"`
 	Name           *string `json:"name,omitempty" jsonschema:"New name for the cluster"`

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -42,6 +42,7 @@ const (
 // by get_build_failure_summary. Pointer booleans let omitted values default to
 // true while still allowing callers to disable an optional section.
 type GetBuildFailureSummaryArgs struct {
+	ToolInput
 	OrgSlug                string `json:"org_slug"`
 	PipelineSlug           string `json:"pipeline_slug"`
 	BuildNumber            string `json:"build_number"`

--- a/pkg/buildkite/joblogs.go
+++ b/pkg/buildkite/joblogs.go
@@ -24,6 +24,7 @@ var _ BuildkiteLogsClient = (*buildkitelogs.Client)(nil)
 
 // Common parameter structures for log tools
 type JobLogsBaseParams struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -30,6 +30,7 @@ func redactUnusedJobFields(job *buildkite.Job) {
 
 // ListJobsArgs struct for typed parameters
 type ListJobsArgs struct {
+	ToolInput
 	OrgSlug            string `json:"org_slug"`
 	PipelineSlug       string `json:"pipeline_slug"`
 	BuildNumber        string `json:"build_number"`
@@ -220,6 +221,7 @@ func ListJobs() (mcp.Tool, mcp.ToolHandlerFor[ListJobsArgs, any], []string) {
 
 // GetJobArgs struct for typed parameters
 type GetJobArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	JobID        string `json:"job_id"`
 	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Pipeline slug. Provide together with 'build_number' for a build-scoped lookup. Omit both to look up the job by organization and job ID alone"`
@@ -286,6 +288,7 @@ type GetJobLogsArgs struct {
 
 // UnblockJobArgs struct for typed parameters
 type UnblockJobArgs struct {
+	ToolInput
 	OrgSlug      string            `json:"org_slug"`
 	PipelineSlug string            `json:"pipeline_slug"`
 	BuildNumber  string            `json:"build_number"`
@@ -332,6 +335,7 @@ func UnblockJob() (mcp.Tool, mcp.ToolHandlerFor[UnblockJobArgs, any], []string) 
 
 // RetryJobArgs struct for typed parameters
 type RetryJobArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -370,6 +374,7 @@ func RetryJob() (mcp.Tool, mcp.ToolHandlerFor[RetryJobArgs, any], []string) {
 
 // GetJobEnvironmentVariablesArgs struct for typed parameters
 type GetJobEnvironmentVariablesArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/organizations.go
+++ b/pkg/buildkite/organizations.go
@@ -13,7 +13,9 @@ type OrganizationsClient interface {
 	List(ctx context.Context, options *buildkite.OrganizationListOptions) ([]buildkite.Organization, *buildkite.Response, error)
 }
 
-type UserTokenOrganizationArgs struct{}
+type UserTokenOrganizationArgs struct {
+	ToolInput
+}
 
 func UserTokenOrganization() (mcp.Tool, mcp.ToolHandlerFor[UserTokenOrganizationArgs, any], []string) {
 	return mcp.Tool{

--- a/pkg/buildkite/pipeline_schedules.go
+++ b/pkg/buildkite/pipeline_schedules.go
@@ -17,6 +17,7 @@ type PipelineSchedulesClient interface {
 }
 
 type ListPipelineSchedulesArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
@@ -68,6 +69,7 @@ func ListPipelineSchedules() (mcp.Tool, mcp.ToolHandlerFor[ListPipelineSchedules
 }
 
 type GetPipelineScheduleArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	ScheduleID   string `json:"schedule_id"`
@@ -102,6 +104,7 @@ func GetPipelineSchedule() (mcp.Tool, mcp.ToolHandlerFor[GetPipelineScheduleArgs
 }
 
 type CreatePipelineScheduleArgs struct {
+	ToolInput
 	OrgSlug      string            `json:"org_slug"`
 	PipelineSlug string            `json:"pipeline_slug"`
 	Cronline     string            `json:"cronline" jsonschema:"Schedule interval as a crontab expression (e.g. '0 0 * * *') or predefined value (e.g. '@daily', '@hourly', '@weekly', '@monthly', '@yearly')"`
@@ -152,6 +155,7 @@ func CreatePipelineSchedule() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineSchedu
 }
 
 type UpdatePipelineScheduleArgs struct {
+	ToolInput
 	OrgSlug      string            `json:"org_slug"`
 	PipelineSlug string            `json:"pipeline_slug"`
 	ScheduleID   string            `json:"schedule_id"`

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -18,6 +18,7 @@ type PipelinesClient interface {
 }
 
 type ListPipelinesArgs struct {
+	ToolInput
 	OrgSlug     string `json:"org_slug"`
 	Name        string `json:"name,omitempty" jsonschema:"Filter pipelines by name"`
 	Repository  string `json:"repository,omitempty" jsonschema:"Filter pipelines by repository URL"`
@@ -103,6 +104,7 @@ func ListPipelines() (mcp.Tool, mcp.ToolHandlerFor[ListPipelinesArgs, any], []st
 }
 
 type GetPipelineArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	DetailLevel  string `json:"detail_level,omitempty" jsonschema:"Response detail level: 'summary', 'detailed', or 'full' (default)"`
@@ -238,6 +240,7 @@ func createPaginatedResult[T any](pipelines []buildkite.Pipeline, converter func
 }
 
 type CreatePipelineArgs struct {
+	ToolInput
 	OrgSlug                   string   `json:"org_slug"`
 	Name                      string   `json:"name"`
 	RepositoryURL             string   `json:"repository_url" jsonschema:"The Git repository URL"`
@@ -317,6 +320,7 @@ func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []
 }
 
 type UpdatePipelineArgs struct {
+	ToolInput
 	OrgSlug                   string   `json:"org_slug"`
 	PipelineSlug              string   `json:"pipeline_slug"`
 	Name                      *string  `json:"name,omitempty"`

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -35,7 +35,7 @@ func sortedToolRequired(t *testing.T, s *jsonschema.Schema) []string {
 }
 
 func TestToolTelemetrySchema(t *testing.T) {
-	const contextDescription = "Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""
+	const contextDescription = "Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."
 
 	s := schemaFor[AccessTokenArgs](t)
 	require.Contains(t, s.Required, "telemetry")

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -20,16 +20,35 @@ func schemaFor[T any](t *testing.T) *jsonschema.Schema {
 
 func sortedRequired[T any](t *testing.T) []string {
 	t.Helper()
-	s := schemaFor[T](t)
+	return sortedToolRequired(t, schemaFor[T](t))
+}
+
+// sortedToolRequired returns the tool-specific required fields after verifying
+// and removing the telemetry field common to every tool input.
+func sortedToolRequired(t *testing.T, s *jsonschema.Schema) []string {
+	t.Helper()
+	require.Contains(t, s.Required, "telemetry")
 	req := slices.Clone(s.Required)
+	req = slices.DeleteFunc(req, func(field string) bool { return field == "telemetry" })
 	slices.Sort(req)
 	return req
 }
 
+func TestToolTelemetrySchema(t *testing.T) {
+	const contextDescription = "Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""
+
+	s := schemaFor[AccessTokenArgs](t)
+	require.Contains(t, s.Required, "telemetry")
+
+	telemetry := s.Properties["telemetry"]
+	require.NotNil(t, telemetry)
+	require.Contains(t, telemetry.Required, "context")
+	require.Equal(t, contextDescription, telemetry.Properties["context"].Description)
+}
+
 func TestListBuildsArgsSchema(t *testing.T) {
 	s := schemaFor[ListBuildsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 
 	// Required fields: org_slug only (pipeline_slug is optional for org-wide queries)
 	require.Equal(t, []string{"org_slug"}, req)
@@ -90,8 +109,7 @@ func TestUpdatePipelineArgsSchema(t *testing.T) {
 
 func TestListPipelineSchedulesArgsSchema(t *testing.T) {
 	s := schemaFor[ListPipelineSchedulesArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -106,8 +124,7 @@ func TestGetPipelineScheduleArgsSchema(t *testing.T) {
 
 func TestCreatePipelineScheduleArgsSchema(t *testing.T) {
 	s := schemaFor[CreatePipelineScheduleArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"cronline", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"label", "message", "commit", "branch", "env", "enabled"} {
@@ -117,8 +134,7 @@ func TestCreatePipelineScheduleArgsSchema(t *testing.T) {
 
 func TestUpdatePipelineScheduleArgsSchema(t *testing.T) {
 	s := schemaFor[UpdatePipelineScheduleArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug", "pipeline_slug", "schedule_id"}, req)
 
 	for _, opt := range []string{"cronline", "label", "message", "commit", "branch", "env", "enabled"} {
@@ -133,8 +149,7 @@ func TestCreateBuildArgsSchema(t *testing.T) {
 
 func TestListAnnotationsArgsSchema(t *testing.T) {
 	s := schemaFor[ListAnnotationsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -144,8 +159,7 @@ func TestListAnnotationsArgsSchema(t *testing.T) {
 
 func TestGetFailedTestExecutionsArgsSchema(t *testing.T) {
 	s := schemaFor[GetFailedTestExecutionsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug", "run_id", "test_suite_slug"}, req)
 
 	for _, opt := range []string{"include_failure_expanded", "page", "per_page"} {
@@ -155,8 +169,7 @@ func TestGetFailedTestExecutionsArgsSchema(t *testing.T) {
 
 func TestReadLogsParamsSchema(t *testing.T) {
 	s := schemaFor[ReadLogsParams](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"cache_ttl", "force_refresh", "seek", "limit"} {
@@ -166,8 +179,7 @@ func TestReadLogsParamsSchema(t *testing.T) {
 
 func TestSearchLogsParamsSchema(t *testing.T) {
 	s := schemaFor[SearchLogsParams](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pattern", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"cache_ttl", "force_refresh", "context", "before_context", "after_context", "case_sensitive", "invert_match", "reverse", "seek_start", "limit"} {
@@ -177,8 +189,7 @@ func TestSearchLogsParamsSchema(t *testing.T) {
 
 func TestTailLogsParamsSchema(t *testing.T) {
 	s := schemaFor[TailLogsParams](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"cache_ttl", "force_refresh", "tail"} {
@@ -188,8 +199,7 @@ func TestTailLogsParamsSchema(t *testing.T) {
 
 func TestListArtifactsForBuildArgsSchema(t *testing.T) {
 	s := schemaFor[ListArtifactsForBuildArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -199,8 +209,7 @@ func TestListArtifactsForBuildArgsSchema(t *testing.T) {
 
 func TestListArtifactsForJobArgsSchema(t *testing.T) {
 	s := schemaFor[ListArtifactsForJobArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -255,8 +264,7 @@ func TestListTestsForBuildArgsSchema(t *testing.T) {
 
 func TestListTestRunsArgsSchema(t *testing.T) {
 	s := schemaFor[ListTestRunsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug", "test_suite_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -271,8 +279,7 @@ func TestGetTestRunArgsSchema(t *testing.T) {
 
 func TestListPipelinesArgsSchema(t *testing.T) {
 	s := schemaFor[ListPipelinesArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug"}, req)
 
 	for _, opt := range []string{"name", "repository", "page", "per_page", "detail_level"} {
@@ -295,8 +302,7 @@ func TestListJobsArgsSchemaFilters(t *testing.T) {
 
 func TestUnblockJobArgsSchema(t *testing.T) {
 	s := schemaFor[UnblockJobArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "job_id", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"fields"} {
@@ -306,8 +312,7 @@ func TestUnblockJobArgsSchema(t *testing.T) {
 
 func TestListJobsArgsSchemaOptionalFields(t *testing.T) {
 	s := schemaFor[ListJobsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 
 	for _, opt := range []string{"state", "detail_level", "include_retried_jobs", "per_page", "after", "before", "include_agent"} {
@@ -317,8 +322,7 @@ func TestListJobsArgsSchemaOptionalFields(t *testing.T) {
 
 func TestListClustersArgsSchema(t *testing.T) {
 	s := schemaFor[ListClustersArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -333,8 +337,7 @@ func TestGetClusterArgsSchema(t *testing.T) {
 
 func TestListAgentsArgsSchema(t *testing.T) {
 	s := schemaFor[ListAgentsArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"org_slug"}, req)
 
 	for _, opt := range []string{"name", "hostname", "version", "cluster_queue_id", "page", "per_page", "detail_level"} {
@@ -347,16 +350,14 @@ func TestListAgentsArgsSchema(t *testing.T) {
 
 func TestGetAgentArgsSchema(t *testing.T) {
 	s := schemaFor[GetAgentArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"agent_id", "org_slug"}, req)
 	require.NotContains(t, s.Required, "detail_level")
 }
 
 func TestListClusterQueuesArgsSchema(t *testing.T) {
 	s := schemaFor[ListClusterQueuesArgs](t)
-	req := slices.Clone(s.Required)
-	slices.Sort(req)
+	req := sortedToolRequired(t, s)
 	require.Equal(t, []string{"cluster_id", "org_slug"}, req)
 
 	for _, opt := range []string{"page", "per_page"} {
@@ -376,7 +377,7 @@ func TestGetBuildTestEngineRunsArgsSchema(t *testing.T) {
 
 func TestListSkillsArgsSchema(t *testing.T) {
 	s := schemaFor[ListSkillsArgs](t)
-	require.Empty(t, s.Required)
+	require.Empty(t, sortedToolRequired(t, s))
 	require.Contains(t, s.Properties, "query")
 }
 

--- a/pkg/buildkite/skills.go
+++ b/pkg/buildkite/skills.go
@@ -42,6 +42,7 @@ func matchesAllTokens(haystack string, tokens []string) bool {
 }
 
 type ListSkillsArgs struct {
+	ToolInput
 	Query string `json:"query,omitempty" jsonschema:"Optional case-insensitive filter over skill name and description"`
 }
 
@@ -73,6 +74,7 @@ func ListSkills() (mcp.Tool, mcp.ToolHandlerFor[ListSkillsArgs, any], []string) 
 }
 
 type LoadSkillArgs struct {
+	ToolInput
 	SkillName string `json:"skill_name" jsonschema:"Name of the skill to load, as returned by list_skills"`
 }
 

--- a/pkg/buildkite/step_uploads.go
+++ b/pkg/buildkite/step_uploads.go
@@ -17,6 +17,7 @@ type StepUploadsClient interface {
 }
 
 type ListStepUploadsArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`
@@ -27,6 +28,7 @@ type ListStepUploadsArgs struct {
 }
 
 type GetStepUploadArgs struct {
+	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
 	BuildNumber  string `json:"build_number"`

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -14,6 +14,7 @@ type TestExecutionsClient interface {
 }
 
 type GetFailedTestExecutionsArgs struct {
+	ToolInput
 	OrgSlug                string `json:"org_slug"`
 	TestSuiteSlug          string `json:"test_suite_slug"`
 	RunID                  string `json:"run_id"`

--- a/pkg/buildkite/test_runs.go
+++ b/pkg/buildkite/test_runs.go
@@ -20,6 +20,7 @@ type TestRunsClient interface {
 }
 
 type ListTestRunsArgs struct {
+	ToolInput
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	Page          int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
@@ -27,6 +28,7 @@ type ListTestRunsArgs struct {
 }
 
 type GetTestRunArgs struct {
+	ToolInput
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	RunID         string `json:"run_id"`

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -20,6 +20,7 @@ type BuildTestsClient interface {
 }
 
 type ListTestsArgs struct {
+	ToolInput
 	OrgSlug       string    `json:"org_slug"`
 	TestSuiteSlug string    `json:"test_suite_slug"`
 	Page          int       `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
@@ -37,6 +38,7 @@ type ListTestsArgs struct {
 }
 
 type ListTestsForBuildArgs struct {
+	ToolInput
 	OrgSlug   string `json:"org_slug"`
 	BuildUUID string `json:"build_uuid" jsonschema:"Buildkite build UUID. This is the build ID, not the pipeline build number."`
 	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -51,6 +51,7 @@ type ListTestsForBuildArgs struct {
 }
 
 type GetTestArgs struct {
+	ToolInput
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	TestID        string `json:"test_id"`

--- a/pkg/buildkite/user.go
+++ b/pkg/buildkite/user.go
@@ -12,7 +12,9 @@ type UserClient interface {
 	CurrentUser(ctx context.Context) (buildkite.User, *buildkite.Response, error)
 }
 
-type CurrentUserArgs struct{}
+type CurrentUserArgs struct {
+	ToolInput
+}
 
 func CurrentUser() (mcp.Tool, mcp.ToolHandlerFor[CurrentUserArgs, any], []string) {
 	tool := mcp.Tool{

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -307,7 +308,7 @@ func newToolDef[In, Out any](toolFunc func() (mcp.Tool, mcp.ToolHandlerFor[In, O
 	if !ok {
 		panic(fmt.Sprintf("tool %q input schema is missing telemetry.context", tool.Name))
 	}
-	contextSchema.MaxLength = jsonschema.Ptr(buildkite.TelemetryContextMaxLength)
+	contextSchema.MaxLength = jsonschema.Ptr(trace.TelemetryContextMaxLength)
 	tool.InputSchema = inputSchema
 
 	return ToolDefinition{

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -294,6 +295,21 @@ func ValidateToolsets(names []string) error {
 // The generic parameters In and Out match the typed handler signature.
 func newToolDef[In, Out any](toolFunc func() (mcp.Tool, mcp.ToolHandlerFor[In, Out], []string)) ToolDefinition {
 	tool, handler, scopes := toolFunc()
+	inputSchema, err := jsonschema.For[In](nil)
+	if err != nil {
+		panic(fmt.Sprintf("generate input schema for tool %q: %v", tool.Name, err))
+	}
+	telemetrySchema, ok := inputSchema.Properties["telemetry"]
+	if !ok {
+		panic(fmt.Sprintf("tool %q input schema is missing telemetry", tool.Name))
+	}
+	contextSchema, ok := telemetrySchema.Properties["context"]
+	if !ok {
+		panic(fmt.Sprintf("tool %q input schema is missing telemetry.context", tool.Name))
+	}
+	contextSchema.MaxLength = jsonschema.Ptr(buildkite.TelemetryContextMaxLength)
+	tool.InputSchema = inputSchema
+
 	return ToolDefinition{
 		Tool: tool,
 		Register: func(s *mcp.Server) {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -725,5 +726,6 @@ func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
 		contextProperty, ok := telemetryProperties["context"].(map[string]any)
 		require.True(t, ok, "%s has no telemetry.context property", tool.Name)
 		require.Equal(t, contextDescription, contextProperty["description"], "%s has the wrong telemetry.context description", tool.Name)
+		require.Equal(t, float64(buildkite.TelemetryContextMaxLength), contextProperty["maxLength"], "%s has the wrong telemetry.context maxLength", tool.Name)
 	}
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -726,6 +726,6 @@ func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
 		contextProperty, ok := telemetryProperties["context"].(map[string]any)
 		require.True(t, ok, "%s has no telemetry.context property", tool.Name)
 		require.Equal(t, contextDescription, contextProperty["description"], "%s has the wrong telemetry.context description", tool.Name)
-		require.Equal(t, float64(trace.TelemetryContextMaxLength), contextProperty["maxLength"], "%s has the wrong telemetry.context maxLength", tool.Name)
+		require.InDelta(t, float64(trace.TelemetryContextMaxLength), contextProperty["maxLength"], 0, "%s has the wrong telemetry.context maxLength", tool.Name)
 	}
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -679,7 +679,7 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 }
 
 func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
-	const contextDescription = "Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""
+	const contextDescription = "Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
 	for _, toolset := range CreateBuiltinToolsets() {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -1,6 +1,7 @@
 package toolsets
 
 import (
+	"context"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -675,4 +676,54 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	}
 	assert.Contains(toolNames, "list_tests")
 	assert.Contains(toolNames, "list_tests_for_build")
+}
+
+func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
+	const contextDescription = "Explain why you are calling this tool and how it fits into the user's overall goal. This parameter is used for analytics and user intent tracking. YOU MUST provide 15-25 words (count carefully). NEVER use first person ('I', 'we', 'you') - maintain third-person perspective. NEVER include sensitive information such as credentials, passwords, or personal data. Example (20 words): \"Searching across the organization's repositories to find all open issues related to performance complaints and latency issues for team prioritization.\""
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	for _, toolset := range CreateBuiltinToolsets() {
+		for _, tool := range toolset.Tools {
+			tool.Register(server)
+		}
+	}
+
+	ctx := context.Background()
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test", Version: "test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	result, err := clientSession.ListTools(ctx, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Tools)
+
+	for _, tool := range result.Tools {
+		inputSchema, ok := tool.InputSchema.(map[string]any)
+		require.True(t, ok, "%s input schema has type %T", tool.Name, tool.InputSchema)
+
+		required, ok := inputSchema["required"].([]any)
+		require.True(t, ok, "%s input schema has no required fields", tool.Name)
+		require.Contains(t, required, "telemetry", "%s must require telemetry", tool.Name)
+
+		properties, ok := inputSchema["properties"].(map[string]any)
+		require.True(t, ok, "%s input schema has no properties", tool.Name)
+		telemetry, ok := properties["telemetry"].(map[string]any)
+		require.True(t, ok, "%s has no telemetry property", tool.Name)
+
+		telemetryRequired, ok := telemetry["required"].([]any)
+		require.True(t, ok, "%s telemetry schema has no required fields", tool.Name)
+		require.Contains(t, telemetryRequired, "context", "%s must require telemetry.context", tool.Name)
+
+		telemetryProperties, ok := telemetry["properties"].(map[string]any)
+		require.True(t, ok, "%s telemetry schema has no properties", tool.Name)
+		contextProperty, ok := telemetryProperties["context"].(map[string]any)
+		require.True(t, ok, "%s has no telemetry.context property", tool.Name)
+		require.Equal(t, contextDescription, contextProperty["description"], "%s has the wrong telemetry.context description", tool.Name)
+	}
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/buildkite/buildkite-mcp-server/pkg/buildkite"
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -726,6 +726,6 @@ func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
 		contextProperty, ok := telemetryProperties["context"].(map[string]any)
 		require.True(t, ok, "%s has no telemetry.context property", tool.Name)
 		require.Equal(t, contextDescription, contextProperty["description"], "%s has the wrong telemetry.context description", tool.Name)
-		require.Equal(t, float64(buildkite.TelemetryContextMaxLength), contextProperty["maxLength"], "%s has the wrong telemetry.context maxLength", tool.Name)
+		require.Equal(t, float64(trace.TelemetryContextMaxLength), contextProperty["maxLength"], "%s has the wrong telemetry.context maxLength", tool.Name)
 	}
 }

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -12,6 +12,9 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+// Keep user-controlled trace attributes within a predictable storage bound.
+const telemetryContextMaxBytes = 512
+
 func NewMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
@@ -93,6 +96,10 @@ func toolTelemetryContext(req mcp.Request) string {
 		} `json:"telemetry"`
 	}
 	if err := json.Unmarshal(params.Arguments, &args); err != nil {
+		return ""
+	}
+
+	if len(args.Telemetry.Context) > telemetryContextMaxBytes {
 		return ""
 	}
 

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -14,6 +15,10 @@ import (
 func NewMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
 		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			if telemetryContext := toolTelemetryContext(req); telemetryContext != "" {
+				ctx = context.WithValue(ctx, telemetryContextKey{}, telemetryContext)
+			}
+
 			ctx, span := Start(ctx, fmt.Sprintf("mcp.%s", method))
 			defer span.End()
 
@@ -74,6 +79,24 @@ func NewMiddleware() mcp.Middleware {
 			return res, err
 		}
 	}
+}
+
+func toolTelemetryContext(req mcp.Request) string {
+	params, ok := req.GetParams().(*mcp.CallToolParamsRaw)
+	if !ok || params == nil || len(params.Arguments) == 0 {
+		return ""
+	}
+
+	var args struct {
+		Telemetry struct {
+			Context string `json:"context"`
+		} `json:"telemetry"`
+	}
+	if err := json.Unmarshal(params.Arguments, &args); err != nil {
+		return ""
+	}
+
+	return args.Telemetry.Context
 }
 
 // clientInfoRequest matches the SDK's typed ServerRequest.ClientInfo

--- a/pkg/trace/middleware.go
+++ b/pkg/trace/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"unicode/utf8"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/rs/zerolog"
@@ -12,8 +13,9 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// Keep user-controlled trace attributes within a predictable storage bound.
-const telemetryContextMaxBytes = 512
+// TelemetryContextMaxLength is the maximum number of Unicode code points
+// accepted in telemetry context values.
+const TelemetryContextMaxLength = 256
 
 func NewMiddleware() mcp.Middleware {
 	return func(next mcp.MethodHandler) mcp.MethodHandler {
@@ -99,7 +101,7 @@ func toolTelemetryContext(req mcp.Request) string {
 		return ""
 	}
 
-	if len(args.Telemetry.Context) > telemetryContextMaxBytes {
+	if utf8.RuneCountInString(args.Telemetry.Context) > TelemetryContextMaxLength {
 		return ""
 	}
 

--- a/pkg/trace/middleware_test.go
+++ b/pkg/trace/middleware_test.go
@@ -126,6 +126,54 @@ func TestNewMiddlewareAddsTelemetryContextToAllToolTraceSpans(t *testing.T) {
 	assert.Equal(telemetryContext, spanAttrs(t, tp, sr, "http.request")[telemetryContextAttribute])
 }
 
+func TestNewMiddlewareTelemetryContextByteLimit(t *testing.T) {
+	tests := []struct {
+		name    string
+		context string
+		want    bool
+	}{
+		{name: "512 ASCII bytes", context: strings.Repeat("a", telemetryContextMaxBytes), want: true},
+		{name: "513 ASCII bytes", context: strings.Repeat("a", telemetryContextMaxBytes+1), want: false},
+		{name: "512 multibyte bytes", context: strings.Repeat("é", telemetryContextMaxBytes/2), want: true},
+		{name: "514 multibyte bytes", context: strings.Repeat("é", telemetryContextMaxBytes/2+1), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := require.New(t)
+			ctx := context.Background()
+
+			server, sr := setupMiddlewareServer(t)
+			t1, t2 := mcp.NewInMemoryTransports()
+			_, err := server.Connect(ctx, t1, nil)
+			assert.NoError(err)
+
+			client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+			session, err := client.Connect(ctx, t2, nil)
+			assert.NoError(err)
+			defer session.Close()
+
+			_, err = session.CallTool(ctx, &mcp.CallToolParams{
+				Name: "ping",
+				Arguments: map[string]any{
+					"telemetry": map[string]any{"context": tt.context},
+				},
+			})
+			assert.NoError(err)
+
+			tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+			for _, spanName := range []string{"mcp.tools/call", "buildkite.Ping", "http.request"} {
+				attrs := spanAttrs(t, tp, sr, spanName)
+				if tt.want {
+					assert.Equal(tt.context, attrs[telemetryContextAttribute])
+				} else {
+					assert.NotContains(attrs, telemetryContextAttribute)
+				}
+			}
+		})
+	}
+}
+
 // captureLogs redirects the global zerolog logger to a buffer for the
 // duration of the test and returns it.
 func captureLogs(t *testing.T) *bytes.Buffer {

--- a/pkg/trace/middleware_test.go
+++ b/pkg/trace/middleware_test.go
@@ -126,16 +126,16 @@ func TestNewMiddlewareAddsTelemetryContextToAllToolTraceSpans(t *testing.T) {
 	assert.Equal(telemetryContext, spanAttrs(t, tp, sr, "http.request")[telemetryContextAttribute])
 }
 
-func TestNewMiddlewareTelemetryContextByteLimit(t *testing.T) {
+func TestNewMiddlewareTelemetryContextLengthLimit(t *testing.T) {
 	tests := []struct {
 		name    string
 		context string
 		want    bool
 	}{
-		{name: "512 ASCII bytes", context: strings.Repeat("a", telemetryContextMaxBytes), want: true},
-		{name: "513 ASCII bytes", context: strings.Repeat("a", telemetryContextMaxBytes+1), want: false},
-		{name: "512 multibyte bytes", context: strings.Repeat("é", telemetryContextMaxBytes/2), want: true},
-		{name: "514 multibyte bytes", context: strings.Repeat("é", telemetryContextMaxBytes/2+1), want: false},
+		{name: "256 ASCII code points", context: strings.Repeat("a", TelemetryContextMaxLength), want: true},
+		{name: "257 ASCII code points", context: strings.Repeat("a", TelemetryContextMaxLength+1), want: false},
+		{name: "256 multibyte code points", context: strings.Repeat("é", TelemetryContextMaxLength), want: true},
+		{name: "257 multibyte code points", context: strings.Repeat("é", TelemetryContextMaxLength+1), want: false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/trace/middleware_test.go
+++ b/pkg/trace/middleware_test.go
@@ -25,13 +25,20 @@ func setupMiddlewareServer(t *testing.T) (*mcp.Server, *tracetest.SpanRecorder) 
 	ctx := context.Background()
 
 	sr := tracetest.NewSpanRecorder()
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sr),
+		sdktrace.WithSpanProcessor(telemetryContextSpanProcessor{}),
+	)
 	otel.SetTracerProvider(tp)
 	t.Cleanup(func() { _ = tp.Shutdown(ctx) })
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.0.1"}, nil)
 	server.AddReceivingMiddleware(NewMiddleware())
-	mcp.AddTool(server, &mcp.Tool{Name: "ping"}, func(_ context.Context, _ *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+	mcp.AddTool(server, &mcp.Tool{Name: "ping"}, func(ctx context.Context, _ *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+		_, span := Start(ctx, "buildkite.Ping")
+		span.End()
+		_, autoInstrumentedSpan := otel.Tracer("test-auto-instrumentation").Start(ctx, "http.request")
+		autoInstrumentedSpan.End()
 		return &mcp.CallToolResult{}, nil, nil
 	})
 
@@ -86,6 +93,37 @@ func TestNewMiddleware(t *testing.T) {
 	assert.Equal("test-client", attrs["mcp.client.name"], "mcp.client.name should be captured from per-request _meta")
 	assert.Equal("v0.0.1", attrs["mcp.client.version"], "mcp.client.version should be captured from per-request _meta")
 	assert.Equal("ping", attrs["mcp.tool_name"], "mcp.tool_name should be set for tools/call requests")
+	assert.NotContains(attrs, telemetryContextAttribute)
+}
+
+func TestNewMiddlewareAddsTelemetryContextToAllToolTraceSpans(t *testing.T) {
+	assert := require.New(t)
+	ctx := context.Background()
+
+	server, sr := setupMiddlewareServer(t)
+
+	t1, t2 := mcp.NewInMemoryTransports()
+	_, err := server.Connect(ctx, t1, nil)
+	assert.NoError(err)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, t2, nil)
+	assert.NoError(err)
+	defer session.Close()
+
+	const telemetryContext = "Fetching the current Buildkite user to verify telemetry context propagation across every span emitted for this tool call."
+	_, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "ping",
+		Arguments: map[string]any{
+			"telemetry": map[string]any{"context": telemetryContext},
+		},
+	})
+	assert.NoError(err)
+
+	tp := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+	assert.Equal(telemetryContext, spanAttrs(t, tp, sr, "mcp.tools/call")[telemetryContextAttribute])
+	assert.Equal(telemetryContext, spanAttrs(t, tp, sr, "buildkite.Ping")[telemetryContextAttribute])
+	assert.Equal(telemetryContext, spanAttrs(t, tp, sr, "http.request")[telemetryContextAttribute])
 }
 
 // captureLogs redirects the global zerolog logger to a buffer for the

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -21,6 +22,10 @@ import (
 // tracerName is the instrumentation library name, fixed for this package.
 const tracerName = "buildkite-mcp-server"
 
+const telemetryContextAttribute = "telemetry.context"
+
+type telemetryContextKey struct{}
+
 func NewProvider(ctx context.Context, exporter, name, version string) (*sdktrace.TracerProvider, error) {
 	exp, err := newExporter(ctx, exporter)
 	if err != nil {
@@ -34,6 +39,7 @@ func NewProvider(ctx context.Context, exporter, name, version string) (*sdktrace
 
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
+		sdktrace.WithSpanProcessor(telemetryContextSpanProcessor{}),
 		sdktrace.WithResource(res),
 	)
 	otel.SetTracerProvider(tp)
@@ -48,8 +54,29 @@ func NewProvider(ctx context.Context, exporter, name, version string) (*sdktrace
 	return tp, nil
 }
 
+// telemetryContextSpanProcessor adds tool intent to spans created by other
+// instrumentation, including outbound HTTP client spans.
+type telemetryContextSpanProcessor struct{}
+
+func (telemetryContextSpanProcessor) OnStart(ctx context.Context, span sdktrace.ReadWriteSpan) {
+	if telemetryContext, ok := ctx.Value(telemetryContextKey{}).(string); ok && telemetryContext != "" {
+		span.SetAttributes(attribute.String(telemetryContextAttribute, telemetryContext))
+	}
+}
+
+func (telemetryContextSpanProcessor) OnEnd(sdktrace.ReadOnlySpan) {}
+
+func (telemetryContextSpanProcessor) Shutdown(context.Context) error { return nil }
+
+func (telemetryContextSpanProcessor) ForceFlush(context.Context) error { return nil }
+
 func Start(ctx context.Context, name string) (context.Context, trace.Span) {
-	return otel.GetTracerProvider().Tracer(tracerName).Start(ctx, name)
+	var options []trace.SpanStartOption
+	if telemetryContext, ok := ctx.Value(telemetryContextKey{}).(string); ok && telemetryContext != "" {
+		options = append(options, trace.WithAttributes(attribute.String(telemetryContextAttribute, telemetryContext)))
+	}
+
+	return otel.GetTracerProvider().Tracer(tracerName).Start(ctx, name, options...)
 }
 
 func NewError(span trace.Span, msg string, args ...any) error {


### PR DESCRIPTION
## Why

Tool calls need consistent intent context for analytics and user-goal tracking without collecting sensitive information.

## What

Adds a required nested `telemetry.context` field to all 50 tool input schemas. The schema instructs callers to provide a 15–25 word, third-person explanation of the call purpose.

## How

Introduces shared `ToolInput` and `ToolTelemetry` structs, embeds them across every tool input, and adds schema and integration tests covering all registered tools.

## Examples

```
⏺ buildkite - Get Organization for User Token (MCP)(telemetry: {"context":"Looking up the organization slug to query the latest CI build for the current feature branch."})
```

```
⏺ buildkite - List Builds (MCP)(telemetry: {"context":"Finding the most recent build for the feat/tool-telemetry-context branch to summarize its status for the user."}, org_slug: "buildkite", pipeline_slug: "buildkite-mcp-server", branch: "feat/tool-telemetry-context", per_page: 1)