### PR TITLE
docs: improve development onboarding

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,6 +64,7 @@ The primary commands are:
 | --- | --- |
 | `mise run setup` | Download Go modules and install the Git hooks |
 | `mise run check` | Run lint, module tidiness, Go fix, and tests |
+| `mise run lint-fix` | Run the linter and apply supported fixes |
 | `mise run build` | Build `./buildkite-mcp-server` |
 | `mise run run` | Run the server over stdio |
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,43 +1,102 @@
 # Development
 
-This contains some notes on developing this software locally.
+This guide covers building, testing, and running the Buildkite MCP server locally.
 
-# prerequisites
+## Quick start
 
-* [goreleaser](http://goreleaser.com)
-* [go 1.24](https://go.dev)
+Install these prerequisites:
 
-# building
+- [Git](https://git-scm.com/)
+- [mise](https://mise.jdx.dev/)
+- Make
 
-List the available make targets.
-
-```
-make help
-```
-
-## Local Build
-
-Build the binary locally.
+Then clone and set up the repository:
 
 ```bash
-make build
+git clone https://github.com/buildkite/buildkite-mcp-server.git
+cd buildkite-mcp-server
+mise trust
+mise install
+mise run setup
 ```
 
-## Check the code
+`mise install` installs the development toolchain pinned in `mise.toml`. This
+project uses Go 1.26.6 for development and CI builds. The older Go version in
+`go.mod` is intentionally retained as the minimum compatible toolchain version.
 
-Check the code for style and correctness and running tests.
+Verify the checkout and build the server:
 
 ```bash
-make check
+mise run check
+mise run build
 ```
 
-## Copy it to your path
+The binary is written to `./buildkite-mcp-server`.
 
-Copy it to your path.
+## Authentication and running locally
+
+API-backed tools require a [Buildkite API access token](https://buildkite.com/user/api-access-tokens). Export the token in your shell; do not commit it to the repository:
+
+```bash
+export BUILDKITE_API_TOKEN="bkua_xxx"
+mise run run
+```
+
+The server uses stdio transport by default. It may appear idle while it waits for
+an MCP client to send requests. A token is not required when using offline replay.
+
+The tracked `.envrc` contains an optional, commented 1Password command for
+Buildkite employees who use `direnv`. Other contributors should export the token
+through their preferred local secret manager or shell environment.
+
+## Development commands
+
+List the available mise tasks and Make targets:
+
+```bash
+mise tasks ls --local
+mise exec -- make help
+```
+
+The primary commands are:
+
+| Command | Purpose |
+| --- | --- |
+| `mise run setup` | Download Go modules and install the Git hooks |
+| `mise run check` | Run lint, module tidiness, Go fix, and tests |
+| `mise run build` | Build `./buildkite-mcp-server` |
+| `mise run run` | Run the server over stdio |
+
+Use `mise exec -- make <target>` for less common Make targets. Running commands
+through mise ensures they use the repository's pinned toolchain.
+
+## Git hooks
+
+`mise run setup` installs Lefthook's pre-commit hook. The hook runs lint,
+`go mod tidy -diff`, and `go fix -diff ./...` using the shared Make targets.
+
+Reinstall the hook directly if needed:
+
+```bash
+mise exec -- lefthook install
+```
+
+## Installing the binary
+
+Install the binary into the Go binary directory:
+
+```bash
+mise exec -- make install
+```
+
+Ensure `$(go env GOPATH)/bin` is on `PATH` if you want to invoke
+`buildkite-mcp-server` without an explicit path.
 
 ## Docker
 
-### Local Development
+Docker is optional for normal development.
+
+### Local development
 
 Build the Docker image using the local development Dockerfile:
 
@@ -51,58 +110,31 @@ Run the container:
 docker run -i --rm -e BUILDKITE_API_TOKEN="your-token" buildkite/buildkite-mcp-server:dev
 ```
 
-# Adding a new Tool
+## Adding a new tool
 
-1. Implement a tool following the patterns in the [internal/buildkite](internal/buildkite) package - mostly delegating to [go-buildkite](https://github.com/buildkite/go-buildkite) and returning JSON. We can play with nicer formatting later and see if it helps.
-2. Register the tool here in the [internal/stdio](internal/commands/stdio.go) file.
-3. Update the README tool list.
-4. Profit!
+1. Implement the tool following the patterns in [`pkg/buildkite`](pkg/buildkite), generally delegating to [go-buildkite](https://github.com/buildkite/go-buildkite) and returning JSON.
+2. Add the tool to the appropriate toolset in [`pkg/toolsets`](pkg/toolsets).
+3. Add or update tests.
+4. Update the tool documentation.
+5. Run `mise run check`.
 
-# Validating tools locally
+## Validating tools with MCP Inspector
 
-When developing and testing the tools, and verifying their configuration https://github.com/modelcontextprotocol/inspector is very helpful.
+[MCP Inspector](https://github.com/modelcontextprotocol/inspector) is useful for exercising tools and verifying their schemas. Node.js is included in the mise toolchain for this optional workflow.
 
-```
-make
-npx @modelcontextprotocol/inspector@latest buildkite-mcp-server stdio
-```
-
-Then log into the web UI and hit connect.
-
-# Publishing a release
-
-- Draft a new release on GitHub: https://github.com/buildkite/buildkite-mcp-server/releases/new
-- Select a new tag version, bumping the minor or patch versions as appropriate
-- Generate release notes
-- Save the release as a draft, and mention internal contributors on Slack before publishing
-- Publish the release
-
-A Buildkite pipeline will then automatically invoke the publishing pipeline, including publishing to GitHub Container Registry, Docker Hub, and update binaries to the GitHub release assets.
-
-# Manually releasing to GitHub Container Registry
-
-This process is automated by the CI pipeline, however you can manually release by following these steps:
-
-To push docker images GHCR you will need to login, you will need to generate a legacy GitHub PSK to do a release locally. This will be entered in the command below.
-
-```
-docker login ghcr.io --username $(gh api user --jq '.login')
+```bash
+mise run build
+mise exec -- npx @modelcontextprotocol/inspector@latest ./buildkite-mcp-server stdio
 ```
 
-Publish a release in GitHub, use the "generate changelog" button to build the changelog, this will create a tag for the release.
+Open the displayed web UI and select **Connect**. The package is fetched by
+`npx`; it is not required for builds or tests.
 
-Fetch tags and pull down the `main` branch, then run GoReleaser at the root of the repository.
-
-```
-git fetch && git pull
-GITHUB_TOKEN=$(gh auth token) goreleaser release
-```
-
-# Recording and replaying API calls for offline evals
+## Recording and replaying API calls for offline evals
 
 The server can record every Buildkite API call it makes to an [HTTP Archive (HAR)](https://en.wikipedia.org/wiki/HAR_(file_format)) file, then replay that file later without a network connection. This is useful for running LLM evals reproducibly — record one real session, then run multiple models (or prompt variants) against the exact same API responses.
 
-## Record a session
+### Record a session
 
 Pass `--record <path>` when starting the server. The file is created immediately (to catch permission errors early) and each API response is appended as it is made.
 
@@ -117,7 +149,7 @@ A few things to note about the recorded file:
 - Binary responses (gzip logs, artifacts) are stored as base64 with `"encoding": "base64"`.
 - POST/PUT request bodies are stored in `postData` so distinct writes to the same endpoint are matched correctly on replay.
 
-## Replay offline
+### Replay offline
 
 Pass `--replay <path>` to serve responses from a previously recorded HAR file. No API token is required.
 
@@ -129,7 +161,7 @@ Replay matches requests by **method + URL** (plus request body for write methods
 
 The server returns a clear error if a tool makes a request for which no HAR entry exists, making it easy to detect when a scenario is incomplete.
 
-## Creating error scenarios
+### Creating error scenarios
 
 Because the HAR format is plain JSON you can hand-edit a recorded file to simulate failure cases:
 
@@ -139,7 +171,7 @@ Because the HAR format is plain JSON you can hand-edit a recorded file to simula
 
 Standard HAR viewers (Chrome DevTools, [HAR Analyzer](https://toolbox.googleapps.com/apps/har_analyzer/)) can open the files for inspection.
 
-## Known limitations
+### Known limitations
 
 - **Full-file rewrite on every request.** Each API call re-marshals and rewrites the entire HAR file. This is fine for typical eval sessions (tens to low hundreds of calls) but will slow down recording for very large sessions. A future improvement would be to append a JSON line and only rewrite on close.
 
@@ -147,7 +179,7 @@ Standard HAR viewers (Chrome DevTools, [HAR Analyzer](https://toolbox.googleapps
 
 - **Transport errors are not recorded.** Only requests that receive an HTTP response are written to the HAR. If the underlying transport returns an error (connection refused, timeout, DNS failure), the call is not captured and the error is returned to the caller as normal. Replay cannot reproduce those failure modes.
 
-# Tracing
+## Tracing
 
 To enable tracing in the MCP server you need to add some environment variables in the configuration, the example below is showing the claude desktop configuration paired with [honeycomb](https://honeycomb.io), however any OTEL service will work as long as it supports GRPC.
 
@@ -169,4 +201,39 @@ To enable tracing in the MCP server you need to add some environment variables i
         }
     }
 }
+```
+
+## Maintainer release process
+
+GoReleaser, `ko`, GitHub CLI, and Docker are included in or used alongside the
+mise toolchain for release workflows. They are not required for normal
+development.
+
+### Publishing a release
+
+1. Draft a [new GitHub release](https://github.com/buildkite/buildkite-mcp-server/releases/new).
+2. Select a new tag, incrementing the minor or patch version as appropriate.
+3. Generate the release notes.
+4. Save the release as a draft and notify internal contributors before publishing.
+5. Publish the release.
+
+The Buildkite pipeline publishes images to GitHub Container Registry and Docker
+Hub, then adds binaries to the GitHub release.
+
+### Manual GitHub Container Registry release
+
+The CI pipeline normally performs this process. If a manual release is required,
+authenticate GitHub CLI and Docker first:
+
+```bash
+docker login ghcr.io --username "$(gh api user --jq '.login')"
+```
+
+After publishing the GitHub release and its tag, update the local `main` branch
+and run GoReleaser:
+
+```bash
+git fetch origin
+git pull --ff-only origin main
+GITHUB_TOKEN="$(gh auth token)" mise exec -- goreleaser release
 ```

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ lint: ## Run linter
 lint-fix: ## Run linter with auto-fix
 	golangci-lint run --fix ./...
 
+.PHONY: tidy-check
+tidy-check: ## Check that Go module files are tidy
+	go mod tidy -diff
+
+.PHONY: fix-check
+fix-check: ## Check for changes recommended by go fix
+	go fix -diff ./...
+
 .PHONY: clean
 clean: ## Clean build artifacts
 	rm -f $(BINARY_NAME) $(COVERAGE_FILE)
@@ -55,7 +63,7 @@ deps: ## Download and tidy dependencies
 	go mod tidy
 
 .PHONY: check
-check: lint test ## Run all checks (lint + test)
+check: lint tidy-check fix-check test ## Run all validation checks
 
 .PHONY: all
 all: clean deps check build ## Run full build pipeline

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,8 +4,8 @@ pre-commit:
   parallel: true
   jobs:
     - name: lint
-      run: golangci-lint run
+      run: make lint
     - name: go mod tidy
-      run: go mod tidy -diff
+      run: make tidy-check
     - name: go fix
-      run: go fix -diff ./...
+      run: make fix-check

--- a/mise.lock
+++ b/mise.lock
@@ -39,36 +39,43 @@ backend = "aqua:golangci/golangci-lint"
 [tools.golangci-lint."platforms.linux-arm64"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-arm64-musl"]
 checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64-musl"]
 checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
 checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-x64"]
 checksum = "sha256:f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470980"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.windows-x64"]
 checksum = "sha256:bd42e3ebc8cb4ececb86941983baaf1dc221bbb04d838e94ce63b49cc91e02bb"
 url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-windows-amd64.zip"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471017"
 provenance = "github-attestations"
 
 [[tools.goreleaser]]
@@ -222,3 +229,35 @@ checksum = "sha256:df7fb73aca464e455f66ab231965cfb15aaea4ccd45be4af4f7df908fc407
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.11/lefthook_2.1.11_Windows_x86_64.gz"
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/523446762"
 provenance = "github-attestations"
+
+[[tools.node]]
+version = "22.22.3"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:cc8bc82b2dd0b595c3b95a4c3c9c8c350907cff011afbdee3d1379e812e1e3e3"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:09c87acbafae65e18fcc0eb188376c1254cab74dc769118f4b60479c5fa326cf"
+url = "https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:c7a10d6816da8eaaa7534dd73c71c6e2b2c391dbbf845e364902d156615dd1b8"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-linux-x64.tar.gz"
+
+[tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:d227692583d6ae17c44028fd8f17cb1b3672167a6baa035818240cbb9db6ea4a"
+url = "https://unofficial-builds.nodejs.org/download/release/v22.22.3/node-v22.22.3-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:0da7ff74ef8611328c8212f17943368713a2ad953fb7d89a8c8a0eae87c23207"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:45830ba752fa0d892c6dcd640946669801293cac820a33591ded40ac075198ec"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-darwin-x64.tar.gz"
+
+[tools.node."platforms.windows-x64"]
+checksum = "sha256:6c8d54f635feff4df76c2ca80f45332eb2ff57d25226edce36592e51a177ee33"
+url = "https://nodejs.org/dist/v22.22.3/node-v22.22.3-win-x64.zip"

--- a/mise.toml
+++ b/mise.toml
@@ -9,4 +9,24 @@ go = "1.26.6"
 golangci-lint = "2.12.2"
 goreleaser = "2.17.1"
 ko = "0.19.1"
-lefthook = "latest"
+lefthook = "2.1.11"
+node = "22.22.3"
+
+[tasks.setup]
+description = "Install repository dependencies and Git hooks"
+run = [
+  "go mod download",
+  "lefthook install",
+]
+
+[tasks.check]
+description = "Run all local validation checks"
+run = "make check"
+
+[tasks.build]
+description = "Build the server binary"
+run = "make build"
+
+[tasks.run]
+description = "Run the server over stdio"
+run = "make run"

--- a/mise.toml
+++ b/mise.toml
@@ -23,6 +23,10 @@ run = [
 description = "Run all local validation checks"
 run = "make check"
 
+[tasks.lint-fix]
+description = "Run the linter and apply supported fixes"
+run = "make lint-fix"
+
 [tasks.build]
 description = "Build the server binary"
 run = "make build"

--- a/mise.toml
+++ b/mise.toml
@@ -25,7 +25,7 @@ run = "make check"
 
 [tasks.lint-fix]
 description = "Run the linter and apply supported fixes"
-run = "make lint-fix"
+run = "golangci-lint run --fix ./..."
 
 [tasks.build]
 description = "Build the server binary"


### PR DESCRIPTION
## Summary

- make mise the primary development setup path
- document Go 1.26.6 for builds while retaining the module compatibility floor
- add mise setup, check, build, and run tasks
- consolidate validation targets across Make and Lefthook
- clarify authentication, MCP Inspector, Docker, and release workflows

## Validation

- mise tasks validate
- mise run setup
- mise run check
- mise run build
- git diff --check