### PR TITLE
docs: add release notes skill

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: release-notes
+description: Draft and update GitHub release notes for this repository. Use when preparing, reviewing, or revising a versioned buildkite-mcp-server release. Do not use for changelog files or ordinary pull request descriptions.
+---
+
+# Release notes
+
+Produce accurate, maintainer-reviewed GitHub release notes that follow the style
+of recent curated releases in this repository.
+
+## Gather evidence
+
+1. Confirm the target version and inspect its current GitHub release, if one
+   exists.
+2. Identify the comparison base from the release series and verify the full
+   comparison range. Do not rely only on locally fetched tags.
+3. Inspect a recent curated release, such as `v1.19.0`, for layout and level of
+   detail. Treat it as a style reference, not a fixed template.
+4. Collect every pull request in the comparison range. Read the pull request
+   descriptions and changed files for user-facing changes. Inspect source at the
+   target tag when needed to verify tool names, arguments, defaults, limits, and
+   behavior.
+
+Use `gh` for GitHub data when available. Do not infer technical details from pull
+request titles alone.
+
+## Draft the release
+
+Start with a short paragraph describing the most important user outcomes. Then
+use the following sections when they have relevant content:
+
+- `## What's Changed`, with concise categories such as Features, Agent Guidance,
+  Development and Evals, and Dependencies.
+- `## Tool Changes`, describing new tools and material changes to existing tools
+  in practical terms.
+- `## New Contributors`, when applicable.
+- A `**Full Changelog**` comparison link as the final line.
+
+For each pull request in `What's Changed`, preserve its title, author attribution,
+and URL. Ensure every pull request in the comparison range appears exactly once
+in those categorized lists. The narrative `Tool Changes` section may discuss the
+same work without repeating attribution.
+
+Prefer concise, factual language. Focus on externally observable behavior and
+agent outcomes. Exclude implementation detail unless it explains a limit,
+compatibility constraint, or operational risk. Do not use em dashes.
+
+## Review and update
+
+Always show the complete Markdown draft before changing GitHub. If the user asked
+only for a draft or review, stop after presenting it.
+
+Editing or creating a GitHub release requires explicit user approval. Approval to
+draft notes is not approval to update or publish a release. After approval:
+
+1. Write the approved Markdown to a temporary notes file.
+2. Update the specified existing release using `gh release edit` with
+   `--notes-file`.
+3. Read the release back from GitHub and verify the complete body and URL.
+4. Remove the temporary file and confirm it did not leave worktree changes.
+
+Do not publish a draft release, create a tag, or create a new release unless the
+user explicitly requests that separate action.

--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -47,11 +47,12 @@ compatibility constraint, or operational risk. Do not use em dashes.
 
 ## Review and update
 
-Always show the complete Markdown draft before changing GitHub. If the user asked
-only for a draft or review, stop after presenting it.
-
-Editing or creating a GitHub release requires explicit user approval. Approval to
-draft notes is not approval to update or publish a release. After approval:
+Always show the complete Markdown draft and stop. Wait for a new user response
+that explicitly approves that exact body before changing GitHub, even when the
+initial request asks to draft and update the release in one step. Approval to
+draft notes or general permission to update a release is not approval of the
+generated body. If the draft changes, present the complete revised Markdown and
+wait for approval again. After approval:
 
 1. Write the approved Markdown to a temporary notes file.
 2. Update the specified existing release using `gh release edit` with

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -214,7 +214,10 @@ development.
 
 1. Draft a [new GitHub release](https://github.com/buildkite/buildkite-mcp-server/releases/new).
 2. Select a new tag, incrementing the minor or patch version as appropriate.
-3. Generate the release notes.
+3. Generate and review the release notes. Codex users can invoke the repository's
+   `$release-notes` skill with the target version. Use a recent curated release
+   as the layout reference, verify every pull request in the comparison range is
+   represented, and review the complete Markdown before updating GitHub.
 4. Save the release as a draft and notify internal contributors before publishing.
 5. Publish the release.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -214,10 +214,11 @@ development.
 
 1. Draft a [new GitHub release](https://github.com/buildkite/buildkite-mcp-server/releases/new).
 2. Select a new tag, incrementing the minor or patch version as appropriate.
-3. Generate and review the release notes. Codex users can invoke the repository's
-   `$release-notes` skill with the target version. Use a recent curated release
-   as the layout reference, verify every pull request in the comparison range is
-   represented, and review the complete Markdown before updating GitHub.
+3. Generate and review the release notes. Agent Skills-compatible coding agents
+   can invoke the repository's `release-notes` skill with the target version. Use
+   a recent curated release as the layout reference, verify every pull request in
+   the comparison range is represented, and review the complete Markdown before
+   updating GitHub.
 4. Save the release as a draft and notify internal contributors before publishing.
 5. Publish the release.
 


### PR DESCRIPTION
## Summary

- add a repository-scoped skill for drafting and updating GitHub release notes
- require complete Markdown review and explicit approval before changing a release
- document the skill in the maintainer release process

## Validation

- pre-commit hooks: `go mod tidy -diff`, `go fix -diff ./...`, and `golangci-lint run ./...`
- skill frontmatter and repository path validated locally
- `git diff --check`
