### PR TITLE
Add min_executions param for ListTests

### DIFF
--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -232,8 +232,8 @@ func TestListTestsArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"org_slug", "test_suite_slug"}, sortedRequired[ListTestsArgs](t))
 
 	optional := []string{
-		"page", "per_page", "period", "min_timestamp", "max_timestamp", "labels",
-		"branch", "owners", "state", "tags", "sort_by", "order",
+		"page", "per_page", "period", "min_timestamp", "max_timestamp", "min_executions",
+		"labels", "branch", "owners", "state", "tags", "sort_by", "order",
 	}
 	for _, property := range optional {
 		require.Contains(t, s.Properties, property)
@@ -242,6 +242,8 @@ func TestListTestsArgsSchema(t *testing.T) {
 
 	require.Equal(t, "string", s.Properties["min_timestamp"].Type)
 	require.Equal(t, "string", s.Properties["max_timestamp"].Type)
+	require.Equal(t, "integer", s.Properties["min_executions"].Type)
+	require.Contains(t, s.Properties["min_executions"].Description, "at least this many executions")
 	require.Contains(t, s.Properties["min_timestamp"].Description, "RFC3339")
 	require.Contains(t, s.Properties["max_timestamp"].Description, "RFC3339")
 	require.Contains(t, s.Properties["period"].Description, "Cannot be combined")

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -28,6 +28,7 @@ type ListTestsArgs struct {
 	Period        string    `json:"period,omitempty" jsonschema:"Relative aggregation window, such as '7days' or '28days'. Whether selected by period or timestamps, the aggregation window cannot exceed the organization's maximum Test Engine window. Cannot be combined with min_timestamp or max_timestamp."`
 	MinTimestamp  time.Time `json:"min_timestamp,omitzero" jsonschema:"Start of the aggregation window in RFC3339 format. When omitted, defaults to the organization's default Test Engine period before the current time."`
 	MaxTimestamp  time.Time `json:"max_timestamp,omitzero" jsonschema:"End of the aggregation window in RFC3339 format. Defaults to the current time when omitted."`
+	MinExecutions int       `json:"min_executions,omitempty" jsonschema:"Return only tests with at least this many executions after applying the selected time window and execution filters (min 1)."`
 	Labels        string    `json:"labels,omitempty" jsonschema:"Filter by comma-separated test labels. Prefix a label with '!' to exclude it, for example 'flaky,!slow'."`
 	Branch        string    `json:"branch,omitempty" jsonschema:"Filter executions included in the metrics by branch. Prefix with '!' to exclude an exact branch or suffix with '*' to match by prefix, for example '!main' or 'feature*'. Use at most one operator."`
 	Owners        string    `json:"owners,omitempty" jsonschema:"Filter by comma-separated test owner slugs. Prefix an owner with '!' to exclude it, for example 'payments,!platform'."`
@@ -74,17 +75,18 @@ func ListTests() (mcp.Tool, mcp.ToolHandlerFor[ListTestsArgs, any], []string) {
 
 			paginationParams := paginationFromArgs(args.Page, args.PerPage)
 			options := &buildkite.TestsListOptions{
-				ListOptions:  paginationParams,
-				Period:       args.Period,
-				MinTimestamp: args.MinTimestamp,
-				MaxTimestamp: args.MaxTimestamp,
-				Labels:       args.Labels,
-				Branch:       args.Branch,
-				Owners:       args.Owners,
-				State:        args.State,
-				Tags:         args.Tags,
-				SortBy:       args.SortBy,
-				Order:        args.Order,
+				ListOptions:   paginationParams,
+				Period:        args.Period,
+				MinTimestamp:  args.MinTimestamp,
+				MaxTimestamp:  args.MaxTimestamp,
+				MinExecutions: args.MinExecutions,
+				Labels:        args.Labels,
+				Branch:        args.Branch,
+				Owners:        args.Owners,
+				State:         args.State,
+				Tags:          args.Tags,
+				SortBy:        args.SortBy,
+				Order:         args.Order,
 			}
 
 			attributes := []attribute.KeyValue{
@@ -93,6 +95,7 @@ func ListTests() (mcp.Tool, mcp.ToolHandlerFor[ListTestsArgs, any], []string) {
 				attribute.Int("page", paginationParams.Page),
 				attribute.Int("per_page", paginationParams.PerPage),
 				attribute.String("period", args.Period),
+				attribute.Int("min_executions", args.MinExecutions),
 				attribute.String("labels", args.Labels),
 				attribute.String("branch", args.Branch),
 				attribute.String("owners", args.Owners),

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -114,6 +114,7 @@ func TestListTests(t *testing.T) {
 			require.Equal(t, buildkite.ListOptions{Page: 2, PerPage: 50}, opt.ListOptions)
 			require.Equal(t, minTimestamp, opt.MinTimestamp)
 			require.Equal(t, maxTimestamp, opt.MaxTimestamp)
+			require.Equal(t, 5, opt.MinExecutions)
 			require.Equal(t, "flaky,!slow", opt.Labels)
 			require.Equal(t, "main*", opt.Branch)
 			require.Equal(t, "payments,!platform", opt.Owners)
@@ -177,6 +178,7 @@ func TestListTests(t *testing.T) {
 		PerPage:       50,
 		MinTimestamp:  minTimestamp,
 		MaxTimestamp:  maxTimestamp,
+		MinExecutions: 5,
 		Labels:        "flaky,!slow",
 		Branch:        "main*",
 		Owners:        "payments,!platform",
@@ -221,6 +223,7 @@ func TestListTestsUsesDefaultPagination(t *testing.T) {
 			require.Equal(t, "7days", opt.Period)
 			require.True(t, opt.MinTimestamp.IsZero())
 			require.True(t, opt.MaxTimestamp.IsZero())
+			require.Zero(t, opt.MinExecutions)
 			return []buildkite.TestWithMetrics{}, &buildkite.Response{Response: &http.Response{Header: http.Header{}}}, nil
 		},
 	}


### PR DESCRIPTION
Make the `min_executions` parameter added in `go-buildkite v5.15.0` available on `ListTests`.