### PR TITLE
Accept a metrics time window on get_test

### DIFF
--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -223,8 +223,19 @@ func TestGetArtifactArgsSchema(t *testing.T) {
 }
 
 func TestGetTestArgsSchema(t *testing.T) {
-	req := sortedRequired[GetTestArgs](t)
-	require.Equal(t, []string{"org_slug", "test_id", "test_suite_slug"}, req)
+	s := schemaFor[GetTestArgs](t)
+	require.Equal(t, []string{"org_slug", "test_id", "test_suite_slug"}, sortedRequired[GetTestArgs](t))
+
+	for _, property := range []string{"period", "min_timestamp", "max_timestamp"} {
+		require.Contains(t, s.Properties, property)
+		require.NotContains(t, s.Required, property, "%s should be optional", property)
+	}
+
+	require.Equal(t, "string", s.Properties["min_timestamp"].Type)
+	require.Equal(t, "string", s.Properties["max_timestamp"].Type)
+	require.Contains(t, s.Properties["min_timestamp"].Description, "RFC3339")
+	require.Contains(t, s.Properties["max_timestamp"].Description, "RFC3339")
+	require.Contains(t, s.Properties["period"].Description, "Cannot be combined")
 }
 
 func TestListTestsArgsSchema(t *testing.T) {

--- a/pkg/buildkite/tests.go
+++ b/pkg/buildkite/tests.go
@@ -55,9 +55,12 @@ type ListTestsForBuildArgs struct {
 
 type GetTestArgs struct {
 	ToolInput
-	OrgSlug       string `json:"org_slug"`
-	TestSuiteSlug string `json:"test_suite_slug"`
-	TestID        string `json:"test_id"`
+	OrgSlug       string    `json:"org_slug"`
+	TestSuiteSlug string    `json:"test_suite_slug"`
+	TestID        string    `json:"test_id"`
+	Period        string    `json:"period,omitempty" jsonschema:"Relative aggregation window for the returned metrics, such as '7days' or '28days'. Whether selected by period or timestamps, the aggregation window cannot exceed the organization's maximum Test Engine window. Cannot be combined with min_timestamp or max_timestamp."`
+	MinTimestamp  time.Time `json:"min_timestamp,omitzero" jsonschema:"Start of the aggregation window in RFC3339 format. When omitted, defaults to the organization's default Test Engine period before the current time."`
+	MaxTimestamp  time.Time `json:"max_timestamp,omitzero" jsonschema:"End of the aggregation window in RFC3339 format. Defaults to the current time when omitted."`
 }
 
 func ListTests() (mcp.Tool, mcp.ToolHandlerFor[ListTestsArgs, any], []string) {
@@ -192,7 +195,7 @@ func ListTestsForBuild() (mcp.Tool, mcp.ToolHandlerFor[ListTestsForBuildArgs, an
 func GetTest() (mcp.Tool, mcp.ToolHandlerFor[GetTestArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_test",
-			Description: "Get a specific test in Buildkite Test Engine. This provides additional metadata for failed test executions",
+			Description: "Get a specific test in Buildkite Test Engine, including execution metrics aggregated over a selected time window. This provides additional metadata for failed test executions.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Test",
 				ReadOnlyHint: true,
@@ -202,14 +205,28 @@ func GetTest() (mcp.Tool, mcp.ToolHandlerFor[GetTestArgs, any], []string) {
 			ctx, span := trace.Start(ctx, "buildkite.GetTest")
 			defer span.End()
 
-			span.SetAttributes(
+			options := &buildkite.TestsGetOptions{
+				Period:       args.Period,
+				MinTimestamp: args.MinTimestamp,
+				MaxTimestamp: args.MaxTimestamp,
+			}
+
+			attributes := []attribute.KeyValue{
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("test_suite_slug", args.TestSuiteSlug),
 				attribute.String("test_id", args.TestID),
-			)
+				attribute.String("period", args.Period),
+			}
+			if !args.MinTimestamp.IsZero() {
+				attributes = append(attributes, attribute.String("min_timestamp", args.MinTimestamp.Format(time.RFC3339)))
+			}
+			if !args.MaxTimestamp.IsZero() {
+				attributes = append(attributes, attribute.String("max_timestamp", args.MaxTimestamp.Format(time.RFC3339)))
+			}
+			span.SetAttributes(attributes...)
 
 			deps := DepsFromContext(ctx)
-			test, _, err := deps.TestsClient.Get(ctx, args.OrgSlug, args.TestSuiteSlug, args.TestID, nil)
+			test, _, err := deps.TestsClient.Get(ctx, args.OrgSlug, args.TestSuiteSlug, args.TestID, options)
 			if err != nil {
 				return handleBuildkiteError(err)
 			}

--- a/pkg/buildkite/tests_test.go
+++ b/pkg/buildkite/tests_test.go
@@ -270,14 +270,25 @@ func TestListTestsReturnsAPIError(t *testing.T) {
 func TestGetTest(t *testing.T) {
 	assert := require.New(t)
 
+	reliability := 0.97
+
 	client := &MockTestsClient{
 		GetFunc: func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
+			assert.Equal("org", org)
+			assert.Equal("suite1", slug)
+			assert.Equal("test-123", testID)
+			assert.Equal(&buildkite.TestsGetOptions{}, opt)
+
 			return buildkite.TestWithMetrics{
 					Test: buildkite.Test{
 						ID:       "test-123",
 						Name:     "Example Test",
 						Location: "spec/example_test.rb",
 					},
+					Reliability:             &reliability,
+					DurationAverage:         1.5,
+					ExecutionsCount:         100,
+					ExecutionsCountByResult: map[string]int{"passed": 97, "failed": 3},
 				}, &buildkite.Response{
 					Response: &http.Response{
 						StatusCode: 200,
@@ -289,14 +300,16 @@ func TestGetTest(t *testing.T) {
 
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
 
-	tool, handler, _ := GetTest()
+	tool, handler, scopes := GetTest()
 	assert.NotNil(tool)
 	assert.NotNil(handler)
 
 	// Test the tool definition
 	assert.Equal("get_test", tool.Name)
 	assert.Contains(tool.Description, "specific test")
+	assert.Contains(tool.Description, "metrics")
 	assert.True(tool.Annotations.ReadOnlyHint)
+	assert.Equal([]string{"read_suites"}, scopes)
 
 	// Test successful request
 	request := createMCPRequest(t, map[string]any{})
@@ -308,7 +321,100 @@ func TestGetTest(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(result)
 
-	textContent := getTextResult(t, result)
-	assert.Contains(textContent.Text, "test-123")
-	assert.Contains(textContent.Text, "Example Test")
+	var test buildkite.TestWithMetrics
+	assert.NoError(json.Unmarshal([]byte(getTextResult(t, result).Text), &test))
+	assert.Equal("test-123", test.ID)
+	assert.Equal("Example Test", test.Name)
+	assert.NotNil(test.Reliability)
+	assert.InDelta(reliability, *test.Reliability, 0.0001)
+	assert.InDelta(1.5, test.DurationAverage, 0.0001)
+	assert.Equal(100, test.ExecutionsCount)
+	assert.Equal(map[string]int{"passed": 97, "failed": 3}, test.ExecutionsCountByResult)
+}
+
+func TestGetTestWithTimeWindow(t *testing.T) {
+	minTimestamp := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	maxTimestamp := time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC)
+
+	client := &MockTestsClient{
+		GetFunc: func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, &buildkite.TestsGetOptions{
+				MinTimestamp: minTimestamp,
+				MaxTimestamp: maxTimestamp,
+			}, opt)
+
+			return buildkite.TestWithMetrics{Test: buildkite.Test{ID: "test-123"}}, &buildkite.Response{
+				Response: &http.Response{StatusCode: 200},
+			}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	_, handler, _ := GetTest()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetTestArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+		TestID:        "test-123",
+		MinTimestamp:  minTimestamp,
+		MaxTimestamp:  maxTimestamp,
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, getTextResult(t, result).Text, "test-123")
+}
+
+func TestGetTestWithPeriod(t *testing.T) {
+	client := &MockTestsClient{
+		GetFunc: func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, &buildkite.TestsGetOptions{Period: "28days"}, opt)
+
+			return buildkite.TestWithMetrics{Test: buildkite.Test{ID: "test-123"}}, &buildkite.Response{
+				Response: &http.Response{StatusCode: 200},
+			}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	_, handler, _ := GetTest()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetTestArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+		TestID:        "test-123",
+		Period:        "28days",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.Contains(t, getTextResult(t, result).Text, "test-123")
+}
+
+func TestGetTestPropagatesAPIError(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 422,
+		Body:       io.NopCloser(strings.NewReader(`{"message":"period cannot be combined with min_timestamp"}`)),
+	}
+
+	client := &MockTestsClient{
+		GetFunc: func(ctx context.Context, org, slug, testID string, opt *buildkite.TestsGetOptions) (buildkite.TestWithMetrics, *buildkite.Response, error) {
+			return buildkite.TestWithMetrics{}, &buildkite.Response{Response: resp}, &buildkite.ErrorResponse{
+				Response: resp,
+				Message:  "period cannot be combined with min_timestamp",
+			}
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{TestsClient: client})
+	_, handler, _ := GetTest()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetTestArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite1",
+		TestID:        "test-123",
+		Period:        "7days",
+		MinTimestamp:  time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, getTextResult(t, result).Text, "period cannot be combined with min_timestamp")
 }


### PR DESCRIPTION
`get_test` already returns `TestWithMetrics`, but passes `nil` options, so the aggregation window was whatever the organization defaults to. Agents asking "did my change fix this test?" need to scope the metrics — reliability, duration, executions by result — to a window around the change, which the `tests#show` API exposes and the `go-buildkite` SDK models as `TestsGetOptions`.

Add optional `period`, `min_timestamp` and `max_timestamp` args mirroring `list_tests`, build `TestsGetOptions` from them, and record them as span attributes. Incompatible combinations (period with either timestamp) stay server-validated and surface through `handleBuildkiteError`, matching `list_tests` rather than duplicating the API's rules client-side.