### PR TITLE
Accept content_limit_bytes as an input arg on get_build_failure_summary

### DIFF
--- a/pkg/buildkite/buildkite.go
+++ b/pkg/buildkite/buildkite.go
@@ -110,6 +110,35 @@ func mcpSanitizedTextResult(span trace.Span, sanitized []byte) (*mcp.CallToolRes
 	return utils.NewToolResultText(string(sanitized)), nil, nil
 }
 
+// payloadStructureBytes reports the serialized size of the payload with every
+// string emptied and the truncation metadata limitSanitizedJSONPayload would
+// add — the smallest size the generic limiter can reach without dropping
+// array items. When this floor exceeds the limit, the generic limiter fails,
+// so semantic item-count reduction is needed exactly then and only then.
+func payloadStructureBytes(payload []byte, limit int) (int, error) {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return 0, fmt.Errorf("decode sanitized JSON: %w", err)
+	}
+
+	root, ok := value.(map[string]any)
+	if !ok {
+		return 0, fmt.Errorf("expected a JSON object")
+	}
+	if _, ok := root["content_limit_bytes"]; ok {
+		root["content_limit_bytes"] = limit
+	}
+	root["content_truncated"] = true
+
+	structure, err := marshalLimitedJSON(root, 0)
+	if err != nil {
+		return 0, err
+	}
+	return len(structure), nil
+}
+
 func limitSanitizedJSONPayload(payload []byte, limit int) ([]byte, error) {
 	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.UseNumber()

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -52,6 +52,7 @@ type GetBuildFailureSummaryArgs struct {
 	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to inspect (default 5, max 20)"`
 	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed test executions to return across all Test Engine runs (default 100, max 200)"`
 	MaxFailedTestsPerRun   int    `json:"max_failed_tests_per_run,omitempty" jsonschema:"Maximum failed test executions to return per Test Engine run (default 20, max 100)"`
+	ContentLimitBytes      int    `json:"content_limit_bytes,omitempty" jsonschema:"Maximum bytes for the response payload (default and max 262144); lower it to fit clients with small tool-result limits, combining with log_tail and max_jobs for finer trimming"`
 	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
 	IncludeAnnotations     *bool  `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
 	IncludeFailedTests     *bool  `json:"include_failed_tests,omitempty" jsonschema:"Include failed Test Engine executions when the build has Test Engine runs (default true)"`
@@ -738,6 +739,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
 			maxFailedTestsPerRun := boundedValue(args.MaxFailedTestsPerRun, defaultFailureSummaryTestsPerRun, maxFailureSummaryTestsPerRun)
 			maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
+			contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
 
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
@@ -747,6 +749,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				attribute.Int("max_jobs", maxJobs),
 				attribute.Int("max_test_runs", maxTestRuns),
 				attribute.Int("max_failed_tests", maxFailedTests),
+				attribute.Int("content_limit_bytes", contentLimit),
 				attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
 				attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
 				attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
@@ -884,6 +887,6 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				attribute.Int("test_run_count", len(result.TestRuns)),
 			)
 
-			return mcpTextResultWithByteLimit(span, &result, failureSummaryContentByteLimit)
+			return mcpTextResultWithByteLimit(span, &result, contentLimit)
 		}, []string{"read_builds", "read_build_logs", "read_suites"}
 }

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -877,7 +877,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 
 			applyFailureSummaryContentLimits(&result)
-			if err := limitFailureSummaryLogCollections(&result, failureSummaryContentByteLimit); err != nil {
+			if err := limitFailureSummaryLogCollections(&result, contentLimit); err != nil {
 				return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
 			}
 

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -716,14 +716,37 @@ func failureSummaryWithAnnotationLimit(result *BuildFailureSummary, maxAnnotatio
 	return limited
 }
 
+// failureSummaryPayloadBytes measures a candidate by its full serialized
+// size — the budget the per-job log trim targets.
+func failureSummaryPayloadBytes(result *BuildFailureSummary, _ int) (int, error) {
+	payload, err := marshalFailureSummaryWithContentBytes(result)
+	if err != nil {
+		return 0, err
+	}
+	return len(payload), nil
+}
+
+// failureSummaryStructureBytes measures a candidate by its strings-emptied
+// floor — the smallest size the generic limiter can reach without dropping
+// array items. Item-bearing collections only need reducing while this floor
+// exceeds the limit; string overage is the generic limiter's job, and
+// dropping items for it would discard diagnostics the limiter could keep.
+func failureSummaryStructureBytes(result *BuildFailureSummary, limit int) (int, error) {
+	payload, err := marshalFailureSummaryWithContentBytes(result)
+	if err != nil {
+		return 0, err
+	}
+	return payloadStructureBytes(payload, limit)
+}
+
 // shrinkFailureSummaryToFit binary-searches the largest per-collection entry
-// count whose serialized payload fits limit and replaces *result with that
+// count whose measured size fits limit and replaces *result with that
 // candidate (or the zero-entry candidate when nothing fits, so later
 // reduction passes start from the smallest form). Entry counts map
-// monotonically to payload size but not arithmetically — JSON escaping,
-// conditional truncation metadata, and the self-referential content_bytes
-// field all shift the size — so each candidate is marshaled and measured.
-func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries int, withLimit func(*BuildFailureSummary, int) BuildFailureSummary) error {
+// monotonically to size but not arithmetically — JSON escaping, conditional
+// truncation metadata, and the self-referential content_bytes field all
+// shift it — so each candidate is marshaled and measured.
+func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries int, withLimit func(*BuildFailureSummary, int) BuildFailureSummary, measure func(*BuildFailureSummary, int) (int, error)) error {
 	if maxEntries == 0 {
 		return nil
 	}
@@ -733,11 +756,11 @@ func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries in
 	for low <= high {
 		mid := low + (high-low)/2
 		candidate := withLimit(result, mid)
-		candidatePayload, candidateErr := marshalFailureSummaryWithContentBytes(&candidate)
-		if candidateErr != nil {
-			return candidateErr
+		size, err := measure(&candidate, limit)
+		if err != nil {
+			return err
 		}
-		if len(candidatePayload) <= limit {
+		if size <= limit {
 			best = candidate
 			low = mid + 1
 		} else {
@@ -750,26 +773,34 @@ func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries in
 }
 
 // limitFailureSummaryCollections reduces the summary's semantic collections
-// until the serialized payload fits limit, sacrificing the least diagnostic
-// value first: per-job log tails (newest lines kept), then failed test
-// executions per run, then annotations. The generic payload limiter that runs
-// afterwards only shortens strings — it never drops array items — so any
-// item-count reduction must happen here.
+// so the generic payload limiter that runs afterwards can fit the limit by
+// shortening strings alone — it never drops array items. Per-job log tails
+// are trimmed against the full serialized size (newest lines kept, the
+// long-standing behavior). Failed test executions and annotations are only
+// reduced while the strings-emptied structure floor exceeds the limit — the
+// exact condition under which the generic limiter would fail — so a payload
+// oversized by string content alone keeps its default collection membership.
 func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) error {
-	reductions := []struct {
+	size, err := failureSummaryPayloadBytes(result, limit)
+	if err != nil {
+		return err
+	}
+	if size <= limit {
+		return nil
+	}
+
+	logEntries := 0
+	for _, job := range result.Jobs {
+		logEntries = max(logEntries, len(job.LogTail))
+	}
+	if err := shrinkFailureSummaryToFit(result, limit, logEntries, failureSummaryWithLogEntryLimit, failureSummaryPayloadBytes); err != nil {
+		return err
+	}
+
+	structureReductions := []struct {
 		maxEntries func(*BuildFailureSummary) int
 		withLimit  func(*BuildFailureSummary, int) BuildFailureSummary
 	}{
-		{
-			maxEntries: func(r *BuildFailureSummary) int {
-				entries := 0
-				for _, job := range r.Jobs {
-					entries = max(entries, len(job.LogTail))
-				}
-				return entries
-			},
-			withLimit: failureSummaryWithLogEntryLimit,
-		},
 		{
 			maxEntries: func(r *BuildFailureSummary) int {
 				entries := 0
@@ -786,15 +817,15 @@ func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) erro
 		},
 	}
 
-	for _, reduction := range reductions {
-		payload, err := marshalFailureSummaryWithContentBytes(result)
+	for _, reduction := range structureReductions {
+		floor, err := failureSummaryStructureBytes(result, limit)
 		if err != nil {
 			return err
 		}
-		if len(payload) <= limit {
+		if floor <= limit {
 			return nil
 		}
-		if err := shrinkFailureSummaryToFit(result, limit, reduction.maxEntries(result), reduction.withLimit); err != nil {
+		if err := shrinkFailureSummaryToFit(result, limit, reduction.maxEntries(result), reduction.withLimit, failureSummaryStructureBytes); err != nil {
 			return err
 		}
 	}

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -682,28 +682,57 @@ func marshalFailureSummaryWithContentBytes(result *BuildFailureSummary) ([]byte,
 	}
 }
 
-func limitFailureSummaryLogCollections(result *BuildFailureSummary, limit int) error {
-	payload, err := marshalFailureSummaryWithContentBytes(result)
-	if err != nil {
-		return err
+// failureSummaryWithExecutionLimit returns a copy of the summary where every
+// test run keeps at most its first perRunLimit failed executions.
+func failureSummaryWithExecutionLimit(result *BuildFailureSummary, perRunLimit int) BuildFailureSummary {
+	limited := *result
+	limited.TestRuns = append([]FailureSummaryTestRun(nil), result.TestRuns...)
+	for i := range limited.TestRuns {
+		executions := result.TestRuns[i].FailedExecutions
+		if len(executions) <= perRunLimit {
+			continue
+		}
+
+		limited.TestRuns[i].FailedExecutions = executions[:perRunLimit]
+		limited.TestRuns[i].Truncated = true
+		limited.FailedTestsTruncated = true
+		limited.ContentTruncated = true
 	}
-	if len(payload) <= limit {
-		return nil
+	return limited
+}
+
+// failureSummaryWithAnnotationLimit returns a copy of the summary keeping at
+// most the first maxAnnotations annotations (the API returns them in priority
+// order).
+func failureSummaryWithAnnotationLimit(result *BuildFailureSummary, maxAnnotations int) BuildFailureSummary {
+	limited := *result
+	if len(result.Annotations) <= maxAnnotations {
+		return limited
 	}
 
-	maxEntries := 0
-	for _, job := range result.Jobs {
-		maxEntries = max(maxEntries, len(job.LogTail))
-	}
+	limited.Annotations = append([]FailureSummaryAnnotation(nil), result.Annotations[:maxAnnotations]...)
+	limited.AnnotationsTruncated = true
+	limited.ContentTruncated = true
+	return limited
+}
+
+// shrinkFailureSummaryToFit binary-searches the largest per-collection entry
+// count whose serialized payload fits limit and replaces *result with that
+// candidate (or the zero-entry candidate when nothing fits, so later
+// reduction passes start from the smallest form). Entry counts map
+// monotonically to payload size but not arithmetically — JSON escaping,
+// conditional truncation metadata, and the self-referential content_bytes
+// field all shift the size — so each candidate is marshaled and measured.
+func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries int, withLimit func(*BuildFailureSummary, int) BuildFailureSummary) error {
 	if maxEntries == 0 {
 		return nil
 	}
 
-	best := failureSummaryWithLogEntryLimit(result, 0)
+	best := withLimit(result, 0)
 	low, high := 0, maxEntries
 	for low <= high {
 		mid := low + (high-low)/2
-		candidate := failureSummaryWithLogEntryLimit(result, mid)
+		candidate := withLimit(result, mid)
 		candidatePayload, candidateErr := marshalFailureSummaryWithContentBytes(&candidate)
 		if candidateErr != nil {
 			return candidateErr
@@ -717,6 +746,58 @@ func limitFailureSummaryLogCollections(result *BuildFailureSummary, limit int) e
 	}
 
 	*result = best
+	return nil
+}
+
+// limitFailureSummaryCollections reduces the summary's semantic collections
+// until the serialized payload fits limit, sacrificing the least diagnostic
+// value first: per-job log tails (newest lines kept), then failed test
+// executions per run, then annotations. The generic payload limiter that runs
+// afterwards only shortens strings — it never drops array items — so any
+// item-count reduction must happen here.
+func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) error {
+	reductions := []struct {
+		maxEntries func(*BuildFailureSummary) int
+		withLimit  func(*BuildFailureSummary, int) BuildFailureSummary
+	}{
+		{
+			maxEntries: func(r *BuildFailureSummary) int {
+				entries := 0
+				for _, job := range r.Jobs {
+					entries = max(entries, len(job.LogTail))
+				}
+				return entries
+			},
+			withLimit: failureSummaryWithLogEntryLimit,
+		},
+		{
+			maxEntries: func(r *BuildFailureSummary) int {
+				entries := 0
+				for _, run := range r.TestRuns {
+					entries = max(entries, len(run.FailedExecutions))
+				}
+				return entries
+			},
+			withLimit: failureSummaryWithExecutionLimit,
+		},
+		{
+			maxEntries: func(r *BuildFailureSummary) int { return len(r.Annotations) },
+			withLimit:  failureSummaryWithAnnotationLimit,
+		},
+	}
+
+	for _, reduction := range reductions {
+		payload, err := marshalFailureSummaryWithContentBytes(result)
+		if err != nil {
+			return err
+		}
+		if len(payload) <= limit {
+			return nil
+		}
+		if err := shrinkFailureSummaryToFit(result, limit, reduction.maxEntries(result), reduction.withLimit); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -877,7 +958,7 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 
 			applyFailureSummaryContentLimits(&result)
-			if err := limitFailureSummaryLogCollections(&result, contentLimit); err != nil {
+			if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
 				return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
 			}
 

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -691,12 +691,25 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 			},
 			TestExecutionsClient: &MockTestExecutionsClient{
 				GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+					// Fully populated executions: even with every string
+					// emptied, the field keys alone put ~100 executions past
+					// the requested cap, forcing semantic item reduction.
 					executions := make([]buildkite.FailedExecution, options.PerPage)
 					for i := range executions {
 						executions[i] = buildkite.FailedExecution{
-							ExecutionID:   fmt.Sprintf("%s-execution-%d", runID, i+1),
-							TestName:      fmt.Sprintf("test %d", i+1),
-							FailureReason: "expected true to be false",
+							ExecutionID:      fmt.Sprintf("%s-execution-%d", runID, i+1),
+							RunID:            runID,
+							TestID:           fmt.Sprintf("test-%d", i+1),
+							RunName:          "nightly",
+							CommitSHA:        "abc123def456",
+							Branch:           "main",
+							TestName:         fmt.Sprintf("test %d", i+1),
+							FailureReason:    "expected true to be false",
+							Duration:         1.25,
+							Location:         "spec/widgets_spec.rb:42",
+							RunURL:           "https://buildkite.com/organizations/org/analytics/suites/suite/runs/run",
+							TestURL:          "https://buildkite.com/organizations/org/analytics/suites/suite/tests/test",
+							TestExecutionURL: "https://buildkite.com/organizations/org/analytics/suites/suite/tests/test/executions/execution",
 						}
 					}
 					return executions, &buildkite.Response{}, nil
@@ -742,6 +755,65 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		require.NoError(t, json.Unmarshal([]byte(text), &summary))
 		require.Equal(t, failureSummaryContentByteLimit, summary.ContentLimitBytes)
 	})
+}
+
+func TestGetBuildFailureSummaryDefaultLimitPreservesCollectionsForStringOverage(t *testing.T) {
+	// An escape-heavy build message pushes the serialized payload past the
+	// default limit while the strings-emptied structure stays tiny. The
+	// generic limiter can fix that by shortening strings alone, so the
+	// semantic pass must not sacrifice failed-test items for it.
+	escapeHeavy := strings.Repeat("\"\\\n", failureSummaryContentByteLimit)
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient: &MockBuildsClient{
+			GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				return buildkite.Build{
+					Number:  1,
+					State:   "failed",
+					Message: escapeHeavy,
+					TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
+						ID:    "run-1",
+						Suite: buildkite.TestEngineSuite{Slug: "suite-1"},
+					}}},
+				}, &buildkite.Response{}, nil
+			},
+		},
+		JobsClient: &MockJobsClient{
+			ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{}, &buildkite.Response{}, nil
+			},
+		},
+		TestExecutionsClient: &MockTestExecutionsClient{
+			GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+				return []buildkite.FailedExecution{{
+					ExecutionID:   "execution-1",
+					TestName:      "TestWidgets",
+					FailureReason: "expected 2, got 3",
+				}}, &buildkite.Response{}, nil
+			},
+		},
+	})
+
+	include := false
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug:            "org",
+		PipelineSlug:       "pipeline",
+		BuildNumber:        "1",
+		IncludeAnnotations: &include,
+	})
+
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+	text := getTextResult(t, callResult).Text
+	require.LessOrEqual(t, len(text), failureSummaryContentByteLimit)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(text), &summary))
+	require.True(t, summary.ContentTruncated)
+	require.Less(t, len(summary.Build.Message), len(escapeHeavy))
+	require.Len(t, summary.TestRuns, 1)
+	require.Len(t, summary.TestRuns[0].FailedExecutions, 1)
+	require.False(t, summary.FailedTestsTruncated)
 }
 
 func TestGetBuildFailureSummaryBoundsTestEngineWork(t *testing.T) {

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -670,6 +670,61 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		require.Contains(t, job.LogTail[len(job.LogTail)-1].C, "line-59")
 	})
 
+	t.Run("trims failed-test collections semantically instead of erroring", func(t *testing.T) {
+		runs := make([]buildkite.TestEngineRun, 4)
+		for i := range runs {
+			runs[i] = buildkite.TestEngineRun{
+				ID:    fmt.Sprintf("run-%d", i+1),
+				Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
+			}
+		}
+		testCtx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient: &MockBuildsClient{
+				GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+					return buildkite.Build{Number: 1, State: "failed", TestEngine: &buildkite.TestEngineProperty{Runs: runs}}, &buildkite.Response{}, nil
+				},
+			},
+			JobsClient: &MockJobsClient{
+				ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+					return buildkite.JobsList{}, &buildkite.Response{}, nil
+				},
+			},
+			TestExecutionsClient: &MockTestExecutionsClient{
+				GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+					executions := make([]buildkite.FailedExecution, options.PerPage)
+					for i := range executions {
+						executions[i] = buildkite.FailedExecution{
+							ExecutionID:   fmt.Sprintf("%s-execution-%d", runID, i+1),
+							TestName:      fmt.Sprintf("test %d", i+1),
+							FailureReason: "expected true to be false",
+						}
+					}
+					return executions, &buildkite.Response{}, nil
+				},
+			},
+		})
+
+		requested := 8 * 1024
+		include := false
+		callResult, _, err := handler(testCtx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+			OrgSlug:            "org",
+			PipelineSlug:       "pipeline",
+			BuildNumber:        "1",
+			ContentLimitBytes:  requested,
+			IncludeAnnotations: &include,
+		})
+
+		require.NoError(t, err)
+		require.False(t, callResult.IsError)
+		text := getTextResult(t, callResult).Text
+		require.LessOrEqual(t, len(text), requested)
+
+		var summary BuildFailureSummary
+		require.NoError(t, json.Unmarshal([]byte(text), &summary))
+		require.True(t, summary.FailedTestsTruncated)
+		require.True(t, summary.ContentTruncated)
+	})
+
 	t.Run("clamps values above the server maximum", func(t *testing.T) {
 		callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 			OrgSlug:           "org",
@@ -1096,7 +1151,7 @@ func TestLimitFailureSummaryLogCollectionsRetainsNewestRowsAndUpdatesMetadata(t 
 		require.Len(t, job.LogTail, entriesPerJob)
 	}
 
-	require.NoError(t, limitFailureSummaryLogCollections(&result, failureSummaryContentByteLimit))
+	require.NoError(t, limitFailureSummaryCollections(&result, failureSummaryContentByteLimit))
 	payload, err := marshalFailureSummaryWithContentBytes(&result)
 	require.NoError(t, err)
 	require.LessOrEqual(t, len(payload), failureSummaryContentByteLimit)

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -613,6 +613,63 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		require.True(t, summary.ContentTruncated)
 	})
 
+	t.Run("trims log tails semantically before the generic limiter", func(t *testing.T) {
+		lines := make([]string, 60)
+		for i := range lines {
+			lines[i] = fmt.Sprintf("line-%02d %s", i, strings.Repeat("x", 200))
+		}
+		logPath := t.TempDir() + "/failed.parquet"
+		writeTestParquetFile(t, logPath, lines)
+		logsClient := &MockBuildkiteLogsClient{
+			NewReaderFunc: func(_ context.Context, _, _, _, _ string, _ time.Duration, _ bool) (*buildkitelogs.ParquetReader, error) {
+				return buildkitelogs.NewParquetReader(logPath), nil
+			},
+		}
+		logCtx := ContextWithDeps(context.Background(), ToolDependencies{
+			BuildsClient: &MockBuildsClient{
+				GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+					return buildkite.Build{ID: "build-id", Number: 1, State: "failed"}, &buildkite.Response{}, nil
+				},
+			},
+			JobsClient: &MockJobsClient{
+				ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+					if options.State[0] == "failed" {
+						return buildkite.JobsList{Items: []buildkite.Job{{ID: "job-id", State: "failed"}}}, &buildkite.Response{}, nil
+					}
+					return buildkite.JobsList{}, &buildkite.Response{}, nil
+				},
+			},
+			BuildkiteLogsClient: logsClient,
+		})
+
+		requested := 6 * 1024
+		include := false
+		callResult, _, err := handler(logCtx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+			OrgSlug:            "org",
+			PipelineSlug:       "pipeline",
+			BuildNumber:        "1",
+			ContentLimitBytes:  requested,
+			IncludeAnnotations: &include,
+			IncludeFailedTests: &include,
+		})
+
+		require.NoError(t, err)
+		require.False(t, callResult.IsError)
+		text := getTextResult(t, callResult).Text
+		require.LessOrEqual(t, len(text), requested)
+
+		var summary BuildFailureSummary
+		require.NoError(t, json.Unmarshal([]byte(text), &summary))
+		require.Len(t, summary.Jobs, 1)
+		job := summary.Jobs[0]
+		require.NotEmpty(t, job.LogTail)
+		require.Positive(t, job.LogEntriesOmitted)
+		require.True(t, job.LogTruncated)
+		// The semantic trim keeps the newest lines, so the final fetched line
+		// must survive.
+		require.Contains(t, job.LogTail[len(job.LogTail)-1].C, "line-59")
+	})
+
 	t.Run("clamps values above the server maximum", func(t *testing.T) {
 		callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 			OrgSlug:           "org",

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -565,6 +565,73 @@ func TestGetBuildFailureSummaryLimitsFinalEscapedJSONPayload(t *testing.T) {
 	require.Less(t, len(summary.Jobs[0].Command), len(escapeHeavy))
 }
 
+func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
+	large := strings.Repeat("x", failureSummaryContentByteLimit)
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+				ID:      "build-id",
+				Number:  1,
+				State:   "failed",
+				Message: large,
+			}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{Items: []buildkite.Job{{
+				ID:      "job-id",
+				Name:    "large command",
+				State:   "failed",
+				Command: large,
+			}}}, &buildkite.Response{}, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient: buildsClient,
+		JobsClient:   jobsClient,
+	})
+	_, handler, _ := GetBuildFailureSummary()
+
+	t.Run("lowers the payload cap", func(t *testing.T) {
+		requested := 8 * 1024
+		callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+			OrgSlug:           "org",
+			PipelineSlug:      "pipeline",
+			BuildNumber:       "1",
+			ContentLimitBytes: requested,
+		})
+
+		require.NoError(t, err)
+		require.False(t, callResult.IsError)
+		text := getTextResult(t, callResult).Text
+		require.LessOrEqual(t, len(text), requested)
+
+		var summary BuildFailureSummary
+		require.NoError(t, json.Unmarshal([]byte(text), &summary))
+		require.Equal(t, requested, summary.ContentLimitBytes)
+		require.True(t, summary.ContentTruncated)
+	})
+
+	t.Run("clamps values above the server maximum", func(t *testing.T) {
+		callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+			OrgSlug:           "org",
+			PipelineSlug:      "pipeline",
+			BuildNumber:       "1",
+			ContentLimitBytes: failureSummaryContentByteLimit * 2,
+		})
+
+		require.NoError(t, err)
+		require.False(t, callResult.IsError)
+		text := getTextResult(t, callResult).Text
+		require.LessOrEqual(t, len(text), failureSummaryContentByteLimit)
+
+		var summary BuildFailureSummary
+		require.NoError(t, json.Unmarshal([]byte(text), &summary))
+		require.Equal(t, failureSummaryContentByteLimit, summary.ContentLimitBytes)
+	})
+}
+
 func TestGetBuildFailureSummaryBoundsTestEngineWork(t *testing.T) {
 	runs := make([]buildkite.TestEngineRun, 4)
 	for i := range runs {


### PR DESCRIPTION
### Description

`get_build_failure_summary` budgets its response against an internal 256 KB ceiling, but common MCP clients cap tool results far lower — Claude Code defaults to 25K tokens (~100 KB). In a live eval session a routine summary came back at ~100,669 characters and was bounced by the client, turning the advertised one-call diagnosis into a file redirect plus seven jq forensic calls before the agent could resume.

MCP has no size-negotiation handshake, so the server can never learn the client's cap — but the calling agent can know it (or discovers it the hard way on the first bounce). This change lets the caller say what fits: the response's existing `content_limit_bytes` field is now also accepted as an optional input argument, enforced by semantic collection reduction before the final generic payload limiter.

Alternative considered: shrinking the server default to ~40 KB (as the eval review suggested). Rejected for this PR because the client cap is client-specific and configurable, so any lower default degrades roomier clients for no reason; opt-in keeps existing behavior byte-identical.

### Context

- Linear: https://linear.app/buildkite/issue/PB-3153/tweak-mcpapi-llm-gets-overloaded-by-build-failure-summary-payload
- Related follow-ups from the same eval session review: #382 (PB-3152, annotation `body_html` hint)

### Changes

- `GetBuildFailureSummaryArgs` gains `content_limit_bytes` (optional; default and max 262144), clamped via the same `boundedValue` idiom as the tool's other knobs.
- The semantic reduction pass (`limitFailureSummaryCollections`) is generalized from logs-only to all item-bearing collections, applied in order of least diagnostic sacrifice while the payload still exceeds the limit: per-job log tails (newest lines kept, `log_entries_omitted` set) → failed test executions per run (first kept, run `truncated` + `failed_tests_truncated` set) → annotations (priority order preserved, `annotations_truncated` set). Each uses the same measured binary search (`shrinkFailureSummaryToFit`), since serialized size isn't arithmetically predictable (JSON escaping, conditional truncation metadata, self-referential `content_bytes`).
- The final generic payload limiter also receives the clamped value; it already rewrites the response's `content_limit_bytes` to the effective value and sets `content_truncated` when shortening strings. It never drops array items — which is exactly why the semantic pass above must handle item counts (a populated failed-test collection previously made small caps return "JSON structure exceeds N byte limit" instead of a summary).
- The effective limit is recorded as a span attribute.
- Tests: `TestGetBuildFailureSummaryHonorsContentLimitBytesArg` covers lowering the cap, clamping values above the server maximum, semantic log trimming (newest lines survive), and the review thread's reproduction — 4 test runs of populated executions under an 8 KiB cap now return a valid summary with `failed_tests_truncated` instead of an error.

### Verification

- `go build ./...` passes; `go test ./pkg/buildkite/` passes, including the new tests.
- Defaults unchanged: omitting the arg produces byte-identical behavior to before (existing payload-limit test still passes).
- Behavioral check: agents on token-capped clients can pass e.g. `content_limit_bytes: 90000` and receive a valid, self-describing truncated summary inline instead of a client-side rejection.
- Known backstop: caps smaller than the irreducible structure (build metadata + job summaries) still return the explicit "JSON structure exceeds" error rather than a summary; job objects are deliberately never dropped.

### Deployment

Low risk: a single optional tool argument, opt-in only — no behavior change for existing callers, no migrations, no ordering concerns.

### Rollback

This change is safe to revert — plain `git revert`. Reverting removes the input argument; any caller that had started passing it would fall back to the 256 KB default (the argument would be ignored or rejected depending on client schema validation), with no state or data involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)