### PR TITLE
chore: mark renovate PRs for manual review

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "group:allNonMajor"
   ],
   "labels": ["dependencies"],
+  "addLabels": ["buildsworth:manual"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "minimumReleaseAge": "3 days",


### PR DESCRIPTION
## Summary

- add the `buildsworth:manual` label to all new Renovate PRs
- preserve the existing dependency and security labels through Renovate's additive label configuration
- prevent Renovate dependency updates from automatically triggering AI review

## Validation

- Renovate configuration validator passed
- pre-commit checks passed