### PR TITLE
Name the JSON paths for build.state and build.job_state_counts in the summary description

### DIFF
--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -835,7 +835,7 @@ func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) erro
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "get_build_failure_summary",
-			Description: "Diagnose a Buildkite build failure in one call. Returns build state, job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
+			Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Get Build Failure Summary",
 				ReadOnlyHint: true,


### PR DESCRIPTION
### Description

An eval session (details in [ticket](https://linear.app/buildkite/issue/PB-3179/tweak-mcpapi-clearly-indicate-where-job-counts-state-field-is-in-build)) showed an agent that knew to consult `job_state_counts` — the field this tool's description advertises as the way to avoid a `list_jobs` call — but probed the file-redirected summary at guessed top-level jq paths (`.build_state`, `.job_state_counts`). jq answers wrong paths with a silent, plausible `null`, so the agent concluded the counts were unavailable and paid the `list_jobs` round trip the field exists to prevent. It corrected the state path (`.build.state`) on its next probe but never re-checked the counts.

Large builds routinely take the file-redirect path (the summary exceeds client inline caps), where the agent navigates purely by jq paths — so the path is the load-bearing fact. This dots both fields in the tool description: `build.state` and `build.job_state_counts`. Same discoverability principle as the `body_html` hint (#382): the hint travels with the tool, ~2 tokens of standing context.

### Context

- Linear: https://linear.app/buildkite/issue/PB-3179/tweak-mcpapi-clearly-indicate-where-job-counts-state-field-is-in-build
- Sibling fixes from the same eval session review: #382 (annotation `body_html` hint), #385 (`content_limit_bytes` input arg)

### Changes

- Two words in the `get_build_failure_summary` tool description: "build state, job_state_counts" → "build.state, build.job_state_counts".

### Verification

- `go build ./...` and `go test ./pkg/buildkite/ -run FailureSummary` pass.
- Behavioral check: eval runs of large builds should show agents reading `.build.job_state_counts` from the redirected summary file and skipping `list_jobs` when the counts confirm coverage.

### Deployment

Very low risk: description string only — no handler, schema, or payload changes, no migrations, no ordering concerns.

### Rollback

This change is safe to revert — plain `git revert` of a description string. Reverting only removes the path hints; behavior is unchanged.

Hand-edited review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)