### PR TITLE
feat: add teams parameter to create_pipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.14.0
+	github.com/buildkite/go-buildkite/v5 v5.15.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.14.0 h1:nhrhNMC0ps/TbU1mdT06bEMuFK1O6rxUaT++YLg/soE=
-github.com/buildkite/go-buildkite/v5 v5.14.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.15.0 h1:ae9F3FBvf8UEXYY7jXkaUyVt2PddH+QrifsGuY4ltzc=
+github.com/buildkite/go-buildkite/v5 v5.15.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -241,17 +241,18 @@ func createPaginatedResult[T any](pipelines []buildkite.Pipeline, converter func
 
 type CreatePipelineArgs struct {
 	ToolInput
-	OrgSlug                   string   `json:"org_slug"`
-	Name                      string   `json:"name"`
-	RepositoryURL             string   `json:"repository_url" jsonschema:"The Git repository URL"`
-	ClusterID                 string   `json:"cluster_id" jsonschema:"The cluster ID to assign the pipeline to"`
-	Description               string   `json:"description,omitempty"`
-	Configuration             string   `json:"configuration" jsonschema:"The pipeline configuration in YAML format"`
-	DefaultBranch             string   `json:"default_branch,omitempty" jsonschema:"The default branch for builds and metrics filtering"`
-	SkipQueuedBranchBuilds    bool     `json:"skip_queued_branch_builds,omitempty" jsonschema:"Skip intermediate builds when new builds are created on the same branch"`
-	CancelRunningBranchBuilds bool     `json:"cancel_running_branch_builds,omitempty" jsonschema:"Cancel running builds when new builds are created on the same branch"`
-	Tags                      []string `json:"tags,omitempty" jsonschema:"Tags to apply to the pipeline for filtering and organization"`
-	CreateWebhook             bool     `json:"create_webhook,omitempty" jsonschema:"Create a GitHub webhook to trigger builds on pull-request and push events"`
+	OrgSlug                   string            `json:"org_slug"`
+	Name                      string            `json:"name"`
+	RepositoryURL             string            `json:"repository_url" jsonschema:"The Git repository URL"`
+	ClusterID                 string            `json:"cluster_id" jsonschema:"The cluster ID to assign the pipeline to"`
+	Description               string            `json:"description,omitempty"`
+	Configuration             string            `json:"configuration" jsonschema:"The pipeline configuration in YAML format"`
+	DefaultBranch             string            `json:"default_branch,omitempty" jsonschema:"The default branch for builds and metrics filtering"`
+	SkipQueuedBranchBuilds    bool              `json:"skip_queued_branch_builds,omitempty" jsonschema:"Skip intermediate builds when new builds are created on the same branch"`
+	CancelRunningBranchBuilds bool              `json:"cancel_running_branch_builds,omitempty" jsonschema:"Cancel running builds when new builds are created on the same branch"`
+	Tags                      []string          `json:"tags,omitempty" jsonschema:"Tags to apply to the pipeline for filtering and organization"`
+	Teams                     map[string]string `json:"teams,omitempty" jsonschema:"Team UUIDs mapped to their access level on the pipeline: read_only, build_and_read or manage_build_and_read. Organizations with teams enabled require at least one team, unless the user is an organization administrator"`
+	CreateWebhook             bool              `json:"create_webhook,omitempty" jsonschema:"Create a GitHub webhook to trigger builds on pull-request and push events"`
 }
 
 func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []string) {
@@ -282,6 +283,7 @@ func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []
 				SkipQueuedBranchBuilds:    args.SkipQueuedBranchBuilds,
 				Configuration:             args.Configuration,
 				Tags:                      args.Tags,
+				Teams:                     args.Teams,
 			}
 
 			if args.DefaultBranch != "" {

--- a/pkg/buildkite/pipelines_test.go
+++ b/pkg/buildkite/pipelines_test.go
@@ -157,6 +157,7 @@ steps:
 			assert.Equal("Test Pipeline", p.Name)
 			assert.Equal("https://example.com/repo.git", p.Repository)
 			assert.Equal(testPipelineDefinition, p.Configuration)
+			assert.Equal(map[string]string{"team-uuid-1": "build_and_read"}, p.Teams)
 
 			return buildkite.Pipeline{
 					ID:        "123",
@@ -199,6 +200,7 @@ steps:
 		Description:   "A test pipeline",
 		Configuration: testPipelineDefinition,
 		Tags:          []string{"tag1", "tag2"},
+		Teams:         map[string]string{"team-uuid-1": "build_and_read"},
 		CreateWebhook: true, // should create webhook by default
 	}
 

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -11,7 +11,7 @@ import (
 )
 
 type TestsClient interface {
-	Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
+	Get(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error)
 	List(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
 }
 
@@ -206,7 +206,7 @@ func GetTest() (mcp.Tool, mcp.ToolHandlerFor[GetTestArgs, any], []string) {
 			)
 
 			deps := DepsFromContext(ctx)
-			test, _, err := deps.TestsClient.Get(ctx, args.OrgSlug, args.TestSuiteSlug, args.TestID)
+			test, _, err := deps.TestsClient.Get(ctx, args.OrgSlug, args.TestSuiteSlug, args.TestID, nil)
 			if err != nil {
 				return handleBuildkiteError(err)
 			}

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -14,15 +14,15 @@ import (
 )
 
 type MockTestsClient struct {
-	GetFunc  func(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error)
+	GetFunc  func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error)
 	ListFunc func(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error)
 }
 
-func (m *MockTestsClient) Get(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error) {
+func (m *MockTestsClient) Get(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
 	if m.GetFunc != nil {
-		return m.GetFunc(ctx, org, slug, testID)
+		return m.GetFunc(ctx, org, slug, testID, opt)
 	}
-	return buildkite.Test{}, nil, nil
+	return buildkite.TestWithMetrics{}, nil, nil
 }
 
 func (m *MockTestsClient) List(ctx context.Context, org, slug string, opt *buildkite.TestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
@@ -268,11 +268,13 @@ func TestGetTest(t *testing.T) {
 	assert := require.New(t)
 
 	client := &MockTestsClient{
-		GetFunc: func(ctx context.Context, org, slug, testID string) (buildkite.Test, *buildkite.Response, error) {
-			return buildkite.Test{
-					ID:       "test-123",
-					Name:     "Example Test",
-					Location: "spec/example_test.rb",
+		GetFunc: func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
+			return buildkite.TestWithMetrics{
+					Test: buildkite.Test{
+						ID:       "test-123",
+						Name:     "Example Test",
+						Location: "spec/example_test.rb",
+					},
 				}, &buildkite.Response{
 					Response: &http.Response{
 						StatusCode: 200,


### PR DESCRIPTION
`create_pipeline` cannot name a team. In an organization with teams enabled, the API rejects the request unless the caller is an organization administrator:

```
{"field":"teams","code":"Please ensure at least one team is added to this pipeline"}
```

Adds a `teams` argument that maps each team UUID to its access level (`read_only`, `build_and_read`, `manage_build_and_read`), matching the [REST API parameter](https://buildkite.com/docs/apis/rest-api/pipelines#create-a-yaml-pipeline). It is optional, so administrators are unaffected.

Needs `go-buildkite` v5.15.0 for `Teams` on `CreatePipeline` — buildkite/go-buildkite#374. That release also changes `TestsService.Get` to take options and return `TestWithMetrics`, so `pkg/buildkite/tests.go` follows the new signature. `get_test` passes nil options, so the API still applies the organization's default aggregation window.

The API also has a deprecated `team_uuids` array, which `go-buildkite` already carries; this uses `teams` instead so callers can set an access level.

## Follow-up

Callers still have no way to look up a team UUID. A `list_teams` tool would need the `read_teams` scope on the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
