### PR TITLE
Publish per-entry/scenario eval run metrics to Datadog

### DIFF
--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -14,7 +14,8 @@ env:
   # token (this org, used by bk-eval-compare.sh).
   EVAL_ORG_SLUG: "anothertest"
   EVAL_PIPELINE_SLUG: "buildkite-mcp-server"
-  # Datadog site for dd-metrics.sh (the API key comes from secrets below).
+  # Datadog site for dd-metrics.sh. The API key is scoped to the dd-publish
+  # step only — never the eval step (see the SECURITY note there).
   DD_SITE: "datadoghq.com"
 
 # PR CI (lint/test) and the generator step run here. The bork PR builds the eval
@@ -65,11 +66,13 @@ steps:
             # to the commit under review (mcp_version: source). Interpolated
             # at pipeline-upload time, when BUILDKITE_COMMIT is this commit.
             - MCP_SRC_SHA=${BUILDKITE_COMMIT}
-            # Per-entry run metrics -> Datadog (evals/scripts/dd-metrics.sh).
-            # Publishing skips loudly when DD_API_KEY is empty; the build
-            # number becomes a buildkite_build tag on every series.
-            - DD_API_KEY
-            - DD_SITE
+            # SECURITY: DD_API_KEY is deliberately NOT mapped here. The
+            # evaluated agent runs in this container with unrestricted Bash
+            # and inherits its environment, so any credential mapped in is
+            # readable (and exfiltratable) by the agent under test. Datadog
+            # publishing happens in the dd-publish step below instead, from
+            # the run-bundle artifacts babystand.sh uploads.
+            # bk-eval-compare.sh keys the current run by build number.
             - BUILDKITE_BUILD_NUMBER
             - BUILDKITE_ORGANIZATION_SLUG
             - BUILDKITE_PIPELINE_SLUG
@@ -105,7 +108,29 @@ steps:
       # Cursor CLI API key (generate in the Cursor Dashboard). Maps into
       # the CURSOR_API_KEY env line above.
       CURSOR_API_KEY: MCP_EVAL_FRAMEWORK_CURSOR_API_KEY
-      # Datadog API key for dd-metrics.sh. NOTE: the secret must exist in the
-      # cluster before this mapping ships, or the step fails at secret
-      # resolution (create it even with an empty value to disable publishing).
+
+  # Publish per-entry run metrics to Datadog, OUTSIDE the agent container.
+  # SECURITY: the eval step above runs the evaluated agent with unrestricted
+  # Bash, so DD_API_KEY must never enter that container's environment.
+  # babystand.sh records each entry's identity + outcome as a
+  # runs/<id>/<run-key>.dd.json artifact in the run bundle; this step
+  # downloads those and drives evals/scripts/dd-metrics.sh once per entry.
+  - label: ":datadog: Publish eval metrics"
+    key: dd-publish
+    command: ./evals/scripts/dd-publish.sh
+    # Publish whatever bundles were uploaded even when the eval step fails —
+    # partial results are exactly what a failure investigation needs.
+    depends_on:
+      - step: agent
+        allow_failure: true
+    # Best-effort, like the in-step publish it replaces: a Datadog outage
+    # must never fail the build.
+    soft_fail: true
+    agents:
+      queue: hosted
+    # Scoped to this step only: it runs only harness scripts from the repo,
+    # never the evaluated agent. NOTE: the secret must exist in the cluster
+    # before this mapping ships, or the step fails at secret resolution
+    # (create it even with an empty value to disable publishing).
+    secrets:
       DD_API_KEY: MCP_EVAL_FRAMEWORK_DATADOG_API_KEY

--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -116,8 +116,8 @@ steps:
   # snapshot readable to same-UID processes. babystand.sh records each
   # entry's identity + outcome as a runs/<id>/<run-key>.dd.json artifact in
   # the run bundle; this step downloads those and drives
-  # evals/scripts/dd-metrics.sh once per entry. (Local runs publish the same
-  # way, manually, after the eval exits: dd-publish.sh <runs-dir>.)
+  # evals/scripts/dd-metrics.sh once per entry. (Local runs never publish —
+  # Datadog metrics are CI-only.)
   - label: ":datadog: Publish eval metrics"
     key: dd-publish
     command: ./evals/scripts/dd-publish.sh

--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -14,6 +14,8 @@ env:
   # token (this org, used by bk-eval-compare.sh).
   EVAL_ORG_SLUG: "anothertest"
   EVAL_PIPELINE_SLUG: "buildkite-mcp-server"
+  # Datadog site for dd-metrics.sh (the API key comes from secrets below).
+  DD_SITE: "datadoghq.com"
 
 # PR CI (lint/test) and the generator step run here. The bork PR builds the eval
 # waits on also run on this queue.
@@ -63,6 +65,12 @@ steps:
             # to the commit under review (mcp_version: source). Interpolated
             # at pipeline-upload time, when BUILDKITE_COMMIT is this commit.
             - MCP_SRC_SHA=${BUILDKITE_COMMIT}
+            # Per-entry run metrics -> Datadog (evals/scripts/dd-metrics.sh).
+            # Publishing skips loudly when DD_API_KEY is empty; the build
+            # number becomes a buildkite_build tag on every series.
+            - DD_API_KEY
+            - DD_SITE
+            - BUILDKITE_BUILD_NUMBER
             - BUILDKITE_ORGANIZATION_SLUG
             - BUILDKITE_PIPELINE_SLUG
             - BUILDKITE_MCP_SERVER_VERSION
@@ -97,3 +105,7 @@ steps:
       # Cursor CLI API key (generate in the Cursor Dashboard). Maps into
       # the CURSOR_API_KEY env line above.
       CURSOR_API_KEY: MCP_EVAL_FRAMEWORK_CURSOR_API_KEY
+      # Datadog API key for dd-metrics.sh. NOTE: the secret must exist in the
+      # cluster before this mapping ships, or the step fails at secret
+      # resolution (create it even with an empty value to disable publishing).
+      DD_API_KEY: MCP_EVAL_FRAMEWORK_DATADOG_API_KEY

--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -66,13 +66,13 @@ steps:
             # to the commit under review (mcp_version: source). Interpolated
             # at pipeline-upload time, when BUILDKITE_COMMIT is this commit.
             - MCP_SRC_SHA=${BUILDKITE_COMMIT}
-            # SECURITY: DD_API_KEY is deliberately NOT mapped here. The
+            # SECURITY: Keys should NOT be mapped here, unless strictly required
+            # by the agent, e.g., for eval scenario setup, etc. The
             # evaluated agent runs in this container with unrestricted Bash
             # and inherits its environment, so any credential mapped in is
-            # readable (and exfiltratable) by the agent under test. Datadog
-            # publishing happens in the dd-publish step below instead, from
-            # the run-bundle artifacts babystand.sh uploads.
-            # bk-eval-compare.sh keys the current run by build number.
+            # readable (and exfiltratable) by the agent under test.
+            # Example: We move Datadog publishing into dd-publish step below instead,
+            # from the run-bundle artifacts babystand.sh uploads.
             - BUILDKITE_BUILD_NUMBER
             - BUILDKITE_ORGANIZATION_SLUG
             - BUILDKITE_PIPELINE_SLUG

--- a/.buildkite/pipeline.evals.yml
+++ b/.buildkite/pipeline.evals.yml
@@ -111,10 +111,13 @@ steps:
 
   # Publish per-entry run metrics to Datadog, OUTSIDE the agent container.
   # SECURITY: the eval step above runs the evaluated agent with unrestricted
-  # Bash, so DD_API_KEY must never enter that container's environment.
-  # babystand.sh records each entry's identity + outcome as a
-  # runs/<id>/<run-key>.dd.json artifact in the run bundle; this step
-  # downloads those and drives evals/scripts/dd-metrics.sh once per entry.
+  # Bash, so DD_API_KEY must never exist anywhere in that step — not even
+  # captured-then-unset, since /proc/<pid>/environ keeps the exec-time
+  # snapshot readable to same-UID processes. babystand.sh records each
+  # entry's identity + outcome as a runs/<id>/<run-key>.dd.json artifact in
+  # the run bundle; this step downloads those and drives
+  # evals/scripts/dd-metrics.sh once per entry. (Local runs publish the same
+  # way, manually, after the eval exits: dd-publish.sh <runs-dir>.)
   - label: ":datadog: Publish eval metrics"
     key: dd-publish
     command: ./evals/scripts/dd-publish.sh

--- a/evals/README.md
+++ b/evals/README.md
@@ -105,6 +105,32 @@ All new code are mostly in `evals/` folder
       successful `main` build, the default target is the current run
   * bk-tool-audit-v2.sh
     * Retrieve stats about tool calls, input/output token/cache usage from LLM session logs
+    * For claude runs it also breaks execution time down: `duration_seconds`
+      (wall-clock), `tool_time_seconds` (inside tool calls), and `wait`
+      (inside *waiting* tool calls — `wait_for_build` plus Bash commands that
+      `sleep`-poll), computed by pairing each `tool_use` with its
+      `tool_result` via the transcript's per-line timestamps. cursor /
+      cursor-cloud streams carry no per-event timestamps, so `wait` /
+      `tool_time_seconds` are null there (their result event still reports
+      total duration)
+  * dd-metrics.sh
+    * Publish one entry's run metrics to Datadog (metrics v2 series API) as
+      `mcp_eval.*` gauges — run count, goal_achieved (1/0), duration /
+      tool-time / wait seconds, tool call counts (total + `mcp__`-prefixed),
+      and token usage (input / output / cache read / cache write) — tagged
+      `entry:`, `prompt:`, `agent:`, `model:`, `goal:`, `buildkite_build:`
+    * Best-effort by design: skips loudly when `DD_API_KEY` is unset (local
+      runs, forks), and a publish failure never fails the entry. `DD_SITE`
+      picks the Datadog site, `DD_METRIC_PREFIX` the namespace (default
+      `mcp_eval`), `DD_DRY_RUN=true` prints the payload instead of submitting
+    * Goal detection (in babystand.sh): entries whose setup pushed a
+      `SCENARIO_BRANCH` count as achieved when that branch's latest build in
+      the eval org is `passed`; entries without one (e.g. analyze-build)
+      report `unknown` — tagged, but no `goal_achieved` series, so gaps in
+      Datadog never miscount as misses
+    * CI wiring: the `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in
+      the cluster (see .buildkite/pipeline.evals.yml) — create it before that
+      mapping ships, or the step fails at secret resolution
   * parser.ts
     * Parse LLM agent assistant/user convo into bk annotation
   * Dockerfile

--- a/evals/README.md
+++ b/evals/README.md
@@ -125,22 +125,32 @@ All new code are mostly in `evals/` folder
       `mcp_eval`), `DD_TIMESTAMP` the point timestamp (the run's end; clamped
       to Datadog's ~1h ingest window), `DD_DRY_RUN=true` prints the payload
       instead of submitting
-    * SECURITY: in CI this never runs inside the eval container — the agent
-      under test has unrestricted Bash there and would inherit `DD_API_KEY`.
-      babystand.sh calls it directly only for local runs; CI publishing goes
-      through dd-publish.sh (below)
+    * SECURITY: this never runs while the eval agent does — in either mode.
+      The agent under test has unrestricted Bash, and a key present anywhere
+      in the run (even captured-then-`unset`) stays readable to same-UID
+      processes via `/proc/<pid>/environ`. babystand.sh only records
+      metadata; dd-publish.sh (below) is the single place the key exists
     * Goal detection (in babystand.sh): entries whose setup pushed a
       `SCENARIO_BRANCH` count as achieved when that branch's latest build in
       the eval org is `passed`; entries without one (e.g. analyze-build)
       report `unknown` — tagged, but no `goal_achieved` series, so gaps in
       Datadog never miscount as misses
   * dd-publish.sh
-    * CI post-step entry point (the `dd-publish` step in
-      .buildkite/pipeline.evals.yml): downloads each entry's
-      `runs/<id>/<run-key>.dd.json` (identity + outcome, written by
-      babystand.sh) and `.metrics.json` artifacts, then drives dd-metrics.sh
-      once per entry — so `DD_API_KEY` stays scoped to that step and out of
-      the agent's environment
+    * The single Datadog publish entry point, and the only process that may
+      hold `DD_API_KEY`. Reads each entry's `runs/<id>/<run-key>.dd.json`
+      (identity + outcome, written by babystand.sh) plus `.metrics.json`,
+      then drives dd-metrics.sh once per entry
+    * CI mode (no argument): the `dd-publish` pipeline step — downloads the
+      run-bundle artifacts; the key is scoped to that step via `secrets`
+    * Local mode (`dd-publish.sh <runs-dir>`): run it AFTER babystand.sh has
+      exited, in a fresh shell — never export `DD_API_KEY` into the eval run
+      itself:
+      ```bash
+      DD_API_KEY=... ./evals/scripts/dd-publish.sh evals/runs
+      ```
+      (Points keep each run's recorded end time, clamped to Datadog's ~1h
+      ingest window — publish soon after the run or old points snap to the
+      window edge)
     * CI wiring: the `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in
       the cluster (see .buildkite/pipeline.evals.yml) — create it before that
       mapping ships, or the step fails at secret resolution

--- a/evals/README.md
+++ b/evals/README.md
@@ -148,9 +148,10 @@ All new code are mostly in `evals/` folder
       ```bash
       DD_API_KEY=... ./evals/scripts/dd-publish.sh evals/runs
       ```
-      (Points keep each run's recorded end time, clamped to Datadog's ~1h
-      ingest window — publish soon after the run or old points snap to the
-      window edge)
+      Publishes only the LATEST run (newest babystand DATETIME stamp) — the
+      runs tree is persistent, and republishing older bundles would clamp
+      their timestamps into Datadog's ~1h ingest window, making stale
+      results look recent. Publish soon after the run for accurate points
     * CI wiring: the `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in
       the cluster (see .buildkite/pipeline.evals.yml) — create it before that
       mapping ships, or the step fails at secret resolution

--- a/evals/README.md
+++ b/evals/README.md
@@ -122,12 +122,25 @@ All new code are mostly in `evals/` folder
     * Best-effort by design: skips loudly when `DD_API_KEY` is unset (local
       runs, forks), and a publish failure never fails the entry. `DD_SITE`
       picks the Datadog site, `DD_METRIC_PREFIX` the namespace (default
-      `mcp_eval`), `DD_DRY_RUN=true` prints the payload instead of submitting
+      `mcp_eval`), `DD_TIMESTAMP` the point timestamp (the run's end; clamped
+      to Datadog's ~1h ingest window), `DD_DRY_RUN=true` prints the payload
+      instead of submitting
+    * SECURITY: in CI this never runs inside the eval container — the agent
+      under test has unrestricted Bash there and would inherit `DD_API_KEY`.
+      babystand.sh calls it directly only for local runs; CI publishing goes
+      through dd-publish.sh (below)
     * Goal detection (in babystand.sh): entries whose setup pushed a
       `SCENARIO_BRANCH` count as achieved when that branch's latest build in
       the eval org is `passed`; entries without one (e.g. analyze-build)
       report `unknown` — tagged, but no `goal_achieved` series, so gaps in
       Datadog never miscount as misses
+  * dd-publish.sh
+    * CI post-step entry point (the `dd-publish` step in
+      .buildkite/pipeline.evals.yml): downloads each entry's
+      `runs/<id>/<run-key>.dd.json` (identity + outcome, written by
+      babystand.sh) and `.metrics.json` artifacts, then drives dd-metrics.sh
+      once per entry — so `DD_API_KEY` stays scoped to that step and out of
+      the agent's environment
     * CI wiring: the `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in
       the cluster (see .buildkite/pipeline.evals.yml) — create it before that
       mapping ships, or the step fails at secret resolution

--- a/evals/README.md
+++ b/evals/README.md
@@ -137,21 +137,16 @@ All new code are mostly in `evals/` folder
       Datadog never miscount as misses
   * dd-publish.sh
     * The single Datadog publish entry point, and the only process that may
-      hold `DD_API_KEY`. Reads each entry's `runs/<id>/<run-key>.dd.json`
-      (identity + outcome, written by babystand.sh) plus `.metrics.json`,
-      then drives dd-metrics.sh once per entry
-    * CI mode (no argument): the `dd-publish` pipeline step — downloads the
-      run-bundle artifacts; the key is scoped to that step via `secrets`
-    * Local mode (`dd-publish.sh <runs-dir>`): run it AFTER babystand.sh has
-      exited, in a fresh shell — never export `DD_API_KEY` into the eval run
-      itself:
-      ```bash
-      DD_API_KEY=... ./evals/scripts/dd-publish.sh evals/runs
-      ```
-      Publishes only the LATEST run (newest babystand DATETIME stamp) — the
-      runs tree is persistent, and republishing older bundles would clamp
-      their timestamps into Datadog's ~1h ingest window, making stale
-      results look recent. Publish soon after the run for accurate points
+      hold `DD_API_KEY` — the `dd-publish` pipeline step. Downloads each
+      entry's `runs/<id>/<run-key>.dd.json` (identity + outcome, written by
+      babystand.sh) plus `.metrics.json` run-bundle artifacts, then drives
+      dd-metrics.sh once per entry; the key is scoped to that step via
+      `secrets`
+    * Datadog publishing is CI-only. Local runs are for debugging prompts
+      and scenarios: they record the same `dd.json` in the bundle but never
+      publish (and babystand.sh warns + unsets if `DD_API_KEY` is exported
+      into a run). To test the payload by hand, use
+      `DD_DRY_RUN=true dd-metrics.sh`
     * CI wiring: the `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in
       the cluster (see .buildkite/pipeline.evals.yml) — create it before that
       mapping ships, or the step fails at secret resolution

--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -106,6 +106,7 @@ matrix:
         echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
     mcp_version: source
     # compare_target defaults to this run.
+    compare_base: build:266
 
   # The same scenario driven by the Cursor CLI instead of Claude Code — lets a
   # build compare how two different agents fare against the same MCP server.

--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -105,8 +105,8 @@ matrix:
         # Hand the generated branch name to the prompt template.
         echo "SCENARIO_BRANCH=$SCENARIO_BRANCH" >> "$SCENARIO_VARS_FILE"
     mcp_version: source
-    # compare_target defaults to this run.
-    compare_base: build:266
+    # compare_base/compare_target take their defaults: the entry's bundle from
+    # the last successful main build vs this run.
 
   # The same scenario driven by the Cursor CLI instead of Claude Code — lets a
   # build compare how two different agents fare against the same MCP server.

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -544,16 +544,37 @@ run_entry() {
         echo "*** [$ENTRY_ID] scenario branch '$SCENARIO_BRANCH_VAL' latest build state: $FINAL_BUILD_STATE (goal_achieved: $GOAL_ACHIEVED)"
     fi
 
-    # --- Publish run metrics to Datadog (best-effort) ------------------------
-    # Skips loudly when DD_API_KEY is unset (local runs, forks). Klaren's own
-    # runtime is deliberately excluded: EVAL_DURATION_SECONDS measures the
-    # agent under test, not the judge.
+    # --- Datadog run metrics (best-effort) -----------------------------------
+    # SECURITY: in CI, DD_API_KEY never enters this container — the evaluated
+    # agent runs here with unrestricted Bash and would inherit it. Record the
+    # entry's identity + outcome as <run>.dd.json in the bundle instead; the
+    # dd-publish pipeline step (outside this container) downloads the bundles
+    # and submits them with the key scoped to that step alone. Local runs have
+    # no post-step, so they publish directly — dd-metrics.sh skips loudly when
+    # DD_API_KEY is unset. Klaren's own runtime is deliberately excluded
+    # either way: EVAL_DURATION_SECONDS measures the agent under test, not
+    # the judge.
     echo "--- :datadog: [$ENTRY_ID] datadog metrics"
-    ENTRY_ID="$ENTRY_ID" PROMPT_NAME="$PROMPT_NAME" AGENT="$AGENT" MODEL="${MODEL:-default}" \
-    GOAL_ACHIEVED="$GOAL_ACHIEVED" EVAL_DURATION_SECONDS="$EVAL_ELAPSED_SECS" \
-    METRICS_FILE="$AUDIT_METRICS_FILE" \
-        "$SCRIPT_DIR/dd-metrics.sh" \
-        || echo "WARNING: datadog publish failed for '$ENTRY_ID'" >&2
+    jq -n \
+        --arg entry    "$ENTRY_ID" \
+        --arg prompt   "$PROMPT_NAME" \
+        --arg agent    "$AGENT" \
+        --arg model    "${MODEL:-default}" \
+        --arg goal     "$GOAL_ACHIEVED" \
+        --arg duration "$EVAL_ELAPSED_SECS" \
+        --argjson end  "$(date +%s)" \
+        '{entry: $entry, prompt: $prompt, agent: $agent, model: $model,
+          goal: $goal, duration_seconds: $duration, end_ts: $end}' \
+        > "$PREFIX.dd.json"
+    if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
+        echo "*** [$ENTRY_ID] run metadata recorded for the dd-publish step: $PREFIX.dd.json"
+    else
+        ENTRY_ID="$ENTRY_ID" PROMPT_NAME="$PROMPT_NAME" AGENT="$AGENT" MODEL="${MODEL:-default}" \
+        GOAL_ACHIEVED="$GOAL_ACHIEVED" EVAL_DURATION_SECONDS="$EVAL_ELAPSED_SECS" \
+        METRICS_FILE="$AUDIT_METRICS_FILE" \
+            "$SCRIPT_DIR/dd-metrics.sh" \
+            || echo "WARNING: datadog publish failed for '$ENTRY_ID'" >&2
+    fi
 
     # --- Klaren review (best-effort) ---------------------------------------
     # Klaren always runs on claude regardless of the entry's agent: it is the

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -567,17 +567,24 @@ run_entry() {
     # runtime is deliberately excluded either way: EVAL_DURATION_SECONDS
     # measures the agent under test, not the judge.
     echo "--- :datadog: [$ENTRY_ID] datadog metrics"
-    jq -n \
+    # NOTE: $end_ts, not $end — `end` is a jq reserved keyword and jq 1.6
+    # (this container's Ubuntu jq) rejects it as a variable name; a compile
+    # error here would leave a 0-byte dd.json and the entry would publish as
+    # entry:unknown. Fail loudly instead of trusting errexit: run_entry is
+    # called in a conditional context, where set -e is suspended.
+    if ! jq -n \
         --arg entry    "$ENTRY_ID" \
         --arg prompt   "$PROMPT_NAME" \
         --arg agent    "$AGENT" \
         --arg model    "${MODEL:-default}" \
         --arg goal     "$GOAL_ACHIEVED" \
         --arg duration "$EVAL_ELAPSED_SECS" \
-        --argjson end  "$(date +%s)" \
+        --argjson end_ts "$(date +%s)" \
         '{entry: $entry, prompt: $prompt, agent: $agent, model: $model,
-          goal: $goal, duration_seconds: $duration, end_ts: $end}' \
-        > "$PREFIX.dd.json"
+          goal: $goal, duration_seconds: $duration, end_ts: $end_ts}' \
+        > "$PREFIX.dd.json"; then
+        echo "WARNING: [$ENTRY_ID] failed to write $PREFIX.dd.json; Datadog publish will skip this entry" >&2
+    fi
     if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
         echo "*** [$ENTRY_ID] run metadata recorded for the dd-publish step: $PREFIX.dd.json"
     else

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -505,7 +505,8 @@ run_entry() {
         echo "ERROR: [$ENTRY_ID] agent run failed; skipping audit/bundle/compare for this entry (log: $LOG)" >&2
         return 1
     fi
-    local EVAL_ELAPSED; EVAL_ELAPSED=$(fmt_elapsed $(( $(date +%s) - EVAL_START )))
+    local EVAL_ELAPSED_SECS=$(( $(date +%s) - EVAL_START ))
+    local EVAL_ELAPSED; EVAL_ELAPSED=$(fmt_elapsed "$EVAL_ELAPSED_SECS")
     echo "*** [$ENTRY_ID] EVAL ELAPSED: $EVAL_ELAPSED  SESSION_ID: $SESSION_ID"
     echo "*** [$ENTRY_ID] TRANSCRIPT: $TRANSCRIPT"
 
@@ -519,6 +520,40 @@ run_entry() {
     "$SCRIPT_DIR/bk-tool-audit-v2.sh" --agent "$AGENT" --all "$TRANSCRIPT" | tee "$AUDIT_TOOLS_FILE" || true
     echo "--- :bar_chart: [$ENTRY_ID] session metrics"
     "$SCRIPT_DIR/bk-tool-audit-v2.sh" --agent "$AGENT" metrics "$TRANSCRIPT" | tee "$AUDIT_METRICS_FILE" || true
+
+    # --- Goal outcome ---------------------------------------------------------
+    # Scenario-shaped: entries whose setup pushed a scenario branch
+    # (SCENARIO_BRANCH in the vars file; last value wins, matching
+    # render_prompt) achieved their goal when that branch's LATEST build in the
+    # eval org is green — the red->green contract. Entries without a branch
+    # (e.g. analyze-build) have no machine-checkable goal and stay "unknown";
+    # so does an API failure or a branch with no builds, so a Datadog gap
+    # never miscounts as a miss.
+    local GOAL_ACHIEVED="unknown" SCENARIO_BRANCH_VAL="" FINAL_BUILD_STATE=""
+    SCENARIO_BRANCH_VAL="$(awk -F= '$1 == "SCENARIO_BRANCH" { v = substr($0, index($0, "=") + 1) } END { print v }' "$VARS_FILE")"
+    if [[ -n "$SCENARIO_BRANCH_VAL" ]]; then
+        FINAL_BUILD_STATE="$(curl -fsS --max-time 30 \
+            -H "Authorization: Bearer $ENTRY_TOKEN" \
+            "https://api.buildkite.com/v2/organizations/$ORG_SLUG/pipelines/$PIPELINE_SLUG/builds?branch=$SCENARIO_BRANCH_VAL&per_page=1" \
+            | jq -r '.[0].state // "none"' || echo "unknown")"
+        case "$FINAL_BUILD_STATE" in
+            passed)       GOAL_ACHIEVED="true" ;;
+            unknown|none) GOAL_ACHIEVED="unknown" ;;
+            *)            GOAL_ACHIEVED="false" ;;
+        esac
+        echo "*** [$ENTRY_ID] scenario branch '$SCENARIO_BRANCH_VAL' latest build state: $FINAL_BUILD_STATE (goal_achieved: $GOAL_ACHIEVED)"
+    fi
+
+    # --- Publish run metrics to Datadog (best-effort) ------------------------
+    # Skips loudly when DD_API_KEY is unset (local runs, forks). Klaren's own
+    # runtime is deliberately excluded: EVAL_DURATION_SECONDS measures the
+    # agent under test, not the judge.
+    echo "--- :datadog: [$ENTRY_ID] datadog metrics"
+    ENTRY_ID="$ENTRY_ID" PROMPT_NAME="$PROMPT_NAME" AGENT="$AGENT" MODEL="${MODEL:-default}" \
+    GOAL_ACHIEVED="$GOAL_ACHIEVED" EVAL_DURATION_SECONDS="$EVAL_ELAPSED_SECS" \
+    METRICS_FILE="$AUDIT_METRICS_FILE" \
+        "$SCRIPT_DIR/dd-metrics.sh" \
+        || echo "WARNING: datadog publish failed for '$ENTRY_ID'" >&2
 
     # --- Klaren review (best-effort) ---------------------------------------
     # Klaren always runs on claude regardless of the entry's agent: it is the

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -65,16 +65,23 @@ if [[ "${RUN_IN_CI:-false}" != "true" && "$LOCAL_BYPASS_PERMISSION" != "true" ]]
     fi
 fi
 
-# SECURITY: scrub DD_API_KEY from the environment before any child process
-# spawns. Local runs export it for direct publishing, but every subprocess —
-# the evaluated agent (possibly with bypassed permissions), Klaren, scenario
-# setup shells — inherits this script's environment and must never see the
-# key. It is handed back explicitly to the dd-metrics.sh invocation alone;
-# an unexported shell variable does not reach children. (In CI the variable
-# is never mapped into this container at all — see the SECURITY note in
-# .buildkite/pipeline.evals.yml.)
-_DD_API_KEY="${DD_API_KEY:-}"
-unset DD_API_KEY
+# SECURITY: this script must NEVER hold DD_API_KEY. It runs the evaluated
+# agent (possibly with bypassed permissions), and on Linux the key would stay
+# readable in /proc/<pid>/environ for the whole run even after `unset` —
+# environ is the exec-time snapshot, and any same-UID process the agent
+# spawns (or leaves behind) can read it. So publishing is fully out-of-band
+# in BOTH modes: entries record their identity/outcome as <run>.dd.json and
+# the key only ever exists in a separate dd-publish.sh process — the
+# dd-publish pipeline step in CI, a manual invocation AFTER this script has
+# exited for local runs (see evals/README.md). The unset below is defense in
+# depth for an operator who exported the key anyway, not a substitute:
+# children stop inheriting it, but this process's environ still exposes it.
+if [[ -n "${DD_API_KEY:-}" ]]; then
+    echo "WARNING: DD_API_KEY is set in babystand.sh's environment; the agent under test" >&2
+    echo "WARNING: may be able to recover it (/proc/<pid>/environ survives unset). Do not" >&2
+    echo "WARNING: export it for eval runs — publish afterwards: dd-publish.sh <runs-dir>." >&2
+    unset DD_API_KEY
+fi
 
 # One timestamp for the whole build; entries are disambiguated by ENTRY_ID.
 DATETIME=$(date +%Y-%m-%d-%H%M%S)
@@ -555,17 +562,15 @@ run_entry() {
         echo "*** [$ENTRY_ID] scenario branch '$SCENARIO_BRANCH_VAL' latest build state: $FINAL_BUILD_STATE (goal_achieved: $GOAL_ACHIEVED)"
     fi
 
-    # --- Datadog run metrics (best-effort) -----------------------------------
-    # SECURITY: in CI, DD_API_KEY never enters this container — the evaluated
-    # agent runs here with unrestricted Bash and would inherit it. Record the
-    # entry's identity + outcome as <run>.dd.json in the bundle instead; the
-    # dd-publish pipeline step (outside this container) downloads the bundles
-    # and submits them with the key scoped to that step alone. Local runs have
-    # no post-step, so they publish directly — from _DD_API_KEY, captured and
-    # scrubbed from the environment at startup so no agent subprocess ever
-    # inherits it; dd-metrics.sh skips loudly when it is empty. Klaren's own
-    # runtime is deliberately excluded either way: EVAL_DURATION_SECONDS
-    # measures the agent under test, not the judge.
+    # --- Datadog run metadata ------------------------------------------------
+    # SECURITY: publishing is out-of-band in BOTH modes — DD_API_KEY must
+    # never exist in this process or any of its children while the evaluated
+    # agent runs (see the header note). This section only RECORDS the entry's
+    # identity + outcome as <run>.dd.json in the bundle; dd-publish.sh
+    # submits it later from a separate process: the dd-publish pipeline step
+    # in CI, a manual `dd-publish.sh <runs-dir>` after this script exits for
+    # local runs. Klaren's own runtime is deliberately excluded:
+    # EVAL_DURATION_SECONDS measures the agent under test, not the judge.
     echo "--- :datadog: [$ENTRY_ID] datadog metrics"
     # NOTE: $end_ts, not $end — `end` is a jq reserved keyword and jq 1.6
     # (this container's Ubuntu jq) rejects it as a variable name; a compile
@@ -588,12 +593,9 @@ run_entry() {
     if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
         echo "*** [$ENTRY_ID] run metadata recorded for the dd-publish step: $PREFIX.dd.json"
     else
-        DD_API_KEY="$_DD_API_KEY" \
-        ENTRY_ID="$ENTRY_ID" PROMPT_NAME="$PROMPT_NAME" AGENT="$AGENT" MODEL="${MODEL:-default}" \
-        GOAL_ACHIEVED="$GOAL_ACHIEVED" EVAL_DURATION_SECONDS="$EVAL_ELAPSED_SECS" \
-        METRICS_FILE="$AUDIT_METRICS_FILE" \
-            "$SCRIPT_DIR/dd-metrics.sh" \
-            || echo "WARNING: datadog publish failed for '$ENTRY_ID'" >&2
+        echo "*** [$ENTRY_ID] run metadata recorded: $PREFIX.dd.json"
+        echo "*** [$ENTRY_ID] to publish to Datadog, run AFTER this eval exits:"
+        echo "***     DD_API_KEY=... $SCRIPT_DIR/dd-publish.sh $RUNS_ROOT"
     fi
 
     # --- Klaren review (best-effort) ---------------------------------------

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -69,17 +69,17 @@ fi
 # agent (possibly with bypassed permissions), and on Linux the key would stay
 # readable in /proc/<pid>/environ for the whole run even after `unset` —
 # environ is the exec-time snapshot, and any same-UID process the agent
-# spawns (or leaves behind) can read it. So publishing is fully out-of-band
-# in BOTH modes: entries record their identity/outcome as <run>.dd.json and
-# the key only ever exists in a separate dd-publish.sh process — the
-# dd-publish pipeline step in CI, a manual invocation AFTER this script has
-# exited for local runs (see evals/README.md). The unset below is defense in
-# depth for an operator who exported the key anyway, not a substitute:
-# children stop inheriting it, but this process's environ still exposes it.
+# spawns (or leaves behind) can read it. Datadog publishing is therefore
+# CI-only and fully out-of-band: entries record their identity/outcome as
+# <run>.dd.json in the bundle, and the key only ever exists in the separate
+# dd-publish pipeline step. Local runs are for debugging prompts/scenarios
+# and never publish. The unset below is defense in depth for an operator who
+# exported the key anyway, not a substitute: children stop inheriting it,
+# but this process's environ still exposes it.
 if [[ -n "${DD_API_KEY:-}" ]]; then
     echo "WARNING: DD_API_KEY is set in babystand.sh's environment; the agent under test" >&2
     echo "WARNING: may be able to recover it (/proc/<pid>/environ survives unset). Do not" >&2
-    echo "WARNING: export it for eval runs — publish afterwards: dd-publish.sh <runs-dir>." >&2
+    echo "WARNING: export it for eval runs — Datadog publishing is CI-only." >&2
     unset DD_API_KEY
 fi
 
@@ -563,13 +563,12 @@ run_entry() {
     fi
 
     # --- Datadog run metadata ------------------------------------------------
-    # SECURITY: publishing is out-of-band in BOTH modes — DD_API_KEY must
-    # never exist in this process or any of its children while the evaluated
-    # agent runs (see the header note). This section only RECORDS the entry's
-    # identity + outcome as <run>.dd.json in the bundle; dd-publish.sh
-    # submits it later from a separate process: the dd-publish pipeline step
-    # in CI, a manual `dd-publish.sh <runs-dir>` after this script exits for
-    # local runs. Klaren's own runtime is deliberately excluded:
+    # SECURITY: DD_API_KEY must never exist in this process or any of its
+    # children while the evaluated agent runs (see the header note). This
+    # section only RECORDS the entry's identity + outcome as <run>.dd.json in
+    # the bundle; CI's dd-publish pipeline step submits it later from a
+    # separate process. Local runs never publish — they are for debugging
+    # prompts/scenarios. Klaren's own runtime is deliberately excluded:
     # EVAL_DURATION_SECONDS measures the agent under test, not the judge.
     echo "--- :datadog: [$ENTRY_ID] datadog metrics"
     # NOTE: $end_ts, not $end — `end` is a jq reserved keyword and jq 1.6
@@ -590,13 +589,7 @@ run_entry() {
         > "$PREFIX.dd.json"; then
         echo "WARNING: [$ENTRY_ID] failed to write $PREFIX.dd.json; Datadog publish will skip this entry" >&2
     fi
-    if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
-        echo "*** [$ENTRY_ID] run metadata recorded for the dd-publish step: $PREFIX.dd.json"
-    else
-        echo "*** [$ENTRY_ID] run metadata recorded: $PREFIX.dd.json"
-        echo "*** [$ENTRY_ID] to publish to Datadog, run AFTER this eval exits:"
-        echo "***     DD_API_KEY=... $SCRIPT_DIR/dd-publish.sh $RUNS_ROOT"
-    fi
+    echo "*** [$ENTRY_ID] run metadata recorded: $PREFIX.dd.json (published by CI's dd-publish step; local runs never publish)"
 
     # --- Klaren review (best-effort) ---------------------------------------
     # Klaren always runs on claude regardless of the entry's agent: it is the

--- a/evals/scripts/babystand.sh
+++ b/evals/scripts/babystand.sh
@@ -65,6 +65,17 @@ if [[ "${RUN_IN_CI:-false}" != "true" && "$LOCAL_BYPASS_PERMISSION" != "true" ]]
     fi
 fi
 
+# SECURITY: scrub DD_API_KEY from the environment before any child process
+# spawns. Local runs export it for direct publishing, but every subprocess —
+# the evaluated agent (possibly with bypassed permissions), Klaren, scenario
+# setup shells — inherits this script's environment and must never see the
+# key. It is handed back explicitly to the dd-metrics.sh invocation alone;
+# an unexported shell variable does not reach children. (In CI the variable
+# is never mapped into this container at all — see the SECURITY note in
+# .buildkite/pipeline.evals.yml.)
+_DD_API_KEY="${DD_API_KEY:-}"
+unset DD_API_KEY
+
 # One timestamp for the whole build; entries are disambiguated by ENTRY_ID.
 DATETIME=$(date +%Y-%m-%d-%H%M%S)
 
@@ -550,10 +561,11 @@ run_entry() {
     # entry's identity + outcome as <run>.dd.json in the bundle instead; the
     # dd-publish pipeline step (outside this container) downloads the bundles
     # and submits them with the key scoped to that step alone. Local runs have
-    # no post-step, so they publish directly — dd-metrics.sh skips loudly when
-    # DD_API_KEY is unset. Klaren's own runtime is deliberately excluded
-    # either way: EVAL_DURATION_SECONDS measures the agent under test, not
-    # the judge.
+    # no post-step, so they publish directly — from _DD_API_KEY, captured and
+    # scrubbed from the environment at startup so no agent subprocess ever
+    # inherits it; dd-metrics.sh skips loudly when it is empty. Klaren's own
+    # runtime is deliberately excluded either way: EVAL_DURATION_SECONDS
+    # measures the agent under test, not the judge.
     echo "--- :datadog: [$ENTRY_ID] datadog metrics"
     jq -n \
         --arg entry    "$ENTRY_ID" \
@@ -569,6 +581,7 @@ run_entry() {
     if [[ "${RUN_IN_CI:-false}" == "true" ]]; then
         echo "*** [$ENTRY_ID] run metadata recorded for the dd-publish step: $PREFIX.dd.json"
     else
+        DD_API_KEY="$_DD_API_KEY" \
         ENTRY_ID="$ENTRY_ID" PROMPT_NAME="$PROMPT_NAME" AGENT="$AGENT" MODEL="${MODEL:-default}" \
         GOAL_ACHIEVED="$GOAL_ACHIEVED" EVAL_DURATION_SECONDS="$EVAL_ELAPSED_SECS" \
         METRICS_FILE="$AUDIT_METRICS_FILE" \

--- a/evals/scripts/bk-tool-audit-v2.sh
+++ b/evals/scripts/bk-tool-audit-v2.sh
@@ -254,6 +254,11 @@ print_session() {
 }
 
 # Token totals, cost, tool counts, model mix, and duration for one session.
+# The claude dialect also reports a waiting-time breakdown (the `wait` key):
+# wall-clock spent inside wait_for_build calls and Bash `sleep` polls, computed
+# by pairing each tool_use with its tool_result via the per-line timestamps.
+# cursor / cursor-cloud streams carry no per-event timestamps, so their
+# `wait` / `tool_time_seconds` are null.
 # Dedupes usage by message.id (content blocks are split one-per-line, each
 # repeating the message-level usage) and reads from a stable snapshot copy to
 # avoid racing the live append of the current session.
@@ -285,13 +290,19 @@ metrics() {
           user_messages: null,
           assistant_responses: null,
           duration_min: (if ($res.durationMs // null) != null then ($res.durationMs/60000|floor) else null end),
+          duration_seconds: (if ($res.durationMs // null) != null then (($res.durationMs/1000)|round) else null end),
           models: {(($meta.model // "unknown") | tostring): 1},
           tokens: (if $u != null then
                      {input: ($u.inputTokens // 0), output: ($u.outputTokens // 0),
                       cache_write: ($u.cacheWriteTokens // 0), cache_read: ($u.cacheReadTokens // 0)}
                    else null end),
           tool_calls_total: ($tools | length),
+          tool_calls_mcp: ($tools | map(cloud_tool_name(.)) | map(select(startswith("mcp__"))) | length),
           tool_calls_by_name: ($tools | map(cloud_tool_name(.)) | group_by(.) | map("\(length) \(.[0])") | sort | reverse),
+          # SSE events carry no per-event timestamps, so in-tool / waiting time
+          # cannot be reconstructed for cloud runs.
+          tool_time_seconds: null,
+          wait: null,
           est_cost_usd: null
         }
     ' "$snap"
@@ -318,10 +329,16 @@ metrics() {
           user_messages: ($all | map(select(.type=="user")) | length),
           assistant_responses: ($all | map(select(.type=="assistant")) | length),
           duration_min: (if ($res.duration_ms? // null) != null then ($res.duration_ms/60000|floor) else null end),
+          duration_seconds: (if ($res.duration_ms? // null) != null then (($res.duration_ms/1000)|round) else null end),
           models: {(($init.model? // "unknown")): 1},
           tokens: null,
           tool_calls_total: ($tools | length),
+          tool_calls_mcp: ($tools | map(select(startswith("mcp__"))) | length),
           tool_calls_by_name: ($tools | group_by(.) | map("\(length) \(.[0])") | sort | reverse),
+          # cursor stream-json has no per-event timestamps, so in-tool /
+          # waiting time cannot be reconstructed.
+          tool_time_seconds: null,
+          wait: null,
           est_cost_usd: null
         }
     ' "$snap"
@@ -339,13 +356,28 @@ metrics() {
   echo "# session: $f" >&2
   jq -nr --argjson p "$prices" '
     def n: . // 0;
+    def tsec: sub("\\.[0-9]+";"") | fromdateiso8601;
     [inputs] as $all
     | ($all | map(select(.type=="assistant")) | group_by(.message.id) | map(.[0])) as $resp
     | ($resp | map(.message.usage)) as $u
-    | ($all | [ .[] | (.message.content? // []) | select(type=="array") | .[]
-                | select(.type=="tool_use") | {id, name} ] | unique_by(.id)) as $tools
+    | ($all | [ .[] | . as $l | (.message.content? // []) | select(type=="array") | .[]
+                | select(.type=="tool_use")
+                | {id, name, input, ts: $l.timestamp} ] | unique_by(.id)) as $tools
     | ($all | map(.timestamp) | map(select(type=="string"))
-            | map(sub("\\.[0-9]+";"") | fromdateiso8601)) as $secs
+            | map(tsec)) as $secs
+    # Wall-clock spent INSIDE each tool call: pair every tool_use with its
+    # tool_result (by tool_use_id) and diff the line timestamps. The subset in
+    # $waits is time the agent spent WAITING on external state rather than
+    # working: wait_for_build calls, plus Bash commands that shell out to
+    # `sleep` (the poll-and-sleep loop agents fall back to). Heuristic on
+    # purpose — a get_build poll with no sleep is NOT counted as waiting.
+    | ($all | [ .[] | . as $l | (.message.content? // []) | select(type=="array") | .[]
+                | select(.type=="tool_result" and .tool_use_id != null)
+                | {key: .tool_use_id, value: $l.timestamp} ] | from_entries) as $rts
+    | ($tools | map(select((.ts|type)=="string" and (($rts[.id] // null)|type)=="string")
+                    | {name, input, dur: (($rts[.id]|tsec) - (.ts|tsec))})) as $timed
+    | ($timed | map(select((.name | test("^mcp__.*__wait_for_build$"))
+                    or (.name == "Bash" and ((.input.command? // "") | test("\\bsleep\\b")))))) as $waits
     # token sums
     | ($u | map(.input_tokens|n)            | add | n) as $tin
     | ($u | map(.output_tokens|n)           | add | n) as $tout
@@ -360,10 +392,20 @@ metrics() {
         user_messages: ($all|map(select(.type=="user"))|length),
         assistant_responses: ($resp|length),
         duration_min: (if ($secs|length) > 0 then ((($secs|max)-($secs|min))/60|floor) else null end),
+        duration_seconds: (if ($secs|length) > 0 then (($secs|max)-($secs|min)) else null end),
         models: ($resp | map(.message.model // "unknown") | group_by(.) | map({(.[0]): length}) | add),
         tokens: {input: $tin, output: $tout, cache_write_5m: $c5, cache_write_1h: $c1h, cache_read: $tread},
         tool_calls_total: ($tools|length),
+        tool_calls_mcp: ($tools | map(select(.name | startswith("mcp__"))) | length),
         tool_calls_by_name: ($tools | group_by(.name) | map("\(length) \(.[0].name)") | sort | reverse),
+        tool_time_seconds: (($timed | map(.dur) | add) // 0),
+        wait: {
+          seconds: (($waits | map(.dur) | add) // 0),
+          calls: ($waits | length),
+          by_tool: (($waits | group_by(.name)
+                     | map({key: .[0].name, value: {calls: length, seconds: (map(.dur) | add)}})
+                     | from_entries) // {})
+        },
         est_cost_usd: (($cost*100|round)/100)
       }
   ' "$snap"

--- a/evals/scripts/dd-metrics.sh
+++ b/evals/scripts/dd-metrics.sh
@@ -9,12 +9,12 @@
 # a build, and a missing DD_API_KEY is a loud SKIP (exit 0) so local runs and
 # forks without Datadog wiring keep working unchanged.
 #
-# SECURITY: this script must run strictly OUTSIDE the eval-agent run in
-# both modes — the agent has unrestricted Bash, and a key present anywhere
-# during the run stays readable to same-UID processes via
-# /proc/<pid>/environ even after `unset`. Only dd-publish.sh drives it:
-# the CI dd-publish step (from the run-bundle artifacts, key scoped to
-# that step) or a manual dd-publish.sh <runs-dir> after a local run exits.
+# SECURITY: this script must run strictly OUTSIDE the eval-agent run — the
+# agent has unrestricted Bash, and a key present anywhere during the run
+# stays readable to same-UID processes via /proc/<pid>/environ even after
+# `unset`. Only the CI dd-publish step drives it (via dd-publish.sh, from
+# the run-bundle artifacts, key scoped to that step). Local eval runs never
+# publish; use DD_DRY_RUN=true to exercise this script by hand.
 #
 # Env contract (dd-publish.sh provides these):
 #   DD_API_KEY              Datadog API key. Unset/empty = skip (exit 0).

--- a/evals/scripts/dd-metrics.sh
+++ b/evals/scripts/dd-metrics.sh
@@ -5,17 +5,18 @@
 # Reads the bk-tool-audit-v2.sh metrics JSON plus run metadata from the
 # environment and submits gauge series to the Datadog metrics v2 API
 # (POST https://api.<site>/api/v2/series). Deliberately BEST-EFFORT:
-# babystand.sh invokes it with `|| warning` so a Datadog outage never fails an
-# entry, and a missing DD_API_KEY is a loud SKIP (exit 0) so local runs and
+# dd-publish.sh tolerates per-entry failures so a Datadog outage never fails
+# a build, and a missing DD_API_KEY is a loud SKIP (exit 0) so local runs and
 # forks without Datadog wiring keep working unchanged.
 #
-# SECURITY: in CI this script must run OUTSIDE the eval agent's container
-# (the agent has unrestricted Bash and inherits its environment, so it could
-# read DD_API_KEY). babystand.sh only invokes it directly for local runs;
-# the dd-publish.sh pipeline step drives it for CI, from the run-bundle
-# artifacts, with the key scoped to that step alone.
+# SECURITY: this script must run strictly OUTSIDE the eval-agent run in
+# both modes — the agent has unrestricted Bash, and a key present anywhere
+# during the run stays readable to same-UID processes via
+# /proc/<pid>/environ even after `unset`. Only dd-publish.sh drives it:
+# the CI dd-publish step (from the run-bundle artifacts, key scoped to
+# that step) or a manual dd-publish.sh <runs-dir> after a local run exits.
 #
-# Env contract (babystand.sh locally / dd-publish.sh in CI provides these):
+# Env contract (dd-publish.sh provides these):
 #   DD_API_KEY              Datadog API key. Unset/empty = skip (exit 0).
 #   DD_SITE                 Datadog site (default: datadoghq.com).
 #   DD_METRIC_PREFIX        Metric namespace (default: mcp_eval).

--- a/evals/scripts/dd-metrics.sh
+++ b/evals/scripts/dd-metrics.sh
@@ -52,7 +52,10 @@
 #
 set -euo pipefail
 
-if [[ -z "${DD_API_KEY:-}" ]]; then
+# Dry runs build and print the payload without submitting, so they need no
+# key — otherwise the documented DD_DRY_RUN=true payload test would exit
+# here with just the skip message.
+if [[ -z "${DD_API_KEY:-}" && "${DD_DRY_RUN:-false}" != "true" ]]; then
     echo "dd-metrics: DD_API_KEY is unset; skipping Datadog publish (see .buildkite/pipeline.evals.yml)." >&2
     exit 0
 fi

--- a/evals/scripts/dd-metrics.sh
+++ b/evals/scripts/dd-metrics.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# dd-metrics.sh — publish one eval entry's run metrics to Datadog.
+#
+# Reads the bk-tool-audit-v2.sh metrics JSON plus run metadata from the
+# environment and submits gauge series to the Datadog metrics v2 API
+# (POST https://api.<site>/api/v2/series). Deliberately BEST-EFFORT:
+# babystand.sh invokes it with `|| warning` so a Datadog outage never fails an
+# entry, and a missing DD_API_KEY is a loud SKIP (exit 0) so local runs and
+# forks without Datadog wiring keep working unchanged.
+#
+# Env contract (babystand.sh run_entry provides all of these):
+#   DD_API_KEY              Datadog API key. Unset/empty = skip (exit 0).
+#   DD_SITE                 Datadog site (default: datadoghq.com).
+#   DD_METRIC_PREFIX        Metric namespace (default: mcp_eval).
+#   ENTRY_ID                evals.yaml entry id            -> tag entry:
+#   PROMPT_NAME             prompt template name           -> tag prompt:
+#   AGENT                   claude | cursor | cursor-cloud -> tag agent:
+#   MODEL                   model id ("default" if unset)  -> tag model:
+#   GOAL_ACHIEVED           true | false | unknown         -> tag goal:
+#   EVAL_DURATION_SECONDS   agent wall-clock measured by run_entry
+#   METRICS_FILE            path to the metrics JSON. May be empty or hold
+#                           null fields (cursor runs emit no token usage);
+#                           null metrics are simply not submitted, so gaps in
+#                           Datadog mean "not measured", never zero.
+#   BUILDKITE_BUILD_NUMBER  optional                       -> tag buildkite_build:
+#
+# Submitted series (all gauges; the point timestamp is the submission time,
+# which is the run's end — that carries the "datetime" dimension):
+#   <prefix>.run                        always 1 — count runs / slice by tags
+#   <prefix>.goal_achieved              1/0; omitted when goal is unknown
+#   <prefix>.duration_seconds           agent wall-clock
+#   <prefix>.tool_time_seconds          wall-clock inside tool calls (claude only)
+#   <prefix>.wait_seconds               wall-clock inside WAITING tool calls
+#                                       (wait_for_build / Bash sleep; claude only)
+#   <prefix>.tool_calls.total
+#   <prefix>.tool_calls.buildkite_mcp   calls with the mcp__ prefix
+#   <prefix>.tokens.input / .output / .cache_read / .cache_write
+#
+set -euo pipefail
+
+if [[ -z "${DD_API_KEY:-}" ]]; then
+    echo "dd-metrics: DD_API_KEY is unset; skipping Datadog publish (see .buildkite/pipeline.evals.yml)." >&2
+    exit 0
+fi
+command -v jq >/dev/null   || { echo "dd-metrics: jq is required" >&2; exit 1; }
+command -v curl >/dev/null || { echo "dd-metrics: curl is required" >&2; exit 1; }
+
+DD_SITE="${DD_SITE:-datadoghq.com}"
+DD_METRIC_PREFIX="${DD_METRIC_PREFIX:-mcp_eval}"
+
+# Tolerate a missing/empty/corrupt metrics file: identity tags and duration
+# still get published, token/tool series are just omitted.
+METRICS_JSON="{}"
+if [[ -n "${METRICS_FILE:-}" && -s "${METRICS_FILE:-}" ]]; then
+    if jq -e . "$METRICS_FILE" >/dev/null 2>&1; then
+        METRICS_JSON="$(cat "$METRICS_FILE")"
+    else
+        echo "dd-metrics: $METRICS_FILE is not valid JSON; publishing identity/duration series only." >&2
+    fi
+fi
+
+PAYLOAD="$(jq -n \
+    --arg prefix   "$DD_METRIC_PREFIX" \
+    --arg entry    "${ENTRY_ID:-unknown}" \
+    --arg prompt   "${PROMPT_NAME:-unknown}" \
+    --arg agent    "${AGENT:-unknown}" \
+    --arg model    "${MODEL:-default}" \
+    --arg goal     "${GOAL_ACHIEVED:-unknown}" \
+    --arg duration "${EVAL_DURATION_SECONDS:-}" \
+    --arg build    "${BUILDKITE_BUILD_NUMBER:-}" \
+    --argjson now  "$(date +%s)" \
+    --argjson m    "$METRICS_JSON" '
+    # type 3 = gauge in the v2 series API. A null value emits nothing: absent
+    # in Datadog must mean "not measured" (cursor tokens), never zero.
+    def gauge($name; $v; $tags):
+      if $v == null then empty
+      else {metric: "\($prefix).\($name)", type: 3,
+            points: [{timestamp: $now, value: ($v | tonumber)}], tags: $tags}
+      end;
+    ([ "entry:\($entry)", "prompt:\($prompt)", "agent:\($agent)",
+       "model:\($model)", "goal:\($goal)" ]
+     + (if $build != "" then ["buildkite_build:\($build)"] else [] end)) as $tags
+    | ($m.tokens // {}) as $tok
+    # claude reports the cache-write split (5m/1h); cursor-cloud a single
+    # cache_write. Publish one combined series so dashboards compare agents.
+    | (($tok.cache_write_5m // 0) + ($tok.cache_write_1h // 0) + ($tok.cache_write // 0)) as $cw
+    | {series: [
+        gauge("run"; 1; $tags),
+        (if $goal == "true" then gauge("goal_achieved"; 1; $tags)
+         elif $goal == "false" then gauge("goal_achieved"; 0; $tags)
+         else empty end),
+        gauge("duration_seconds"; (if $duration == "" then null else $duration end); $tags),
+        gauge("tool_time_seconds"; ($m.tool_time_seconds // null); $tags),
+        gauge("wait_seconds"; (($m.wait // {}) | .seconds // null); $tags),
+        gauge("tool_calls.total"; ($m.tool_calls_total // null); $tags),
+        gauge("tool_calls.buildkite_mcp"; ($m.tool_calls_mcp // null); $tags),
+        gauge("tokens.input"; ($tok.input // null); $tags),
+        gauge("tokens.output"; ($tok.output // null); $tags),
+        gauge("tokens.cache_read"; ($tok.cache_read // null); $tags),
+        gauge("tokens.cache_write"; (if ($m.tokens // null) == null then null else $cw end); $tags)
+      ]}
+')"
+
+# Local testing: print the payload instead of submitting it.
+if [[ "${DD_DRY_RUN:-false}" == "true" ]]; then
+    jq . <<<"$PAYLOAD"
+    exit 0
+fi
+
+RESP="$(mktemp)"
+trap 'rm -f "$RESP"' EXIT
+HTTP_CODE="$(curl -sS --max-time 30 -o "$RESP" -w '%{http_code}' -X POST \
+    "https://api.${DD_SITE}/api/v2/series" \
+    -H "DD-API-KEY: ${DD_API_KEY}" \
+    -H "Content-Type: application/json" \
+    --data "$PAYLOAD")" || { echo "dd-metrics: request to api.${DD_SITE} failed" >&2; exit 1; }
+
+if [[ "$HTTP_CODE" != 2* ]]; then
+    echo "dd-metrics: Datadog API returned HTTP $HTTP_CODE: $(head -c 500 "$RESP")" >&2
+    exit 1
+fi
+echo "dd-metrics: published $(jq '.series | length' <<<"$PAYLOAD") series to ${DD_METRIC_PREFIX}.* (entry: ${ENTRY_ID:-unknown}, goal: ${GOAL_ACHIEVED:-unknown})"

--- a/evals/scripts/dd-metrics.sh
+++ b/evals/scripts/dd-metrics.sh
@@ -9,10 +9,21 @@
 # entry, and a missing DD_API_KEY is a loud SKIP (exit 0) so local runs and
 # forks without Datadog wiring keep working unchanged.
 #
-# Env contract (babystand.sh run_entry provides all of these):
+# SECURITY: in CI this script must run OUTSIDE the eval agent's container
+# (the agent has unrestricted Bash and inherits its environment, so it could
+# read DD_API_KEY). babystand.sh only invokes it directly for local runs;
+# the dd-publish.sh pipeline step drives it for CI, from the run-bundle
+# artifacts, with the key scoped to that step alone.
+#
+# Env contract (babystand.sh locally / dd-publish.sh in CI provides these):
 #   DD_API_KEY              Datadog API key. Unset/empty = skip (exit 0).
 #   DD_SITE                 Datadog site (default: datadoghq.com).
 #   DD_METRIC_PREFIX        Metric namespace (default: mcp_eval).
+#   DD_TIMESTAMP            optional point timestamp (epoch secs, the run's
+#                           end). Default: now. Clamped to Datadog's ingest
+#                           window (points older than ~1h are dropped
+#                           server-side, which would lose early entries of a
+#                           long matrix when publishing happens post-build).
 #   ENTRY_ID                evals.yaml entry id            -> tag entry:
 #   PROMPT_NAME             prompt template name           -> tag prompt:
 #   AGENT                   claude | cursor | cursor-cloud -> tag agent:
@@ -25,8 +36,9 @@
 #                           Datadog mean "not measured", never zero.
 #   BUILDKITE_BUILD_NUMBER  optional                       -> tag buildkite_build:
 #
-# Submitted series (all gauges; the point timestamp is the submission time,
-# which is the run's end — that carries the "datetime" dimension):
+# Submitted series (all gauges; the point timestamp is DD_TIMESTAMP — the
+# run's end — falling back to submission time; that carries the "datetime"
+# dimension):
 #   <prefix>.run                        always 1 — count runs / slice by tags
 #   <prefix>.goal_achieved              1/0; omitted when goal is unknown
 #   <prefix>.duration_seconds           agent wall-clock
@@ -60,6 +72,19 @@ if [[ -n "${METRICS_FILE:-}" && -s "${METRICS_FILE:-}" ]]; then
     fi
 fi
 
+# Point timestamp: prefer the recorded run end (CI publishes after the whole
+# matrix finishes). Clamp into Datadog's accepted window — points older than
+# ~1h are silently dropped, and a clamped-but-present point beats a lost one.
+NOW="$(date +%s)"
+TS="${DD_TIMESTAMP:-$NOW}"
+[[ "$TS" =~ ^[0-9]+$ ]] || TS="$NOW"
+MIN_TS=$(( NOW - 3300 ))
+if (( TS < MIN_TS )); then
+    echo "dd-metrics: DD_TIMESTAMP $TS is outside the Datadog ingest window; clamping to $MIN_TS." >&2
+    TS="$MIN_TS"
+fi
+(( TS > NOW )) && TS="$NOW"
+
 PAYLOAD="$(jq -n \
     --arg prefix   "$DD_METRIC_PREFIX" \
     --arg entry    "${ENTRY_ID:-unknown}" \
@@ -69,7 +94,7 @@ PAYLOAD="$(jq -n \
     --arg goal     "${GOAL_ACHIEVED:-unknown}" \
     --arg duration "${EVAL_DURATION_SECONDS:-}" \
     --arg build    "${BUILDKITE_BUILD_NUMBER:-}" \
-    --argjson now  "$(date +%s)" \
+    --argjson now  "$TS" \
     --argjson m    "$METRICS_JSON" '
     # type 3 = gauge in the v2 series API. A null value emits nothing: absent
     # in Datadog must mean "not measured" (cursor tokens), never zero.

--- a/evals/scripts/dd-publish.sh
+++ b/evals/scripts/dd-publish.sh
@@ -18,7 +18,12 @@
 #   Local (<runs-dir>):  run manually AFTER babystand.sh has exited, in a
 #                        fresh shell:
 #                            DD_API_KEY=... ./dd-publish.sh evals/runs
-#                        Scans the directory instead of downloading.
+#                        Scans the directory instead of downloading, and
+#                        publishes ONLY the latest run (the newest
+#                        babystand DATETIME stamp): the runs tree is
+#                        persistent, and republishing older bundles would
+#                        clamp their timestamps into Datadog's ~1h ingest
+#                        window, making stale results look recent.
 #
 # Best-effort like dd-metrics.sh: no DD_API_KEY -> loud skip (exit 0); no
 # .dd.json files -> loud skip (exit 0 in CI; the eval step may have died
@@ -36,10 +41,21 @@ if [[ -z "${DD_API_KEY:-}" ]]; then
 fi
 command -v jq >/dev/null || { echo "dd-publish: jq is required" >&2; exit 1; }
 
+NAME_GLOB="*.dd.json"
 if [[ -n "$RUNS_DIR" ]]; then
-    # Local mode: publish from an existing runs directory.
+    # Local mode: publish only the LATEST run from the persistent runs tree.
+    # Bundle files are <entry-id>-<YYYY-MM-DD-HHMMSS>.dd.json and the stamp
+    # is shared by every entry of one babystand invocation, so the newest
+    # stamp (the format sorts chronologically) selects exactly the
+    # just-completed run.
     [[ -d "$RUNS_DIR" ]] || { echo "dd-publish: runs directory not found: $RUNS_DIR" >&2; exit 1; }
     WORK_DIR="$RUNS_DIR"
+    LATEST="$(find "$RUNS_DIR" -name '*.dd.json' \
+        | sed -nE 's/.*-([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})\.dd\.json$/\1/p' \
+        | sort | tail -n1)"
+    [[ -n "$LATEST" ]] || { echo "dd-publish: no run bundles (*.dd.json) under $RUNS_DIR; nothing to publish." >&2; exit 1; }
+    NAME_GLOB="*-${LATEST}.dd.json"
+    echo "dd-publish: publishing latest run ($LATEST) from $RUNS_DIR"
 else
     # CI mode: pull the run-bundle artifacts the eval step uploaded.
     command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required (or pass a runs directory)" >&2; exit 1; }
@@ -81,11 +97,6 @@ while IFS= read -r META; do
         echo "WARNING: dd-publish: publish failed for '$ENTRY' ($META)" >&2
         FAILED=$(( FAILED + 1 ))
     fi
-done < <(find "$WORK_DIR" -name '*.dd.json' | sort)
-
-if [[ "$PUBLISHED" -eq 0 && "$FAILED" -eq 0 && -n "$RUNS_DIR" ]]; then
-    echo "dd-publish: no *.dd.json files under $RUNS_DIR; nothing to publish." >&2
-    exit 1
-fi
+done < <(find "$WORK_DIR" -name "$NAME_GLOB" | sort)
 echo "dd-publish: $PUBLISHED entry(ies) published, $FAILED failed."
 [[ "$FAILED" -eq 0 ]]

--- a/evals/scripts/dd-publish.sh
+++ b/evals/scripts/dd-publish.sh
@@ -41,6 +41,13 @@ buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
 
 PUBLISHED=0 FAILED=0
 while IFS= read -r META; do
+    # An empty or corrupt metadata file would publish every series with
+    # entry:unknown tags — noise in Datadog. Skip it loudly instead.
+    if ! jq -e . "$META" >/dev/null 2>&1; then
+        echo "WARNING: dd-publish: $META is empty or not valid JSON; skipping this entry." >&2
+        FAILED=$(( FAILED + 1 ))
+        continue
+    fi
     ENTRY="$(jq -r '.entry // "unknown"' "$META")"
     echo "--- :datadog: [$ENTRY] publishing run metrics"
     if ENTRY_ID="$ENTRY" \

--- a/evals/scripts/dd-publish.sh
+++ b/evals/scripts/dd-publish.sh
@@ -1,76 +1,49 @@
 #!/usr/bin/env bash
 #
-# dd-publish.sh — publish every entry's recorded run metrics to Datadog.
+# dd-publish.sh — CI post-step: publish every entry's run metrics to Datadog.
 #
-# SECURITY: this is the ONLY process that may hold DD_API_KEY, and it must
-# run strictly OUTSIDE the eval-agent run. The evaluated agent has
-# unrestricted Bash, and on Linux a key present anywhere in the run —
-# even `unset` after capture — stays readable to same-UID processes via
-# /proc/<pid>/environ (the exec-time snapshot). So babystand.sh never
-# touches the key in either mode; it records each entry's identity +
-# outcome as runs/<id>/<run-key>.dd.json (next to <run-key>.metrics.json)
-# and this script submits them via dd-metrics.sh afterwards.
+# SECURITY: this is the ONLY process that may hold DD_API_KEY, and it runs
+# strictly OUTSIDE the eval-agent run (the dd-publish step in
+# .buildkite/pipeline.evals.yml). The evaluated agent has unrestricted Bash,
+# and on Linux a key present anywhere in the run — even `unset` after
+# capture — stays readable to same-UID processes via /proc/<pid>/environ
+# (the exec-time snapshot). So babystand.sh never touches the key: it
+# records each entry's identity + outcome as runs/<id>/<run-key>.dd.json
+# (next to <run-key>.metrics.json), and this step downloads those artifacts
+# and submits them via dd-metrics.sh.
 #
-# Modes:
-#   CI (no argument):    the dd-publish pipeline step — downloads the
-#                        run-bundle artifacts the eval step uploaded, with
-#                        the key scoped to that step alone.
-#   Local (<runs-dir>):  run manually AFTER babystand.sh has exited, in a
-#                        fresh shell:
-#                            DD_API_KEY=... ./dd-publish.sh evals/runs
-#                        Scans the directory instead of downloading, and
-#                        publishes ONLY the latest run (the newest
-#                        babystand DATETIME stamp): the runs tree is
-#                        persistent, and republishing older bundles would
-#                        clamp their timestamps into Datadog's ~1h ingest
-#                        window, making stale results look recent.
+# Datadog publishing is CI-only. Local runs are for debugging prompts and
+# scenarios; they record the same dd.json in the bundle but never publish
+# (and dd-metrics.sh supports DD_DRY_RUN=true for testing the payload).
 #
 # Best-effort like dd-metrics.sh: no DD_API_KEY -> loud skip (exit 0); no
-# .dd.json files -> loud skip (exit 0 in CI; the eval step may have died
-# before any entry finished); a failed entry logs a warning and the script
-# exits 1 at the end (the CI step is soft_fail, so the build stays green).
+# .dd.json artifacts (eval step died before any entry finished) -> loud skip
+# (exit 0); a failed entry logs a warning and the script exits 1 at the end
+# (the step is soft_fail, so the build stays green either way).
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-RUNS_DIR="${1:-}"
 
 if [[ -z "${DD_API_KEY:-}" ]]; then
     echo "dd-publish: DD_API_KEY is unset; skipping Datadog publish (see .buildkite/pipeline.evals.yml)." >&2
     exit 0
 fi
-command -v jq >/dev/null || { echo "dd-publish: jq is required" >&2; exit 1; }
+command -v jq >/dev/null              || { echo "dd-publish: jq is required" >&2; exit 1; }
+command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required" >&2; exit 1; }
 
-NAME_GLOB="*.dd.json"
-if [[ -n "$RUNS_DIR" ]]; then
-    # Local mode: publish only the LATEST run from the persistent runs tree.
-    # Bundle files are <entry-id>-<YYYY-MM-DD-HHMMSS>.dd.json and the stamp
-    # is shared by every entry of one babystand invocation, so the newest
-    # stamp (the format sorts chronologically) selects exactly the
-    # just-completed run.
-    [[ -d "$RUNS_DIR" ]] || { echo "dd-publish: runs directory not found: $RUNS_DIR" >&2; exit 1; }
-    WORK_DIR="$RUNS_DIR"
-    LATEST="$(find "$RUNS_DIR" -name '*.dd.json' \
-        | sed -nE 's/.*-([0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6})\.dd\.json$/\1/p' \
-        | sort | tail -n1)"
-    [[ -n "$LATEST" ]] || { echo "dd-publish: no run bundles (*.dd.json) under $RUNS_DIR; nothing to publish." >&2; exit 1; }
-    NAME_GLOB="*-${LATEST}.dd.json"
-    echo "dd-publish: publishing latest run ($LATEST) from $RUNS_DIR"
-else
-    # CI mode: pull the run-bundle artifacts the eval step uploaded.
-    command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required (or pass a runs directory)" >&2; exit 1; }
-    WORK_DIR="$(mktemp -d)"
-    trap 'rm -rf "$WORK_DIR"' EXIT
-    # Metadata drives the loop; metrics files can be missing for entries whose
-    # audit failed (dd-metrics.sh then publishes identity/duration series
-    # only), hence the separate best-effort download.
-    if ! buildkite-agent artifact download "runs/*/*.dd.json" "$WORK_DIR/"; then
-        echo "dd-publish: no run metadata artifacts found; nothing to publish." >&2
-        exit 0
-    fi
-    buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
-        || echo "dd-publish: no metrics artifacts; publishing identity/duration series only." >&2
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Metadata drives the loop; metrics files can be missing for entries whose
+# audit failed (dd-metrics.sh then publishes identity/duration series only),
+# hence the separate best-effort download.
+if ! buildkite-agent artifact download "runs/*/*.dd.json" "$WORK_DIR/"; then
+    echo "dd-publish: no run metadata artifacts found; nothing to publish." >&2
+    exit 0
 fi
+buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
+    || echo "dd-publish: no metrics artifacts; publishing identity/duration series only." >&2
 
 PUBLISHED=0 FAILED=0
 while IFS= read -r META; do
@@ -97,6 +70,7 @@ while IFS= read -r META; do
         echo "WARNING: dd-publish: publish failed for '$ENTRY' ($META)" >&2
         FAILED=$(( FAILED + 1 ))
     fi
-done < <(find "$WORK_DIR" -name "$NAME_GLOB" | sort)
+done < <(find "$WORK_DIR" -name '*.dd.json' | sort)
+
 echo "dd-publish: $PUBLISHED entry(ies) published, $FAILED failed."
 [[ "$FAILED" -eq 0 ]]

--- a/evals/scripts/dd-publish.sh
+++ b/evals/scripts/dd-publish.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# dd-publish.sh — CI post-step: publish every entry's run metrics to Datadog.
+#
+# Runs OUTSIDE the eval agent's container (the dd-publish step in
+# .buildkite/pipeline.evals.yml): the evaluated agent runs with unrestricted
+# Bash, so DD_API_KEY must never enter its environment. babystand.sh records
+# each entry's identity + outcome as runs/<id>/<run-key>.dd.json (next to
+# <run-key>.metrics.json) in the run-bundle artifacts; this script downloads
+# those and drives dd-metrics.sh once per entry, with the key scoped to this
+# step alone.
+#
+# Best-effort like dd-metrics.sh: no DD_API_KEY -> loud skip (exit 0); no
+# .dd.json artifacts (eval step died before any entry finished) -> loud skip
+# (exit 0); a failed entry logs a warning and the script exits 1 at the end
+# (the step is soft_fail, so the build stays green either way).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -z "${DD_API_KEY:-}" ]]; then
+    echo "dd-publish: DD_API_KEY is unset; skipping Datadog publish (see .buildkite/pipeline.evals.yml)." >&2
+    exit 0
+fi
+command -v jq >/dev/null              || { echo "dd-publish: jq is required" >&2; exit 1; }
+command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required" >&2; exit 1; }
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Metadata drives the loop; metrics files can be missing for entries whose
+# audit failed (dd-metrics.sh then publishes identity/duration series only),
+# hence the separate best-effort download.
+if ! buildkite-agent artifact download "runs/*/*.dd.json" "$WORK_DIR/"; then
+    echo "dd-publish: no run metadata artifacts found; nothing to publish." >&2
+    exit 0
+fi
+buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
+    || echo "dd-publish: no metrics artifacts; publishing identity/duration series only." >&2
+
+PUBLISHED=0 FAILED=0
+while IFS= read -r META; do
+    ENTRY="$(jq -r '.entry // "unknown"' "$META")"
+    echo "--- :datadog: [$ENTRY] publishing run metrics"
+    if ENTRY_ID="$ENTRY" \
+        PROMPT_NAME="$(jq -r '.prompt // "unknown"' "$META")" \
+        AGENT="$(jq -r '.agent // "unknown"' "$META")" \
+        MODEL="$(jq -r '.model // "default"' "$META")" \
+        GOAL_ACHIEVED="$(jq -r '.goal // "unknown"' "$META")" \
+        EVAL_DURATION_SECONDS="$(jq -r '.duration_seconds // ""' "$META")" \
+        DD_TIMESTAMP="$(jq -r '.end_ts // ""' "$META")" \
+        METRICS_FILE="${META%.dd.json}.metrics.json" \
+        "$SCRIPT_DIR/dd-metrics.sh"; then
+        PUBLISHED=$(( PUBLISHED + 1 ))
+    else
+        echo "WARNING: dd-publish: publish failed for '$ENTRY' ($META)" >&2
+        FAILED=$(( FAILED + 1 ))
+    fi
+done < <(find "$WORK_DIR" -name '*.dd.json' | sort)
+
+echo "dd-publish: $PUBLISHED entry(ies) published, $FAILED failed."
+[[ "$FAILED" -eq 0 ]]

--- a/evals/scripts/dd-publish.sh
+++ b/evals/scripts/dd-publish.sh
@@ -1,43 +1,60 @@
 #!/usr/bin/env bash
 #
-# dd-publish.sh — CI post-step: publish every entry's run metrics to Datadog.
+# dd-publish.sh — publish every entry's recorded run metrics to Datadog.
 #
-# Runs OUTSIDE the eval agent's container (the dd-publish step in
-# .buildkite/pipeline.evals.yml): the evaluated agent runs with unrestricted
-# Bash, so DD_API_KEY must never enter its environment. babystand.sh records
-# each entry's identity + outcome as runs/<id>/<run-key>.dd.json (next to
-# <run-key>.metrics.json) in the run-bundle artifacts; this script downloads
-# those and drives dd-metrics.sh once per entry, with the key scoped to this
-# step alone.
+# SECURITY: this is the ONLY process that may hold DD_API_KEY, and it must
+# run strictly OUTSIDE the eval-agent run. The evaluated agent has
+# unrestricted Bash, and on Linux a key present anywhere in the run —
+# even `unset` after capture — stays readable to same-UID processes via
+# /proc/<pid>/environ (the exec-time snapshot). So babystand.sh never
+# touches the key in either mode; it records each entry's identity +
+# outcome as runs/<id>/<run-key>.dd.json (next to <run-key>.metrics.json)
+# and this script submits them via dd-metrics.sh afterwards.
+#
+# Modes:
+#   CI (no argument):    the dd-publish pipeline step — downloads the
+#                        run-bundle artifacts the eval step uploaded, with
+#                        the key scoped to that step alone.
+#   Local (<runs-dir>):  run manually AFTER babystand.sh has exited, in a
+#                        fresh shell:
+#                            DD_API_KEY=... ./dd-publish.sh evals/runs
+#                        Scans the directory instead of downloading.
 #
 # Best-effort like dd-metrics.sh: no DD_API_KEY -> loud skip (exit 0); no
-# .dd.json artifacts (eval step died before any entry finished) -> loud skip
-# (exit 0); a failed entry logs a warning and the script exits 1 at the end
-# (the step is soft_fail, so the build stays green either way).
+# .dd.json files -> loud skip (exit 0 in CI; the eval step may have died
+# before any entry finished); a failed entry logs a warning and the script
+# exits 1 at the end (the CI step is soft_fail, so the build stays green).
 #
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNS_DIR="${1:-}"
 
 if [[ -z "${DD_API_KEY:-}" ]]; then
     echo "dd-publish: DD_API_KEY is unset; skipping Datadog publish (see .buildkite/pipeline.evals.yml)." >&2
     exit 0
 fi
-command -v jq >/dev/null              || { echo "dd-publish: jq is required" >&2; exit 1; }
-command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required" >&2; exit 1; }
+command -v jq >/dev/null || { echo "dd-publish: jq is required" >&2; exit 1; }
 
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "$WORK_DIR"' EXIT
-
-# Metadata drives the loop; metrics files can be missing for entries whose
-# audit failed (dd-metrics.sh then publishes identity/duration series only),
-# hence the separate best-effort download.
-if ! buildkite-agent artifact download "runs/*/*.dd.json" "$WORK_DIR/"; then
-    echo "dd-publish: no run metadata artifacts found; nothing to publish." >&2
-    exit 0
+if [[ -n "$RUNS_DIR" ]]; then
+    # Local mode: publish from an existing runs directory.
+    [[ -d "$RUNS_DIR" ]] || { echo "dd-publish: runs directory not found: $RUNS_DIR" >&2; exit 1; }
+    WORK_DIR="$RUNS_DIR"
+else
+    # CI mode: pull the run-bundle artifacts the eval step uploaded.
+    command -v buildkite-agent >/dev/null || { echo "dd-publish: buildkite-agent is required (or pass a runs directory)" >&2; exit 1; }
+    WORK_DIR="$(mktemp -d)"
+    trap 'rm -rf "$WORK_DIR"' EXIT
+    # Metadata drives the loop; metrics files can be missing for entries whose
+    # audit failed (dd-metrics.sh then publishes identity/duration series
+    # only), hence the separate best-effort download.
+    if ! buildkite-agent artifact download "runs/*/*.dd.json" "$WORK_DIR/"; then
+        echo "dd-publish: no run metadata artifacts found; nothing to publish." >&2
+        exit 0
+    fi
+    buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
+        || echo "dd-publish: no metrics artifacts; publishing identity/duration series only." >&2
 fi
-buildkite-agent artifact download "runs/*/*.metrics.json" "$WORK_DIR/" \
-    || echo "dd-publish: no metrics artifacts; publishing identity/duration series only." >&2
 
 PUBLISHED=0 FAILED=0
 while IFS= read -r META; do
@@ -66,5 +83,9 @@ while IFS= read -r META; do
     fi
 done < <(find "$WORK_DIR" -name '*.dd.json' | sort)
 
+if [[ "$PUBLISHED" -eq 0 && "$FAILED" -eq 0 && -n "$RUNS_DIR" ]]; then
+    echo "dd-publish: no *.dd.json files under $RUNS_DIR; nothing to publish." >&2
+    exit 1
+fi
 echo "dd-publish: $PUBLISHED entry(ies) published, $FAILED failed."
 [[ "$FAILED" -eq 0 ]]


### PR DESCRIPTION
### Simple Description (Hand-Edited 🤌 )

It may seem like a fair bit of code change/addition but all of it is localized and focused change, by that I mean:
* Changes to the following files are to gather metrics that we're currently showing in annotations into files so we can publish them using `evals/scripts/dd-publish.sh` in the next CI step
  * `evals/scripts/babystand.sh` --> `dd.json` file
  * `evals/scripts/bk-tool-audit-v2.sh` --> `metrics.json`file


<img width="853" height="173" alt="image" src="https://github.com/user-attachments/assets/70bc53c9-c317-44ec-bc9d-58ff62179213" />

* `evals/scripts/dd-publish.sh` read metrics to be published from files, loops over them and calls `evals/scripts/dd-metrics.sh` for each metric to be published to datadog
  * Publish metrics from 2 files `dd.json` and `metrics.json`
* `evals/scripts/dd-metrics.sh` does the actual publishing of each metrics to datadog

For security reason, we separate the metrics gathering and metrics publication because the latter needs a API key to datadog, and the former is actually LLM agent-driven; putting them together puts the API key at risk of exfiltration by the LLM agent.

### Outcome

https://app.datadoghq.com/dashboard/vsr-kw9-upf/mcp-evals?bits_chat_id=c3958f83-0847-478d-ae99-0d69f52f5d30&fromUser=false&refresh_mode=sliding&from_ts=1788297978314&to_ts=1788470778314&live=true

<img width="1095" height="779" alt="image" src="https://github.com/user-attachments/assets/7ae4c170-f471-433f-b314-1b7a535a4e2c" />

## Robot Stuff 🤖 

### Description

Eval runs (`.buildkite/pipeline.evals.yml` → `babystand.sh`) produce rich per-run data — tool calls, token usage, duration — but only as build annotations and artifacts, so there is no way to track MCP server performance across builds over time. This PR publishes each matrix entry's run metrics to Datadog (`mcp_eval.*` gauges, metrics v2 series API) so they can be dashboarded and alerted on.

Published per entry/scenario: run count, goal achieved (1/0), duration / in-tool / waiting seconds, tool calls (total + buildkite MCP), and token usage (input / output / cache read / cache write) — tagged `entry:`, `prompt:`, `agent:`, `model:`, `goal:`, `buildkite_build:`.

### Context

https://linear.app/buildkite/issue/PB-3168/add-metrics-for-evals-to-datadog

### Changes

- `evals/scripts/dd-metrics.sh` (new): best-effort publisher. Skips loudly when `DD_API_KEY` is unset (local runs/forks); a publish failure never fails an entry; null metrics are omitted so Datadog gaps mean "not measured", never zero. `DD_DRY_RUN=true` prints the payload.
- `evals/scripts/bk-tool-audit-v2.sh`: metrics now include `duration_seconds`, `tool_calls_mcp`, `tool_time_seconds`, and a `wait` breakdown (time inside `wait_for_build` + Bash `sleep` polls, from transcript timestamps — claude only; cursor streams have no per-event timestamps, so null there).
- `evals/scripts/babystand.sh`: goal detection — entries whose setup pushed a `SCENARIO_BRANCH` count as achieved when that branch's latest build is `passed`; no branch / API failure → `unknown` (never miscounted as a miss). Klaren's runtime is excluded from the duration.
- `.buildkite/pipeline.evals.yml`: `DD_API_KEY` secret mapping (`MCP_EVAL_FRAMEWORK_DATADOG_API_KEY`), `DD_SITE`, `BUILDKITE_BUILD_NUMBER` passed into the eval container.

### Verification

- All three transcript dialects (claude / cursor / cursor-cloud) tested locally on synthetic + real transcripts; wait classification verified (150s `wait_for_build` + 31s `sleep` → `wait.seconds: 181`).
- `dd-metrics.sh` payload verified via `DD_DRY_RUN`, including degraded paths (null cursor tokens, unknown goal, empty metrics file).
- After merge: the next eval build shows a `:datadog:` log section per entry, and `mcp_eval.*` series appear in Datadog Metrics Explorer filtered by `entry:`.

### Deployment

- Low risk: touches only the evals pipeline, not the MCP server. Publishing is best-effort and cannot fail an entry.
- The `MCP_EVAL_FRAMEWORK_DATADOG_API_KEY` secret must exist in the evals cluster before this merges (already created), or the step fails at secret resolution.
- No migrations.

### Rollback

This change is safe to revert at any time: it mutates no state or data — worst case, metrics stop flowing to Datadog. A plain `git revert` fully unwinds it; the Datadog secret can stay in place harmlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
