### PR TITLE
Add eval scaneario that step upload a broken pipeline yml

### DIFF
--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -83,6 +83,37 @@ matrix:
     mcp_version: source
     # compare_target defaults to this run.
 
+  # Based on the original babystand scenario: drive a red CI branch to green.
+  # This scenario exercises the mcp get information from step upload/dynamic pipelines tool 
+  - id: red-to-green-complete-step-upload-bad-pipeline-yml
+    agent: claude
+    model: claude-opus-4-8
+    prompt: red-to-green-complete
+    scenario:
+      setup: |
+        # See 'red-to-green-complete' above
+        SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
+        git fetch
+        git checkout -b "$SCENARIO_BRANCH" origin/test-step-upload-job-failed
+        cat > .buildkite/steps.yml <<'EOF'
+        common:
+          - &right_deploy
+            docker#v5.13.0:
+              image: alpine:3.20
+
+        steps:
+          - label: ":wave: Hello"
+            command: echo "hello world"
+            plugins:
+              <<: *wrong_deploy
+        EOF
+        # Hand the generated branch name to the prompt template.
+        echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
+        git push -u origin HEAD
+        rm .buildkite/steps.yml
+    mcp_version: source
+    # compare_target defaults to this run.
+
   # The same scenario driven by the Cursor CLI instead of Claude Code — lets a
   # build compare how two different agents fare against the same MCP server.
   # Requires CURSOR_API_KEY (uncomment its env + secrets lines in

--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -61,27 +61,29 @@
 
 matrix:
   # The original babystand scenario: drive a red CI branch to green.
-  - id: red-to-green-complete
-    agent: claude
-    model: claude-opus-4-8
-    prompt: red-to-green-complete
-    scenario:
-      setup: |
-        # Establish the red CI signal: branch from the deliberately-broken base
-        # and push it (the branch push triggers its own Quality Checks build,
-        # which is what the agent then fixes). The branch is pushed to the EVAL
-        # repo (EVAL_REPO_SLUG — this setup runs inside babystand.sh's clone of
-        # it), so its builds run on the EVAL org's pipeline; scenario branches
-        # never exist in the repo hosting this eval, so the eval pipeline cannot
-        # recurse (see the CROSS-REPO note in .buildkite/pipeline.evals.yml).
-        SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
-        git fetch
-        git checkout -b "$SCENARIO_BRANCH" origin/test-broken-and-failed-jobs
-        git push -u origin HEAD
-        # Hand the generated branch name to the prompt template.
-        echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
-    mcp_version: source
-    # compare_target defaults to this run.
+  #- id: red-to-green-complete
+  #  agent: claude
+  #  model: claude-opus-4-8
+  #  prompt: red-to-green-complete
+  #  scenario:
+  #    setup: |
+  #      # Establish the red CI signal: branch from the deliberately-broken base
+  #      # and push it (the branch push triggers its own Quality Checks build,
+  #      # which is what the agent then fixes). The branch is pushed to the EVAL
+  #      # repo (EVAL_REPO_SLUG — this setup runs inside babystand.sh's clone of
+  #      # it), so its builds run on the EVAL org's pipeline; scenario branches
+  #      # never exist in the repo hosting this eval, so the eval pipeline cannot
+  #      # recurse (see the CROSS-REPO note in .buildkite/pipeline.evals.yml).
+  #      SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
+  #      git config user.name "MCP Evals Framework"
+  #      git config user.email "mcp-evals-framework@buildkite.com"
+  #      git fetch
+  #      git checkout -b "$SCENARIO_BRANCH" origin/test-broken-and-failed-jobs
+  #      git push -u origin HEAD
+  #      # Hand the generated branch name to the prompt template.
+  #      echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
+  #  mcp_version: source
+  #  # compare_target defaults to this run.
 
   # Based on the original babystand scenario: drive a red CI branch to green.
   # This scenario exercises the mcp get information from step upload/dynamic pipelines tool 
@@ -93,6 +95,8 @@ matrix:
       setup: |
         # See 'red-to-green-complete' above
         SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
+        git config user.name "MCP Evals Framework"
+        git config user.email "mcp-evals-framework@buildkite.com"
         git fetch
         git checkout -b "$SCENARIO_BRANCH" origin/test-step-upload-job-failed
         cat > .buildkite/steps.yml <<'EOF'
@@ -107,10 +111,19 @@ matrix:
             plugins:
               <<: *wrong_deploy
         EOF
+        git add .buildkite/steps.yml
+        git commit -m "Get Ready For Build"
+
+
         # Hand the generated branch name to the prompt template.
         echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
         git push -u origin HEAD
-        rm .buildkite/steps.yml
+
+        git rm .buildkite/steps.yml
+        git commit --amend --no-edit --allow-empty
+        git push --force-with-lease
+        git reflog expire --expire=now --all
+        git gc --prune=now
     mcp_version: source
     # compare_target defaults to this run.
 


### PR DESCRIPTION
Introduce an eval scenario that exercises LLM agents ability to utilize the upcoming `step upload`  tools (list, get)

The scenario: 
* The is a scenario branch here: https://github.com/nethsix/buildkite-mcp-server/tree/test-step-upload-job-failed
  * The `.buildlkite/pipeline.yml` creates a pipeline by using a `step upload` to upload `.buildkite/steps.yml` as dynamic pipeline
  * `steps.yml` file does NOT exist in that scenario branch
    *  It is dynamically created by `evals/evals.yaml` here
    * We didn't create it in the scenario branch because we want to delete it and force the LLM agent to recover it from the `step upload` tools
      * If `steps.yml` is in the scenario branch, LLM will try all sorts of ways to recover it by checking out the scenario branch again

Expected outcome of this eval scenario
* LLM agent will fumble around because currently this repo has not incorporated the `step upload` tools
* `step upload` tools will land in this [PR](https://github.com/buildkite/buildkite-mcp-server/pull/364), and this eval scenario should demonstrate LLM agent successfully recovers `steps.yml` 