### PR TITLE
Make telemetry tool input optional for backward compatibility

### DIFF
--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -21,7 +21,7 @@ type PaginatedResult[T any] struct {
 
 // ToolInput contains metadata common to every tool invocation.
 type ToolInput struct {
-	Telemetry ToolTelemetry `json:"telemetry" jsonschema:"Analytics metadata describing the tool call's purpose"`
+	Telemetry ToolTelemetry `json:"telemetry,omitempty" jsonschema:"Analytics metadata describing the tool call's purpose"`
 }
 
 // ToolTelemetry describes why a tool is being called.

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -23,13 +23,13 @@ func sortedRequired[T any](t *testing.T) []string {
 	return sortedToolRequired(t, schemaFor[T](t))
 }
 
-// sortedToolRequired returns the tool-specific required fields after verifying
-// and removing the telemetry field common to every tool input.
+// sortedToolRequired returns the tool's required fields after verifying that
+// the telemetry field common to every tool input stays optional: clients that
+// cached a pre-telemetry schema must not fail validation for omitting it.
 func sortedToolRequired(t *testing.T, s *jsonschema.Schema) []string {
 	t.Helper()
-	require.Contains(t, s.Required, "telemetry")
+	require.NotContains(t, s.Required, "telemetry")
 	req := slices.Clone(s.Required)
-	req = slices.DeleteFunc(req, func(field string) bool { return field == "telemetry" })
 	slices.Sort(req)
 	return req
 }
@@ -38,7 +38,7 @@ func TestToolTelemetrySchema(t *testing.T) {
 	const contextDescription = "Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."
 
 	s := schemaFor[AccessTokenArgs](t)
-	require.Contains(t, s.Required, "telemetry")
+	require.NotContains(t, s.Required, "telemetry")
 
 	telemetry := s.Properties["telemetry"]
 	require.NotNil(t, telemetry)

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -679,7 +679,7 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	assert.Contains(toolNames, "list_tests_for_build")
 }
 
-func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
+func TestBuiltinToolSchemasAdvertiseOptionalTelemetry(t *testing.T) {
 	const contextDescription = "Explain why calling this tool fits the user's overall goal. This parameter supports analytics and user-intent tracking. Provide 15-25 meaningful words in third-person perspective. Avoid credentials, passwords, and personal data; the server does not classify sensitive content."
 
 	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "test"}, nil)
@@ -708,9 +708,11 @@ func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
 		inputSchema, ok := tool.InputSchema.(map[string]any)
 		require.True(t, ok, "%s input schema has type %T", tool.Name, tool.InputSchema)
 
-		required, ok := inputSchema["required"].([]any)
-		require.True(t, ok, "%s input schema has no required fields", tool.Name)
-		require.Contains(t, required, "telemetry", "%s must require telemetry", tool.Name)
+		// telemetry stays optional at the top level so clients that cached a
+		// pre-telemetry schema do not fail argument validation by omitting it.
+		if required, ok := inputSchema["required"].([]any); ok {
+			require.NotContains(t, required, "telemetry", "%s must not require telemetry", tool.Name)
+		}
 
 		properties, ok := inputSchema["properties"].(map[string]any)
 		require.True(t, ok, "%s input schema has no properties", tool.Name)


### PR DESCRIPTION
#362 (v1.20.0) added `telemetry` to the **required** fields of every tool's input schema. That breaks MCP clients that cached a pre-1.20.0 schema — remote-connector gateways and long-lived sessions that don't re-fetch `tools/list` mid-session. They omit the field, and every tool call now fails argument validation with `validating "arguments": validating root: required: missing properties: ["telemetry"]`, including zero-argument tools like `user_token_organization` that previously accepted `{}`. We hit this against the hosted server (mcp.buildkite.com) from Claude Code via a claude.ai connector: 100% of calls fail, and the client can't recover because the stale schema doesn't even advertise the field.

This PR marks the embedded `ToolInput.Telemetry` field `omitempty`, so `telemetry` is still advertised on every tool (description and `maxLength` intact, `context` still required *within* the object when it is supplied) but is no longer required at the top level. Clients that have the current schema keep sending it and it is recorded as before; clients on a cached schema work again. The tracing middleware already tolerates absence (`toolTelemetryContext` returns an empty string), so no handler changes are needed.

- `pkg/buildkite/buildkite.go`: `json:"telemetry"` → `json:"telemetry,omitempty"`.
- `pkg/buildkite/schema_test.go`, `pkg/toolsets/toolsets_test.go`: assert the new contract — telemetry advertised everywhere, required nowhere.

Verified by driving the stdio server: `tools/call` with no `telemetry` now passes validation and reaches the API; calls that include `telemetry.context` behave unchanged. `go test ./...` and `golangci-lint run` are clean.