### PR TITLE
Show real MCP tool names in cursor / cursor-cloud eval audits

### DIFF
--- a/evals/scripts/bk-tool-audit-v2.sh
+++ b/evals/scripts/bk-tool-audit-v2.sh
@@ -97,46 +97,75 @@ newest_session() {
 #   shellToolCall, ...), with the call's arguments under that key's .args.
 #   MCP invocations are wrapped: mcpToolCall's real identity lives at
 #   .args.toolName + .args.serverIdentifier and the real tool arguments nest
-#   at .args.args (observed schema — eval build 98). Normalize those to
-#   claude-style mcp__<server>__<tool> so cross-agent tool tables line up;
-#   getMcpToolsToolCall (schema fetch) stays as-is — it is a distinct
-#   tool-discovery step worth seeing in audits. function.name is a defensive
-#   fallback for the OpenAI-style shape other cursor versions may emit.
+#   at .args.args (observed schema — eval build 98; newer runs also emit the
+#   Cloud-style {server, toolName, arguments} field names, so both spellings
+#   are accepted). Normalize those to claude-style mcp__<server>__<tool> so
+#   cross-agent tool tables line up; getMcpToolsToolCall (schema fetch) stays
+#   as-is — it is a distinct tool-discovery step worth seeing in audits.
+#   function.name is a defensive fallback for the OpenAI-style shape other
+#   cursor versions may emit.
+#   CAVEAT (same as cursor-cloud below): the FIRST event for a call may be an
+#   args-less placeholder, with args only arriving on a later event for the
+#   same call_id. Reading only "started" events therefore loses MCP identity
+#   ("4 mcpToolCall" instead of per-tool names). cursor_calls collapses ALL
+#   tool_call events by call_id — first occurrence keeps its stream position,
+#   but an args-less stored event is upgraded to a later sibling that has
+#   args. Events with no call_id pass through unmerged (one call each).
 CURSOR_TOOL_NAME_JQ='
   def cursor_tool_name($t):
     ($t.value.args // {}) as $a
     | if $t.key == "mcpToolCall" and (($a.toolName // $a.name) != null) then
-        "mcp__\($a.serverIdentifier // $a.providerIdentifier // "mcp")__\($a.toolName // $a.name)"
+        "mcp__\($a.serverIdentifier // $a.providerIdentifier // $a.server // "mcp")__\($a.toolName // $a.name)"
       elif (($a.function? | type) == "object") and ($a.function.name != null) then
         $a.function.name
-      else $t.key end;'
+      else $t.key end;
+  def cursor_calls:
+    reduce (.[] | select(.type=="tool_call" and (.tool_call|type=="object"))) as $e (
+      {seen: {}, out: []};
+      (($e.call_id // "") | tostring) as $id
+      | if $id == "" then
+          (if $e.subtype == "started" then .out += [$e] else . end)
+        elif .seen[$id] == null then .seen[$id] = (.out|length) | .out += [$e]
+        elif ((.out[.seen[$id]].tool_call | to_entries[0].value.args // null) == null)
+             and (($e.tool_call | to_entries[0].value.args // null) != null)
+        then .out[.seen[$id]] = $e
+        else . end)
+    | .out;'
 # cursor-cloud: cursor-cloud.sh captures the Cloud Agents SSE stream as
 # {"type": "<event>", "data": {...}} lines. A tool call appears at least twice
 # (a started/running event with args, a completed event repeating them with the
 # result), all sharing data.callId — and the stream may additionally REPLAY
 # events if the SSE connection dropped and reconnected mid-run. So calls are
-# deduped by callId, keeping the FIRST occurrence to preserve stream order
-# (group_by would sort by id and scramble the timeline). Tool names: the docs
-# describe tool_call.name as the PUBLIC wrapper name — "mcp" for every MCP
-# invocation — which would collapse all MCP calls into one bucket and break
-# per-tool comparisons. When the name is such a wrapper, derive the identity
-# from the args (same field candidates the cursor CLI dialect uses for its
-# mcpToolCall shape) into claude-style mcp__<server>__<tool>; non-wrapper
-# names pass through as sent. The exact args shape is a first-live-run check.
+# deduped by callId, keeping the FIRST occurrence's stream position to
+# preserve order (group_by would sort by id and scramble the timeline) — BUT
+# NOT its payload: live runs show the first event for a callId is often an
+# args-less "running" placeholder, with args arriving only on a later event.
+# Keeping the bare first event blanked every MCP identity ("5 mcp" in
+# metrics), so an args-less stored event is upgraded in place to a later
+# sibling that has args. Tool names: the docs describe tool_call.name as the
+# PUBLIC wrapper name — "mcp" for every MCP invocation — which would collapse
+# all MCP calls into one bucket and break per-tool comparisons. When the name
+# is such a wrapper, derive the identity from the args into claude-style
+# mcp__<server>__<tool>; non-wrapper names pass through as sent. The args
+# shape per the Cloud Agents API is {server, toolName, arguments} — the older
+# CLI-observed spellings (serverIdentifier, .args nesting) stay as fallbacks.
 CURSOR_CLOUD_CALLS_JQ='
   def cloud_tool_events: [.[] | select(type=="object" and .type=="tool_call" and (.data|type=="object")) | .data];
   def dedupe_calls:
     reduce .[] as $e ({seen: {}, out: []};
         (($e.callId // "") | tostring) as $id
-        | if $id != "" and .seen[$id] then .
-          else .seen[$id] = true | .out += [$e] end)
+        | if $id == "" then .out += [$e]
+          elif .seen[$id] == null then .seen[$id] = (.out|length) | .out += [$e]
+          elif ((.out[.seen[$id]].args // null) == null) and (($e.args // null) != null)
+          then .out[.seen[$id]] = $e
+          else . end)
     | .out;
   def cloud_tool_name($d):
     ($d.args // {}) as $a
     | (($d.name // "unknown") | tostring) as $n
     | if ($n == "mcp" or $n == "mcpToolCall" or $n == "mcp_tool_call")
          and (($a.toolName // $a.name // null) != null)
-      then "mcp__\($a.serverIdentifier // $a.providerIdentifier // $a.server // "mcp")__\($a.toolName // $a.name)"
+      then "mcp__\($a.server // $a.serverIdentifier // $a.providerIdentifier // "mcp")__\($a.toolName // $a.name)"
       else $n end;'
 extract() {
   local f="$1"
@@ -146,18 +175,21 @@ extract() {
       | (.args // {}) as $a
       | cloud_tool_name(.) as $name
       | select($name | '"$TOOL_FILTER"')
-      | (if ($name != (.name // "unknown")) and (($a.args? | type) == "object")
-         then $a.args else $a end) as $input
+      | (if $name != (.name // "unknown") then
+           (if ($a.arguments? | type) == "object" then $a.arguments
+            elif ($a.args? | type) == "object" then $a.args
+            else $a end)
+         else $a end) as $input
       | if $names == 1 then {tool: $name}
         else {id: (.callId // null), tool: $name, input: $input} end
     ' "$f"
   elif [[ "$AGENT" == "cursor" ]]; then
-    jq -c --argjson names "$NAMES_ONLY" "$CURSOR_TOOL_NAME_JQ"'
-      select(.type=="tool_call" and .subtype=="started" and (.tool_call|type=="object"))
+    jq -c -n --argjson names "$NAMES_ONLY" "$CURSOR_TOOL_NAME_JQ"'
+      [inputs] | cursor_calls | .[]
       | (.tool_call | to_entries[0]) as $t
       | ($t.value.args // {}) as $a
       | cursor_tool_name($t) as $name
-      | (if $t.key == "mcpToolCall" then ($a.args // {}) else $a end) as $input
+      | (if $t.key == "mcpToolCall" then ($a.args // $a.arguments // {}) else $a end) as $input
       | select($name | '"$TOOL_FILTER"')
       | if $names == 1 then {tool: $name}
         else {id: (.call_id // null), tool: $name, input: $input} end
@@ -278,8 +310,8 @@ metrics() {
     # mcp__<server>__<tool>), so metrics and tool listings agree.
     jq -nr "$CURSOR_TOOL_NAME_JQ"'
       [inputs | select(type=="object")] as $all
-      | ($all | map(select(.type=="tool_call" and .subtype=="started" and (.tool_call|type=="object"))
-                    | (.tool_call | to_entries[0]) as $t | cursor_tool_name($t))) as $tools
+      | ($all | cursor_calls
+              | map((.tool_call | to_entries[0]) as $t | cursor_tool_name($t))) as $tools
       | ($all | map(select(.type=="result")) | last) as $res
       | ($all | map(select(.type=="system" and .subtype=="init")) | first) as $init
       | {


### PR DESCRIPTION
### Description

The eval session audit (`evals/scripts/bk-tool-audit-v2.sh`) could not name the MCP tools used in cursor CLI and cursor-cloud runs — every MCP call was reported under the wrapper name (`5 mcp` for cursor-cloud, `4 mcpToolCall` for cursor CLI), while Claude Code runs correctly show `mcp__buildkite__wait_for_build` etc. This made per-tool comparisons across agents impossible.

Example:

For cursor CLI, and cursor cloud, no mcp tool name is recorded, i.e., only generic `get_mcp_tools`
```
{                                                                                                                                                                                        
    "user_messages": null,                                                                                                                                                                 
    "assistant_responses": null,                                                                                                                                                           
    "duration_min": 3,                                                                                                                                                                     
    "models": {                                                                                                                                                                            
      "claude-opus-4-8": 1                                                                                                                                                                 
    },                                                                                                                                                                                     
    "tokens": {                                                                                                                                                                            
      "input": 38,                                                                                                                                                                         
      "output": 6043,                                                                                                                                                                      
      "cache_write": 85680,                                                                                                                                                                
      "cache_read": 1182854                                                                                                                                                                
    },                                                                                                                                                                                     
    "tool_calls_total": 17,                                                                                                                                                                
    "tool_calls_by_name": [                                                                                                                                                                
      "5 mcp",                                                                                                                                                                             
      "3 run_terminal_cmd",                                                                                                                                                                
      "3 get_mcp_tools",                                                                                                                                                                   
      "2 read_file",                                                                                                                                                                       
      "1 update_goal",                                                                                                                                                                     
      "1 edit_file",                                                                                                                                                                       
      "1 create_goal",                                                                                                                                                                     
      "1 await"                                                                                                                                                                            
    ],                                                                                                                                                                                     
    "est_cost_usd": null                                                                                                                                                                   
  }                                                                                                                                                                                        
```

For other LLMs, actual mcp tool names are visible: 

```
  {                                                                                                                                                                                        
    "user_messages": 12,                                                                                                                                                                   
    "assistant_responses": 11,                                                                                                                                                             
    "duration_min": 3,                                                                                                                                                                     
    "models": {                                                                                                                                                                            
      "claude-opus-4-8": 11                                                                                                                                                                
    },                                                                                                                                                                                     
    "tokens": {                                                                                                                                                                            
      "input": 22,                                                                                                                                                                         
      "output": 3380,                                                                                                                                                                      
      "cache_write_5m": 20196,                                                                                                                                                             
      "cache_write_1h": 0,                                                                                                                                                                 
      "cache_read": 617874                                                                                                                                                                 
    },                                                                                                                                                                                     
    "tool_calls_total": 10,                                                                                                                                                                
    "tool_calls_by_name": [                                                                                                                                                                
      "3 mcp__buildkite__wait_for_build",                                                                                                                                                  
      "2 mcp__buildkite__list_builds",                                                                                                                                                     
      "2 Bash",                                                                                                                                                                            
      "1 mcp__buildkite__get_build_failure_summary",                                                                                                                                       
      "1 Read",                                                                                                                                                                            
      "1 Edit"                                                                                                                                                                             
    ],                                                                                                                                                                                     
    "est_cost_usd": 0.52                                                                                                                                                                   
  }                     

```

Root cause (same for both dialects): Cursor emits a tool call as several stream events sharing one call id, and the first event is often an args-less placeholder — the args arrive only on a later event. The script kept the first event when collapsing duplicates, so the MCP identity (which lives inside `args` as `{server, toolName, arguments}` — the outer `name` is always just the public wrapper) was lost, and the name derivation fell back to the wrapper. Confirmed against a live cursor-cloud transcript: 13 of 26 calls had an args-less first event with args on a later sibling.

Alternative considered: reading only "completed" events instead — rejected because a call that never completes (timeout/cancel) would disappear from the audit entirely.

### Context

- Linear: https://linear.app/buildkite/issue/PB-3138/cursor-cli-and-cursor-cloud-llm-agent-evals-output-needs-to-show-the
- Cloud Agents API event schema (tool_call `name` is the public wrapper name; MCP calls are `{server, toolName, arguments}`): https://cursor.com/docs/cloud-agent/api/endpoints

### Changes

- Both cursor dialects now merge a call's events when deduping: the first occurrence keeps its stream position (preserves timeline order), but an args-less stored event is upgraded in place to a later sibling that has args.
- The cursor CLI dialect reads all `tool_call` events merged by `call_id` (previously "started" only); `metrics` and the tool listing share the same merged view so they agree. Events with no `call_id` keep the old one-call-per-started behavior.
- Accept the Cloud Agents API field spellings (`server`, nested `arguments`) alongside the previously observed CLI ones (`serverIdentifier`, nested `.args`), so both old and new transcripts parse.

### Verification

- Synthetic fixtures reproducing the exact symptom (placeholder first event, args on completed) resolve to claude-style `mcp__<server>__<tool>` names in `metrics`, plain listing, `--names`, and `--results` modes, for both dialects; old-schema cursor CLI events still parse.
- Regression: the 2026-08-20 live cursor-cloud transcript (26 tool calls, no `mcp` wrapper calls) produces byte-identical output before and after the change.
- Real confirmation: the next eval run's audit annotations should show per-tool MCP names for cursor and cursor-cloud entries.
  -  Test using branch [`test-pb-3138-cursor-cloud`](https://github.com/buildkite/buildkite-mcp-server/tree/test-pb-3138-cursor-cloud)
    - https://buildkite.com/buildkite/buildkite-mcp-server-evals-framework/builds/238/canvas

Before:

```
{                                                                                                                                                                                        
    "user_messages": null,                                                                                                                                                                 
    "assistant_responses": null,                                                                                                                                                           
    "duration_min": 3,                                                                                                                                                                     
    "models": {                                                                                                                                                                            
      "claude-opus-4-8": 1                                                                                                                                                                 
    },                                                                                                                                                                                     
    "tokens": {                                                                                                                                                                            
      "input": 38,                                                                                                                                                                         
      "output": 6043,                                                                                                                                                                      
      "cache_write": 85680,                                                                                                                                                                
      "cache_read": 1182854                                                                                                                                                                
    },                                                                                                                                                                                     
    "tool_calls_total": 17,                                                                                                                                                                
    "tool_calls_by_name": [                                                                                                                                                                
      "5 mcp",                                                                                                                                                                             
      "3 run_terminal_cmd",                                                                                                                                                                
      "3 get_mcp_tools",                                                                                                                                                                   
      "2 read_file",                                                                                                                                                                       
      "1 update_goal",                                                                                                                                                                     
      "1 edit_file",                                                                                                                                                                       
      "1 create_goal",                                                                                                                                                                     
      "1 await"                                                                                                                                                                            
    ],                                                                                                                                                                                     
    "est_cost_usd": null                                                                                                                                                                   
  }  
```

After:

```
{
  "user_messages": null,
  "assistant_responses": null,
  "duration_min": 3,
  "models": {
    "claude-opus-4-8": 1
  },
  "tokens": {
    "input": 28,
    "output": 5575,
    "cache_write": 86462,
    "cache_read": 937452
  },
  "tool_calls_total": 16,
  "tool_calls_by_name": [
    "2 run_terminal_cmd",
    "2 read_file",
    "2 mcp__buildkite-mcp-server__wait_for_build",
    "2 mcp__buildkite-mcp-server__list_builds",
    "2 get_mcp_tools",
    "1 update_goal",
    "1 pr_management",
    "1 mcp__buildkite-mcp-server__get_build_failure_summary",
    "1 file_search",
    "1 edit_file",
    "1 create_goal"
  ],
  "est_cost_usd": null
}
```

### Deployment

Low risk: eval tooling only — a reporting script consumed by `babystand.sh` in the eval pipeline. No server/library code paths touched, no migrations, no deploy ordering concerns.

### Rollback

This change is safe to revert — plain `git revert`, no state or data involved. Reverting only restores the old audit output (wrapper names instead of real MCP tool names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)