### PR TITLE
Name the annotation content field in get_build_failure_summary description

### DIFF
--- a/pkg/buildkite/annotations.go
+++ b/pkg/buildkite/annotations.go
@@ -67,7 +67,7 @@ func normalizeAnnotationScope(scope, jobID string) (string, error) {
 func ListAnnotations() (mcp.Tool, mcp.ToolHandlerFor[ListAnnotationsArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "list_annotations",
-			Description: "List annotations for a build or a specific job. Use scope='build' (default) or scope='job' with job_id",
+			Description: "List annotations for a build or a specific job. Use scope='build' (default) or scope='job' with job_id. Annotation content is in the body_html field; there is no body field",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "List Annotations",
 				ReadOnlyHint: true,

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -722,7 +722,7 @@ func limitFailureSummaryLogCollections(result *BuildFailureSummary, limit int) e
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build_failure_summary",
-			Description: "Diagnose a Buildkite build failure in one call. Returns build state, job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Start with this tool before calling individual job, log, annotation, or test tools.",
+			Description: "Diagnose a Buildkite build failure in one call. Returns build state, job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build Failure Summary",
 				ReadOnlyHint: true,


### PR DESCRIPTION
### Description

An eval session showed an LLM agent overlooking the annotation content that `get_build_failure_summary` had already delivered. The agent probed `annotations[].body` with jq, which returns a silent `0` for a missing field, concluded all 9 annotation bodies were empty, and rebuilt the same root-cause evidence from ~57 KB of raw log tails plus 3 artifact fetches (~6 extra tool calls). The content was in `body_html` the whole time: the Buildkite REST API only serves rendered HTML, go-buildkite maps it 1:1, and no field named `body` exists at any layer.

This adds one sentence to the descriptions of the two tools that return annotation content, so agents know where it lives before they probe: *"Annotation content is in the body_html field; there is no body field."*

Alternatives considered: adding the same note to the server-wide instructions (rejected for now to keep standing context cost minimal — the sentence travels with the tools where the trap bites), and emitting a `body` alias in the payload (a more durable structural fix, left for the ticket's follow-up discussion along with `scope='all'` support in `list_annotations`).

### Context

- Linear: https://linear.app/buildkite/issue/PB-3152/tweak-mcpapi-llm-agent-overlooks-annotations-content
- The `body_html`-only shape originates in the REST API and flows through go-buildkite (`Annotation.BodyHTML`, `json:"body_html"`) into `FailureSummaryAnnotation` and the raw annotation objects returned by `list_annotations`.

### Changes

- One sentence added to the `get_build_failure_summary` tool description in `pkg/buildkite/failure_summary.go`.
- The same sentence added to the `list_annotations` tool description in `pkg/buildkite/annotations.go` — it returns raw API annotation objects with the identical `body_html`-only shape, so the same probe hits the same silent trap.
- Total standing-context cost: ~15 tokens per tool.

### Verification

- `go build ./...` passes; `go test ./pkg/buildkite/ -run FailureSummary` and `-run Annotation` pass.
- Behavioral check: eval runs of the red-to-green scenarios should show agents reading `annotations[].body_html` instead of falling back to log tails and artifacts.

### Deployment

Very low risk: description strings only — no handler, schema, or payload changes, no migrations, no ordering concerns.

### Rollback

This change is safe to revert — plain `git revert` of description strings. Reverting only removes the hints; behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)