### PR TITLE
feat: add list_tests_for_build MCP tool

### DIFF
--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -44,6 +44,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 		TestRunsClient:          globals.Client.TestRuns,
 		TestExecutionsClient:    globals.Client.TestRuns,
 		TestsClient:             globals.Client.Tests,
+		BuildTestsClient:        globals.Client.BuildTests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,
 		FailureSummary:          globals.FailureSummary,
 	}

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -37,6 +37,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 		TestRunsClient:          globals.Client.TestRuns,
 		TestExecutionsClient:    globals.Client.TestRuns,
 		TestsClient:             globals.Client.Tests,
+		BuildTestsClient:        globals.Client.BuildTests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,
 		FailureSummary:          globals.FailureSummary,
 	}

--- a/pkg/buildkite/dependencies.go
+++ b/pkg/buildkite/dependencies.go
@@ -29,6 +29,7 @@ type ToolDependencies struct {
 	TestRunsClient          TestRunsClient
 	TestExecutionsClient    TestExecutionsClient
 	TestsClient             TestsClient
+	BuildTestsClient        BuildTestsClient
 	BuildkiteLogsClient     BuildkiteLogsClient
 	FailureSummary          FailureSummaryConfig
 }

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -242,6 +242,17 @@ func TestListTestsArgsSchema(t *testing.T) {
 	require.Contains(t, s.Properties["order"].Description, "asc")
 }
 
+func TestListTestsForBuildArgsSchema(t *testing.T) {
+	s := schemaFor[ListTestsForBuildArgs](t)
+	require.Equal(t, []string{"build_uuid", "org_slug"}, sortedRequired[ListTestsForBuildArgs](t))
+
+	for _, property := range []string{"page", "per_page", "labels", "branch", "owners", "state", "tags", "sort_by", "order"} {
+		require.Contains(t, s.Properties, property)
+		require.NotContains(t, s.Required, property, "%s should be optional", property)
+	}
+	require.Contains(t, s.Properties["build_uuid"].Description, "not the pipeline build number")
+}
+
 func TestListTestRunsArgsSchema(t *testing.T) {
 	s := schemaFor[ListTestRunsArgs](t)
 	req := slices.Clone(s.Required)

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -15,6 +15,10 @@ type TestsClient interface {
 	List(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
 }
 
+type BuildTestsClient interface {
+	List(ctx context.Context, org, buildUUID string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
+}
+
 type ListTestsArgs struct {
 	OrgSlug       string    `json:"org_slug"`
 	TestSuiteSlug string    `json:"test_suite_slug"`
@@ -30,6 +34,20 @@ type ListTestsArgs struct {
 	Tags          string    `json:"tags,omitempty" jsonschema:"Filter by comma-separated execution tags in key:value form. Values support '!' for exclusion and '*' for prefix matching. Result values additionally support '~' for any matching execution and '^' for every execution matching, for example 'framework:!rspec,scm.branch:feature*,result:^passed'."`
 	SortBy        string    `json:"sort_by,omitempty" jsonschema:"Metric used to sort results: 'duration_avg', 'duration_sum', 'duration_min', 'duration_max', or 'reliability'. Defaults to 'duration_avg'. Metrics cover only executions in the selected window."`
 	Order         string    `json:"order,omitempty" jsonschema:"Sort direction: 'asc' or 'desc'. Defaults to 'desc'."`
+}
+
+type ListTestsForBuildArgs struct {
+	OrgSlug   string `json:"org_slug"`
+	BuildUUID string `json:"build_uuid" jsonschema:"Buildkite build UUID. This is the build ID, not the pipeline build number."`
+	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
+	PerPage   int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+	Labels    string `json:"labels,omitempty" jsonschema:"Filter by comma-separated test labels. Prefix a label with '!' to exclude it, for example 'flaky,!slow'."`
+	Branch    string `json:"branch,omitempty" jsonschema:"Filter executions included in the metrics by branch. Prefix with '!' to exclude an exact branch or suffix with '*' for prefix matching, for example '!main' or 'feature*'. Use at most one operator."`
+	Owners    string `json:"owners,omitempty" jsonschema:"Filter by comma-separated test owner slugs. Prefix an owner with '!' to exclude it, for example 'payments,!platform'."`
+	State     string `json:"state,omitempty" jsonschema:"Filter by test state: 'enabled', 'muted', or 'skipped'."`
+	Tags      string `json:"tags,omitempty" jsonschema:"Filter by comma-separated execution tags in key:value form. Values support '!' for exclusion and '*' for prefix matching. Result values additionally support '~' for any matching execution and '^' for every execution matching, for example 'framework:!rspec,scm.branch:feature*,result:^passed'."`
+	SortBy    string `json:"sort_by,omitempty" jsonschema:"Metric used to sort results: 'duration_avg', 'duration_sum', 'duration_min', 'duration_max', or 'reliability'. Defaults to 'duration_avg'."`
+	Order     string `json:"order,omitempty" jsonschema:"Sort direction: 'asc' or 'desc'. Defaults to 'desc'."`
 }
 
 type GetTestArgs struct {
@@ -90,6 +108,64 @@ func ListTests() (mcp.Tool, mcp.ToolHandlerFor[ListTestsArgs, any], []string) {
 
 			deps := DepsFromContext(ctx)
 			tests, resp, err := deps.TestsClient.List(ctx, args.OrgSlug, args.TestSuiteSlug, options)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			result := PaginatedResult[buildkite.TestWithMetrics]{
+				Items: tests,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			span.SetAttributes(attribute.Int("item_count", len(tests)))
+
+			return mcpTextResult(span, &result)
+		}, []string{"read_suites"}
+}
+
+func ListTestsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListTestsForBuildArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_tests_for_build",
+			Description: "List tests and their execution metrics for a Buildkite build. Requires the build UUID (the build ID, not the pipeline build number) and supports filtering, metric sorting, and pagination.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Tests for Build",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args ListTestsForBuildArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListTestsForBuild")
+			defer span.End()
+
+			paginationParams := paginationFromArgs(args.Page, args.PerPage)
+			options := &buildkite.BuildTestsListOptions{
+				ListOptions: paginationParams,
+				Labels:      args.Labels,
+				Branch:      args.Branch,
+				Owners:      args.Owners,
+				State:       args.State,
+				Tags:        args.Tags,
+				SortBy:      args.SortBy,
+				Order:       args.Order,
+			}
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("build_uuid", args.BuildUUID),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+				attribute.String("labels", args.Labels),
+				attribute.String("branch", args.Branch),
+				attribute.String("owners", args.Owners),
+				attribute.String("state", args.State),
+				attribute.String("tags", args.Tags),
+				attribute.String("sort_by", args.SortBy),
+				attribute.String("order", args.Order),
+			)
+
+			deps := DepsFromContext(ctx)
+			tests, resp, err := deps.BuildTestsClient.List(ctx, args.OrgSlug, args.BuildUUID, options)
 			if err != nil {
 				return handleBuildkiteError(err)
 			}

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -34,6 +34,74 @@ func (m *MockTestsClient) List(ctx context.Context, org, slug string, opt *build
 
 var _ TestsClient = (*MockTestsClient)(nil)
 
+type MockBuildTestsClient struct {
+	ListFunc func(ctx context.Context, org, buildUUID string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
+}
+
+func (m *MockBuildTestsClient) List(ctx context.Context, org, buildUUID string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+	return m.ListFunc(ctx, org, buildUUID, opt)
+}
+
+var _ BuildTestsClient = (*MockBuildTestsClient)(nil)
+
+func TestListTestsForBuild(t *testing.T) {
+	client := &MockBuildTestsClient{
+		ListFunc: func(ctx context.Context, org, buildUUID string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "019d66fb-e8db-47eb-866c-94b85d42b9a1", buildUUID)
+			require.Equal(t, buildkite.ListOptions{Page: 2, PerPage: 50}, opt.ListOptions)
+			require.Equal(t, "flaky,!slow", opt.Labels)
+			require.Equal(t, "main*", opt.Branch)
+			require.Equal(t, "payments,!platform", opt.Owners)
+			require.Equal(t, "enabled", opt.State)
+			require.Equal(t, "framework:rspec,result:^failed", opt.Tags)
+			require.Equal(t, "reliability", opt.SortBy)
+			require.Equal(t, "asc", opt.Order)
+
+			reliability := 0.97
+			return []buildkite.TestWithMetrics{{
+					Test:            buildkite.Test{ID: "test-123", Name: "Example Test"},
+					Reliability:     &reliability,
+					ExecutionsCount: 100,
+				}}, &buildkite.Response{Response: &http.Response{Header: http.Header{
+					"Link": []string{`<https://api.buildkite.com/v2/analytics/organizations/org/builds/019d66fb-e8db-47eb-866c-94b85d42b9a1/tests?page=3>; rel="next"`},
+				}}}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{BuildTestsClient: client})
+	tool, handler, scopes := ListTestsForBuild()
+
+	require.Equal(t, "list_tests_for_build", tool.Name)
+	require.Equal(t, "List Tests for Build", tool.Annotations.Title)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Contains(t, tool.Description, "build UUID")
+	require.Equal(t, []string{"read_suites"}, scopes)
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ListTestsForBuildArgs{
+		OrgSlug:   "org",
+		BuildUUID: "019d66fb-e8db-47eb-866c-94b85d42b9a1",
+		Page:      2,
+		PerPage:   50,
+		Labels:    "flaky,!slow",
+		Branch:    "main*",
+		Owners:    "payments,!platform",
+		State:     "enabled",
+		Tags:      "framework:rspec,result:^failed",
+		SortBy:    "reliability",
+		Order:     "asc",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var response PaginatedResult[buildkite.TestWithMetrics]
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, result).Text), &response))
+	require.Equal(t, `<https://api.buildkite.com/v2/analytics/organizations/org/builds/019d66fb-e8db-47eb-866c-94b85d42b9a1/tests?page=3>; rel="next"`, response.Headers["Link"])
+	require.Len(t, response.Items, 1)
+	require.Equal(t, "test-123", response.Items[0].ID)
+	require.Equal(t, 100, response.Items[0].ExecutionsCount)
+}
+
 func TestListTests(t *testing.T) {
 	minTimestamp := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
 	maxTimestamp := time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC)

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -379,6 +379,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 			Description: "Tools for managing test runs and test results",
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.ListTests),
+				newToolDef(buildkite.ListTestsForBuild),
 				newToolDef(buildkite.ListTestRuns),
 				newToolDef(buildkite.GetTestRun),
 				newToolDef(buildkite.GetFailedTestExecutions),

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -674,4 +674,5 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 		toolNames = append(toolNames, tool.Tool.Name)
 	}
 	assert.Contains(toolNames, "list_tests")
+	assert.Contains(toolNames, "list_tests_for_build")
 }


### PR DESCRIPTION
### Description

Agents can inspect test metrics across a Test Engine suite, but cannot currently answer which tests were slowest or flakiest on a specific build. This adds build-scoped test metrics through the new Build Tests API.

### Context

- Linear: https://linear.app/buildkite/issue/TE-6672

### Changes

- Add a read-only `list_tests_for_build` tool backed by `go-buildkite`'s `BuildTests` client.
- Support pagination, filtering, and sorting by duration or reliability.
- Register the tool in the Test Engine toolset and wire its dependency into HTTP and stdio servers.
- Cover argument schema, client forwarding, response pagination, and tool registration.

### Rollback

Safe to revert. The change only adds a read-only MCP tool and has no persistent state or migration.
