### PR TITLE
Add MCP tools for listing and inspecting cluster secrets

### DIFF
--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -32,6 +32,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 		PipelinesClient:         globals.Client.Pipelines,
 		PipelineSchedulesClient: globals.Client.PipelineSchedules,
 		ClustersClient:          globals.Client.Clusters,
+		ClusterSecretsClient:    globals.Client.ClusterSecrets,
 		ClusterQueuesClient:     globals.Client.ClusterQueues,
 		AgentsClient:            globals.Client.Agents,
 		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client, HTTPClient: globals.HTTPClient},

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -25,6 +25,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 		PipelinesClient:         globals.Client.Pipelines,
 		PipelineSchedulesClient: globals.Client.PipelineSchedules,
 		ClustersClient:          globals.Client.Clusters,
+		ClusterSecretsClient:    globals.Client.ClusterSecrets,
 		ClusterQueuesClient:     globals.Client.ClusterQueues,
 		AgentsClient:            globals.Client.Agents,
 		ArtifactsClient:         &buildkite.BuildkiteClientAdapter{Client: globals.Client, HTTPClient: globals.HTTPClient},

--- a/pkg/buildkite/cluster_secrets.go
+++ b/pkg/buildkite/cluster_secrets.go
@@ -1,0 +1,47 @@
+package buildkite
+
+import (
+  "context"
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+type ClusterSecretsClient interface {
+	Get(ctx context.Context, org, clusterId, secretID string) (buildkite.ClusterSecret, *buildkite.Response, error)
+}
+
+type GetClusterSecretArgs struct {
+	ToolInput
+	OrgSlug string `json:"org_slug"`
+	ClusterID string `json:"cluster_id"`
+	SecretID string `json:"secret_id"`
+}
+
+func GetClusterSecret() (mcp.Tool, mcp.ToolHandlerFor[GetClusterSecretArgs, any], []string) {
+	return mcp.Tool {
+		Name: "get_cluster_secret",
+		Description: "Get cluster secret value",
+		Annotations: &mcp.ToolAnnotations {
+			Title: "Get Cluster Secret",
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, request *mcp.CallToolRequest, args GetClusterSecretArgs) (*mcp.CallToolResult, any, error) {
+		ctx, span := trace.Start(ctx, "buildkite.GetClusterSecret")
+		defer span.End()
+
+		span.SetAttributes(
+			attribute.String("org_slug", args.OrgSlug),
+			attribute.String("cluster_id", args.ClusterID),
+		)
+
+		deps := DepsFromContext(ctx)
+		secret, _, err := deps.ClusterSecretsClient.Get(ctx, args.OrgSlug, args.ClusterID, args.SecretID)
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
+
+		return mcpTextResult(span, &secret)
+	}, []string{"read_secrets_details"}
+}

--- a/pkg/buildkite/cluster_secrets.go
+++ b/pkg/buildkite/cluster_secrets.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ClusterSecretsClient interface {
-	Get(ctx context.Context, org, clusterId, secretID string) (buildkite.ClusterSecret, *buildkite.Response, error)
+	Get(ctx context.Context, org, clusterID, secretID string) (buildkite.ClusterSecret, *buildkite.Response, error)
 }
 
 type GetClusterSecretArgs struct {
@@ -23,7 +23,7 @@ type GetClusterSecretArgs struct {
 func GetClusterSecret() (mcp.Tool, mcp.ToolHandlerFor[GetClusterSecretArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_cluster_secret",
-			Description: "Get cluster secret value",
+			Description: "Get cluster secret information",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Cluster Secret",
 				ReadOnlyHint: true,
@@ -35,6 +35,7 @@ func GetClusterSecret() (mcp.Tool, mcp.ToolHandlerFor[GetClusterSecretArgs, any]
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("cluster_id", args.ClusterID),
+				attribute.String("secret_id", args.SecretID),
 			)
 
 			deps := DepsFromContext(ctx)

--- a/pkg/buildkite/cluster_secrets.go
+++ b/pkg/buildkite/cluster_secrets.go
@@ -1,7 +1,8 @@
 package buildkite
 
 import (
-  "context"
+	"context"
+
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -14,34 +15,34 @@ type ClusterSecretsClient interface {
 
 type GetClusterSecretArgs struct {
 	ToolInput
-	OrgSlug string `json:"org_slug"`
+	OrgSlug   string `json:"org_slug"`
 	ClusterID string `json:"cluster_id"`
-	SecretID string `json:"secret_id"`
+	SecretID  string `json:"secret_id"`
 }
 
 func GetClusterSecret() (mcp.Tool, mcp.ToolHandlerFor[GetClusterSecretArgs, any], []string) {
-	return mcp.Tool {
-		Name: "get_cluster_secret",
-		Description: "Get cluster secret value",
-		Annotations: &mcp.ToolAnnotations {
-			Title: "Get Cluster Secret",
-			ReadOnlyHint: true,
-		},
-	}, func(ctx context.Context, request *mcp.CallToolRequest, args GetClusterSecretArgs) (*mcp.CallToolResult, any, error) {
-		ctx, span := trace.Start(ctx, "buildkite.GetClusterSecret")
-		defer span.End()
+	return mcp.Tool{
+			Name:        "get_cluster_secret",
+			Description: "Get cluster secret value",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Cluster Secret",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args GetClusterSecretArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetClusterSecret")
+			defer span.End()
 
-		span.SetAttributes(
-			attribute.String("org_slug", args.OrgSlug),
-			attribute.String("cluster_id", args.ClusterID),
-		)
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("cluster_id", args.ClusterID),
+			)
 
-		deps := DepsFromContext(ctx)
-		secret, _, err := deps.ClusterSecretsClient.Get(ctx, args.OrgSlug, args.ClusterID, args.SecretID)
-		if err != nil {
-			return handleBuildkiteError(err)
-		}
+			deps := DepsFromContext(ctx)
+			secret, _, err := deps.ClusterSecretsClient.Get(ctx, args.OrgSlug, args.ClusterID, args.SecretID)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
 
-		return mcpTextResult(span, &secret)
-	}, []string{"read_secrets_details"}
+			return mcpTextResult(span, &secret)
+		}, []string{"read_secrets_details"}
 }

--- a/pkg/buildkite/cluster_secrets.go
+++ b/pkg/buildkite/cluster_secrets.go
@@ -10,6 +10,7 @@ import (
 )
 
 type ClusterSecretsClient interface {
+	List(ctx context.Context, org, clusterID string, opt *buildkite.ClusterSecretsListOptions) ([]buildkite.ClusterSecret, *buildkite.Response, error)
 	Get(ctx context.Context, org, clusterID, secretID string) (buildkite.ClusterSecret, *buildkite.Response, error)
 }
 
@@ -45,5 +46,62 @@ func GetClusterSecret() (mcp.Tool, mcp.ToolHandlerFor[GetClusterSecretArgs, any]
 			}
 
 			return mcpTextResult(span, &secret)
+		}, []string{"read_secrets_details"}
+}
+
+type ListClusterSecretsArgs struct {
+	ToolInput
+	OrgSlug   string `json:"org_slug"`
+	ClusterID string `json:"cluster_id"`
+	Page      int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
+	PerPage   int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`
+}
+
+func ListClusterSecrets() (mcp.Tool, mcp.ToolHandlerFor[ListClusterSecretsArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "list_cluster_secrets",
+			Description: "List cluster secrets",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "List Cluster Secrets",
+				ReadOnlyHint: true,
+			},
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args ListClusterSecretsArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ListClusterSecrets")
+			defer span.End()
+
+			paginationParams := paginationFromArgs(args.Page, args.PerPage)
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("cluster_id", args.ClusterID),
+				attribute.Int("page", paginationParams.Page),
+				attribute.Int("per_page", paginationParams.PerPage),
+			)
+
+			deps := DepsFromContext(ctx)
+			secrets, resp, err := deps.ClusterSecretsClient.List(
+				ctx,
+				args.OrgSlug,
+				args.ClusterID,
+				&buildkite.ClusterSecretsListOptions{
+					ListOptions: paginationParams,
+				},
+			)
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			result := PaginatedResult[buildkite.ClusterSecret]{
+				Items: secrets,
+				Headers: map[string]string{
+					"Link": resp.Header.Get("Link"),
+				},
+			}
+
+			span.SetAttributes(
+				attribute.Int("item_count", len(secrets)),
+			)
+
+			return mcpTextResult(span, &result)
 		}, []string{"read_secrets_details"}
 }

--- a/pkg/buildkite/cluster_secrets_test.go
+++ b/pkg/buildkite/cluster_secrets_test.go
@@ -1,0 +1,81 @@
+package buildkite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type mockClusterSecretsClient struct {
+	GetFunc func(
+		ctx context.Context,
+		org string,
+		clusterID string,
+		secretID string,
+	) (buildkite.ClusterSecret, *buildkite.Response, error)
+}
+
+func (m *mockClusterSecretsClient) Get(
+	ctx context.Context,
+	org string,
+	clusterID string,
+	secretID string,
+) (buildkite.ClusterSecret, *buildkite.Response, error) {
+	return m.GetFunc(ctx, org, clusterID, secretID)
+}
+
+var _ ClusterSecretsClient = (*mockClusterSecretsClient)(nil)
+
+func TestGetClusterSecret(t *testing.T) {
+	client := &mockClusterSecretsClient{
+		GetFunc: func(
+			ctx context.Context,
+			org string,
+			clusterID string,
+			secretID string,
+		) (buildkite.ClusterSecret, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "cluster-id", clusterID)
+			require.Equal(t, "secret-id", secretID)
+
+			return buildkite.ClusterSecret{
+				ID: "secret-id",
+				Key: "DATABASE_PASSWORD",
+				Description: "Database password",
+				Policy: "- pipeline_slug: example",
+			}, nil, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		ClusterSecretsClient: client,
+	})
+
+	tool, handler, scopes := GetClusterSecret()
+
+	require.Equal(t, "get_cluster_secret", tool.Name)
+	require.NotNil(t, tool.Annotations)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Equal(t, []string{"read_secrets_details"}, scopes)
+
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, GetClusterSecretArgs{
+		OrgSlug: "org",
+		ClusterID: "cluster-id",
+		SecretID: "secret-id",
+	})
+	require.NoError(t, err)
+
+	textContent := getTextResult(t, result)
+	require.JSONEq(t, `{
+		"id": "secret-id",
+		"key": "DATABASE_PASSWORD",
+		"description": "Database password",
+		"policy": "- pipeline_slug: example",
+		"created_by": {},
+		"organization": {}
+	}`, textContent.Text)
+	require.NotContains(t, textContent.Text, `"value"`)
+}

--- a/pkg/buildkite/cluster_secrets_test.go
+++ b/pkg/buildkite/cluster_secrets_test.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/buildkite/go-buildkite/v5"
@@ -11,12 +12,27 @@ import (
 )
 
 type mockClusterSecretsClient struct {
+	ListFunc func(
+		ctx context.Context,
+		org string,
+		clusterID string,
+		opt *buildkite.ClusterSecretsListOptions,
+	) ([]buildkite.ClusterSecret, *buildkite.Response, error)
 	GetFunc func(
 		ctx context.Context,
 		org string,
 		clusterID string,
 		secretID string,
 	) (buildkite.ClusterSecret, *buildkite.Response, error)
+}
+
+func (m *mockClusterSecretsClient) List(
+	ctx context.Context,
+	org string,
+	clusterID string,
+	opt *buildkite.ClusterSecretsListOptions,
+) ([]buildkite.ClusterSecret, *buildkite.Response, error) {
+	return m.ListFunc(ctx, org, clusterID, opt)
 }
 
 func (m *mockClusterSecretsClient) Get(
@@ -29,6 +45,95 @@ func (m *mockClusterSecretsClient) Get(
 }
 
 var _ ClusterSecretsClient = (*mockClusterSecretsClient)(nil)
+
+func TestListClusterSecrets(t *testing.T) {
+	client := &mockClusterSecretsClient{
+		ListFunc: func(
+			ctx context.Context,
+			org string,
+			clusterID string,
+			opt *buildkite.ClusterSecretsListOptions,
+		) ([]buildkite.ClusterSecret, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "cluster-id", clusterID)
+			require.Equal(t, 1, opt.Page)
+			require.Equal(t, 100, opt.PerPage)
+
+			return []buildkite.ClusterSecret{
+					{
+						ID:          "secret-id",
+						Key:         "DATABASE_PASSWORD",
+						Description: "Database password",
+						Policy:      "- pipeline_slug: example",
+					},
+				}, &buildkite.Response{
+					Response: &http.Response{
+						StatusCode: http.StatusOK,
+						Header: http.Header{
+							"Link": {`<https://api.buildkite.com/v2/organizations/org/clusters/cluster-id/secrets?page=2>; rel="next"`},
+						},
+					},
+				}, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		ClusterSecretsClient: client,
+	})
+
+	tool, handler, scopes := ListClusterSecrets()
+	require.Equal(t, "list_cluster_secrets", tool.Name)
+	require.NotNil(t, tool.Annotations)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Equal(t, []string{"read_secrets_details"}, scopes)
+
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, ListClusterSecretsArgs{
+		OrgSlug:   "org",
+		ClusterID: "cluster-id",
+	})
+	require.NoError(t, err)
+
+	textContent := getTextResult(t, result)
+	require.JSONEq(t, `{
+		"headers": {
+			"Link": "<https://api.buildkite.com/v2/organizations/org/clusters/cluster-id/secrets?page=2>; rel=\"next\""
+		},
+		"items": [{
+			"id": "secret-id",
+			"key": "DATABASE_PASSWORD",
+			"description": "Database password",
+			"policy": "- pipeline_slug: example",
+			"created_by": {},
+			"organization": {}
+		}]
+	}`, textContent.Text)
+	require.NotContains(t, textContent.Text, `"value"`)
+}
+
+func TestListClusterSecretsWithError(t *testing.T) {
+	assert := require.New(t)
+
+	client := &mockClusterSecretsClient{
+		ListFunc: func(
+			ctx context.Context,
+			org string,
+			clusterID string,
+			opt *buildkite.ClusterSecretsListOptions,
+		) ([]buildkite.ClusterSecret, *buildkite.Response, error) {
+			return nil, &buildkite.Response{}, fmt.Errorf("API error")
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ClusterSecretsClient: client})
+
+	_, handler, _ := ListClusterSecrets()
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, ListClusterSecretsArgs{OrgSlug: "org", ClusterID: "cluster-id"})
+	assert.NoError(err)
+	assert.True(result.IsError)
+	assert.Contains(result.Content[0].(*mcp.TextContent).Text, "API error")
+}
 
 func TestGetClusterSecret(t *testing.T) {
 	client := &mockClusterSecretsClient{

--- a/pkg/buildkite/cluster_secrets_test.go
+++ b/pkg/buildkite/cluster_secrets_test.go
@@ -2,9 +2,11 @@ package buildkite
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/buildkite/go-buildkite/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,4 +80,28 @@ func TestGetClusterSecret(t *testing.T) {
 		"organization": {}
 	}`, textContent.Text)
 	require.NotContains(t, textContent.Text, `"value"`)
+}
+
+func TestGetClusterSecretWithError(t *testing.T) {
+	assert := require.New(t)
+
+	client := &mockClusterSecretsClient{
+		GetFunc: func(
+			ctx context.Context,
+			org string,
+			clusterID string,
+			secretID string,
+		) (buildkite.ClusterSecret, *buildkite.Response, error) {
+			return buildkite.ClusterSecret{}, &buildkite.Response{}, fmt.Errorf("API error")
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ClusterSecretsClient: client})
+
+	_, handler, _ := GetClusterSecret()
+	request := createMCPRequest(t, map[string]any{})
+	result, _, err := handler(ctx, request, GetClusterSecretArgs{OrgSlug: "org", ClusterID: "cluster-id", SecretID: "secret-id"})
+	assert.NoError(err)
+	assert.True(result.IsError)
+	assert.Contains(result.Content[0].(*mcp.TextContent).Text, "API error")
 }

--- a/pkg/buildkite/cluster_secrets_test.go
+++ b/pkg/buildkite/cluster_secrets_test.go
@@ -41,10 +41,10 @@ func TestGetClusterSecret(t *testing.T) {
 			require.Equal(t, "secret-id", secretID)
 
 			return buildkite.ClusterSecret{
-				ID: "secret-id",
-				Key: "DATABASE_PASSWORD",
+				ID:          "secret-id",
+				Key:         "DATABASE_PASSWORD",
 				Description: "Database password",
-				Policy: "- pipeline_slug: example",
+				Policy:      "- pipeline_slug: example",
 			}, nil, nil
 		},
 	}
@@ -62,9 +62,9 @@ func TestGetClusterSecret(t *testing.T) {
 
 	request := createMCPRequest(t, map[string]any{})
 	result, _, err := handler(ctx, request, GetClusterSecretArgs{
-		OrgSlug: "org",
+		OrgSlug:   "org",
 		ClusterID: "cluster-id",
-		SecretID: "secret-id",
+		SecretID:  "secret-id",
 	})
 	require.NoError(t, err)
 

--- a/pkg/buildkite/dependencies.go
+++ b/pkg/buildkite/dependencies.go
@@ -17,6 +17,7 @@ type ToolDependencies struct {
 	PipelinesClient         PipelinesClient
 	PipelineSchedulesClient PipelineSchedulesClient
 	ClustersClient          ClustersClient
+	ClusterSecretsClient    ClusterSecretsClient
 	ClusterQueuesClient     ClusterQueuesClient
 	AgentsClient            AgentsClient
 	ArtifactsClient         ArtifactsClient

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -348,6 +348,11 @@ func TestGetClusterArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"cluster_id", "org_slug"}, req)
 }
 
+func TestGetClusterSecretArgsSchema(t *testing.T) {
+	req := sortedRequired[GetClusterSecretArgs](t)
+	require.Equal(t, []string{"cluster_id", "org_slug", "secret_id"}, req)
+}
+
 func TestListAgentsArgsSchema(t *testing.T) {
 	s := schemaFor[ListAgentsArgs](t)
 	req := sortedToolRequired(t, s)

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -348,6 +348,17 @@ func TestGetClusterArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"cluster_id", "org_slug"}, req)
 }
 
+func TestListClusterSecretsArgsSchema(t *testing.T) {
+	s := schemaFor[ListClusterSecretsArgs](t)
+	req := sortedToolRequired(t, s)
+	require.Equal(t, []string{"cluster_id", "org_slug"}, req)
+
+	for _, opt := range []string{"page", "per_page"} {
+		require.Contains(t, s.Properties, opt)
+		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
+	}
+}
+
 func TestGetClusterSecretArgsSchema(t *testing.T) {
 	req := sortedRequired[GetClusterSecretArgs](t)
 	require.Equal(t, []string{"cluster_id", "org_slug", "secret_id"}, req)

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -347,6 +347,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 			Description: "Tools for managing Buildkite cluster secrets",
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.GetClusterSecret),
+				newToolDef(buildkite.ListClusterSecrets),
 			},
 		},
 		ToolsetAgents: {

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -239,6 +239,7 @@ func NewTool(tool mcp.Tool, register func(s *mcp.Server), scopes []string) ToolD
 const (
 	ToolsetAll            = "all" // Special name to enable all toolsets
 	ToolsetClusters       = "clusters"
+	ToolsetClusterSecrets = "cluster_secrets"
 	ToolsetAgents         = "agents"
 	ToolsetPipelines      = "pipelines"
 	ToolsetBuilds         = "builds"
@@ -254,6 +255,7 @@ const (
 var ValidToolsets = []string{
 	ToolsetAll,
 	ToolsetClusters,
+	ToolsetClusterSecrets,
 	ToolsetAgents,
 	ToolsetPipelines,
 	ToolsetBuilds,
@@ -338,6 +340,13 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.UpdateClusterQueue),
 				newToolDef(buildkite.PauseClusterQueueDispatch),
 				newToolDef(buildkite.ResumeClusterQueueDispatch),
+			},
+		},
+		ToolsetClusterSecrets: {
+			Name:        "Cluster Secret Management",
+			Description: "Tools for managing Buildkite cluster secrets",
+			Tools: []ToolDefinition{
+				newToolDef(buildkite.GetClusterSecret),
 			},
 		},
 		ToolsetAgents: {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -657,7 +657,7 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	registry.RegisterToolsets(builtin)
 
 	// Check that expected toolsets are registered
-	expectedToolsets := []string{"clusters", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "investigations", "user", "skills"}
+	expectedToolsets := []string{"clusters", "cluster_secrets", "agents", "pipelines", "builds", "artifacts", "logs", "tests", "annotations", "investigations", "user", "skills"}
 	for _, name := range expectedToolsets {
 		_, exists := registry.Get(name)
 		assert.True(exists, "expected toolset %s to be registered", name)
@@ -729,4 +729,47 @@ func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {
 		require.Equal(t, contextDescription, contextProperty["description"], "%s has the wrong telemetry.context description", tool.Name)
 		require.InDelta(t, float64(trace.TelemetryContextMaxLength), contextProperty["maxLength"], 0, "%s has the wrong telemetry.context maxLength", tool.Name)
 	}
+}
+
+func TestClusterSecretsToolset(t *testing.T) {
+	assert := require.New(t)
+
+	registry := NewToolsetRegistry()
+	registry.RegisterToolsets(CreateBuiltinToolsets())
+
+	clusterSecrets, exists := registry.Get(ToolsetClusterSecrets)
+	assert.True(exists)
+
+	// The toolset contains get_cluster_secret.
+	assert.Len(clusterSecrets.Tools, 1)
+	assert.Equal(
+		"get_cluster_secret",
+		clusterSecrets.Tools[0].Tool.Name,
+	)
+
+	// The toolset requires only read_secrets_details.
+	assert.Equal(
+		[]string{"read_secrets_details"},
+		clusterSecrets.GetRequiredScopes(),
+	)
+
+	// Read-only filtering retains get_cluster_secret.
+	readOnlyTools := registry.GetEnabledTools(
+		[]string{ToolsetClusterSecrets},
+		true,
+	)
+	assert.Len(readOnlyTools, 1)
+	assert.Equal(
+		"get_cluster_secret",
+		readOnlyTools[0].Tool.Name,
+	)
+
+	// Read-only OAuth authorization requests the correct scope.
+	assert.Equal(
+		[]string{"read_secrets_details"},
+		registry.GetRequiredScopes(
+			[]string{ToolsetClusterSecrets},
+			true,
+		),
+	)
 }

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -740,7 +740,6 @@ func TestClusterSecretsToolset(t *testing.T) {
 	clusterSecrets, exists := registry.Get(ToolsetClusterSecrets)
 	assert.True(exists)
 
-	// The toolset contains the Get and List cluster secret tools.
 	assert.Len(clusterSecrets.Tools, 2)
 	assert.Equal(
 		"get_cluster_secret",
@@ -751,13 +750,11 @@ func TestClusterSecretsToolset(t *testing.T) {
 		clusterSecrets.Tools[1].Tool.Name,
 	)
 
-	// The toolset requires only read_secrets_details.
 	assert.Equal(
 		[]string{"read_secrets_details"},
 		clusterSecrets.GetRequiredScopes(),
 	)
 
-	// Read-only filtering retains get_cluster_secret.
 	readOnlyTools := registry.GetEnabledTools(
 		[]string{ToolsetClusterSecrets},
 		true,
@@ -773,7 +770,6 @@ func TestClusterSecretsToolset(t *testing.T) {
 		readOnlyTools[1].Tool.Name,
 	)
 
-	// Read-only OAuth authorization requests the correct scope.
 	assert.Equal(
 		[]string{"read_secrets_details"},
 		registry.GetRequiredScopes(

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -740,11 +740,15 @@ func TestClusterSecretsToolset(t *testing.T) {
 	clusterSecrets, exists := registry.Get(ToolsetClusterSecrets)
 	assert.True(exists)
 
-	// The toolset contains get_cluster_secret.
-	assert.Len(clusterSecrets.Tools, 1)
+	// The toolset contains the Get and List cluster secret tools.
+	assert.Len(clusterSecrets.Tools, 2)
 	assert.Equal(
 		"get_cluster_secret",
 		clusterSecrets.Tools[0].Tool.Name,
+	)
+	assert.Equal(
+		"list_cluster_secrets",
+		clusterSecrets.Tools[1].Tool.Name,
 	)
 
 	// The toolset requires only read_secrets_details.
@@ -758,10 +762,15 @@ func TestClusterSecretsToolset(t *testing.T) {
 		[]string{ToolsetClusterSecrets},
 		true,
 	)
-	assert.Len(readOnlyTools, 1)
+	assert.Len(readOnlyTools, 2)
 	assert.Equal(
 		"get_cluster_secret",
 		readOnlyTools[0].Tool.Name,
+	)
+
+	assert.Equal(
+		"list_cluster_secrets",
+		readOnlyTools[1].Tool.Name,
 	)
 
 	// Read-only OAuth authorization requests the correct scope.


### PR DESCRIPTION
## Why

MCP clients cannot currently discover or inspect Buildkite cluster secrets. Secret metadata should be accessible without exposing the write-only secret value.

## What

Adds read-only `list_cluster_secrets` and `get_cluster_secret` tools in a dedicated `cluster_secrets` toolset.

The tools support list pagination, require the `read_secrets_details` scope, and are available through both stdio and HTTP modes. Coverage includes schemas, API errors, metadata serialization, tool registration, scopes, and read-only filtering.