### PR TITLE
feat: add step ID to job summaries

### DIFF
--- a/pkg/buildkite/jobs.go
+++ b/pkg/buildkite/jobs.go
@@ -55,6 +55,7 @@ type JobSummary struct {
 	SoftFailed   bool                      `json:"soft_failed,omitempty"`
 	SignalReason string                    `json:"signal_reason,omitempty"`
 	StepKey      string                    `json:"step_key,omitempty"`
+	StepID       string                    `json:"step_id,omitempty"`
 	RetriesCount int                       `json:"retries_count,omitempty"`
 	RetrySource  *buildkite.JobRetrySource `json:"retry_source,omitempty"`
 }
@@ -84,6 +85,11 @@ type JobListResult[T any] struct {
 }
 
 func summarizeJob(job buildkite.Job) JobSummary {
+	var stepID string
+	if job.Step != nil {
+		stepID = job.Step.ID
+	}
+
 	return JobSummary{
 		ID:           job.ID,
 		Name:         job.Name,
@@ -93,6 +99,7 @@ func summarizeJob(job buildkite.Job) JobSummary {
 		SoftFailed:   job.SoftFailed,
 		SignalReason: job.SignalReason,
 		StepKey:      job.StepKey,
+		StepID:       stepID,
 		RetriesCount: job.RetriesCount,
 		RetrySource:  job.RetrySource,
 	}

--- a/pkg/buildkite/jobs_test.go
+++ b/pkg/buildkite/jobs_test.go
@@ -388,6 +388,7 @@ func TestListJobs(t *testing.T) {
 					SoftFailed:      true,
 					SignalReason:    "agent_stop",
 					StepKey:         "test",
+					Step:            &buildkite.StepInfo{ID: "step-1"},
 					RetriesCount:    1,
 					RetrySource:     &buildkite.JobRetrySource{JobID: "job-0", RetryType: "manual"},
 					BuildURL:        "https://api.buildkite.com/v2/builds/123",
@@ -411,7 +412,7 @@ func TestListJobs(t *testing.T) {
 		require.Len(t, response.Items, 1)
 		assert.Equal(t, map[string]any{
 			"id": "job-1", "name": "test", "state": "failed", "command": "go test ./...", "exit_status": float64(1),
-			"soft_failed": true, "signal_reason": "agent_stop", "step_key": "test",
+			"soft_failed": true, "signal_reason": "agent_stop", "step_key": "test", "step_id": "step-1",
 			"retries_count": float64(1), "retry_source": map[string]any{"job_id": "job-0", "retry_type": "manual"},
 		}, response.Items[0])
 	})

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -94,6 +94,10 @@ var instructionSections = []instructionSection{
 		text:    "Job state \"broken\" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.",
 	},
 	{
+		toolset: toolsets.ToolsetBuilds,
+		text:    "Job output links: Job summaries expose a step ID as step_id; full job responses expose it as step.id. To link directly to that job's output, use https://buildkite.com/{org_slug}/{pipeline_slug}/builds/{build_number}/list?sid={step_id}&tab=output.",
+	},
+	{
 		toolset: toolsets.ToolsetLogs,
 		text:    "Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.",
 	},

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -19,6 +19,7 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		forbiddenAccess  = "A 403 response means the credentials were accepted but access was denied"
 		buildNumber      = "build_number is a sequential"
 		jobStateBroken   = `Job state "broken"`
+		jobOutputLinks   = "Job output links:"
 		logInvestigation = "Log investigation order:"
 		annotationScope  = "Annotation scope:"
 		failureSummary   = "Build failure investigation:"
@@ -36,45 +37,45 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		{
 			name:    "all toolsets includes every section",
 			enabled: []string{"all"},
-			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, logInvestigation, annotationScope),
+			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope),
 		},
 		{
 			name:    "builds alone",
 			enabled: []string{"builds"},
-			want:    append(append([]string{}, always...), jobStateBroken),
+			want:    append(append([]string{}, always...), jobStateBroken, jobOutputLinks),
 			notWant: []string{startHere, skillDiscovery, failureSummary, logInvestigation, annotationScope},
 		},
 		{
 			name:    "skills alone",
 			enabled: []string{"skills"},
 			want:    append(append([]string{}, always...), skillDiscovery),
-			notWant: []string{startHere, failureSummary, jobStateBroken, logInvestigation, annotationScope},
+			notWant: []string{startHere, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
 		},
 		{
 			name:    "user alone",
 			enabled: []string{"user"},
 			want:    append(append([]string{}, always...), startHere),
-			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, logInvestigation, annotationScope},
+			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
 		},
 		{
 			name:     "all toolsets, read-only, omits annotation scope",
 			enabled:  []string{"all"},
 			readOnly: true,
-			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, logInvestigation),
+			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation),
 			notWant:  []string{annotationScope},
 		},
 		{
 			name:    "investigations alone",
 			enabled: []string{"investigations"},
 			want:    append(append([]string{}, always...), failureSummary),
-			notWant: []string{startHere, skillDiscovery, jobStateBroken, logInvestigation, annotationScope},
+			notWant: []string{startHere, skillDiscovery, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
 		},
 		{
 			name:     "annotations toolset, read-only, omits annotation scope",
 			enabled:  []string{"annotations"},
 			readOnly: true,
 			want:     append([]string{}, always...),
-			notWant:  []string{annotationScope},
+			notWant:  []string{jobOutputLinks, annotationScope},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add `step_id` to lightweight job summaries, populated from `job.Step.ID` when available.
- Preserve compact responses by omitting `step_id` when step metadata is absent.
- Document how to construct direct job-output links from `step_id` or `step.id` in the builds server instructions.
- Add test coverage for the summary field and toolset-gated instructions.

The documented `/list?sid={step_id}&tab=output` link format works with both the current and classic Buildkite UIs.

## Testing

- `go test ./...`
- Manually verified the job-output link with both the current and classic Buildkite UIs.

Fixes #55