### PR TITLE
Add git config email and user name in eval #1

### DIFF
--- a/evals/evals.yaml
+++ b/evals/evals.yaml
@@ -99,6 +99,7 @@ matrix:
         # never exist in the repo hosting this eval, so the eval pipeline cannot
         # recurse (see the CROSS-REPO note in .buildkite/pipeline.evals.yml).
         SCENARIO_BRANCH="mcp-eval-scenario-${ENTRY_ID}-${DATETIME}"
+        git config user.email "secret-agent@llm.com" && git config user.name "secret-agent"
         git fetch
         git checkout -b "$SCENARIO_BRANCH" origin/test-broken-and-failed-jobs
         git push -u origin HEAD


### PR DESCRIPTION
In the eval scenario #1, we use 'git' to fetch, checkout ,and push.
However we didn't set git `user.email` and `user.name` thus when doing `git push` it will fail, and the LLM performing the eval will have to go through the extra step to set those up.
This PR fixes this by performing `git config` to set email and name so those errors won't affect the eval metrics