### PR TITLE
docs: add tool parameter description guidelines

### DIFF
--- a/.agents/skills/tool-parameter-descriptions/SKILL.md
+++ b/.agents/skills/tool-parameter-descriptions/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: tool-parameter-descriptions
+description: Write or review concise MCP tool parameter descriptions that add only information needed to construct correct calls.
+---
+
+# Tool Parameter Descriptions
+
+Use these guidelines when adding or reviewing MCP tool input schemas.
+
+## Standard
+
+A parameter description must add information that cannot be recovered from the parameter name, JSON type, required status, or tool description.
+
+Keep a description when it communicates at least one of:
+
+- Accepted values, syntax, units, bounds, or defaults.
+- Dependencies or mutual exclusion with other parameters.
+- Behavior when omitted or set to a sentinel value such as zero.
+- Replacement, destructive, or other side effects.
+- Identifier type or source when similar identifiers are easily confused.
+- Non-obvious filtering or matching behavior.
+
+Otherwise, omit it. In particular, do not:
+
+- Restate the parameter name, such as `build_number: "Build number"`.
+- Say that a parameter is optional when the schema already expresses that.
+- Repeat information already provided by the tool description.
+- Add generic domain explanation that does not affect the argument value.
+
+Prefer short phrases over complete sentences. Put machine-readable constraints such as enums, bounds, and defaults in the schema when supported; use prose only for information the schema cannot express clearly.
+
+## Review
+
+Read the handler as well as the parameter type. Check defaults, validation, identifier formats, coupled parameters, pagination behavior, and side effects before deciding whether a description is needed.
+
+Use this deletion test: if removing the description would not make a materially different or invalid tool call more likely, remove it.
+
+Examples:
+
+- Omit `Description of the cluster` from `description`.
+- Replace `Build number` with `Sequential build number, not the build UUID` when that distinction matters.
+- Use `Maximum matches to return; 0 returns all` for a limit with non-obvious zero behavior.
+- Preserve warnings such as an update replacing an entire map.
+
+Update schema tests for behaviorally important descriptions and run the relevant Go tests. Use LLM evals for changes intended to improve tool selection or argument construction; unit tests cannot establish model effectiveness.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,6 +119,14 @@ docker run -i --rm -e BUILDKITE_API_TOKEN="your-token" buildkite/buildkite-mcp-s
 4. Update the tool documentation.
 5. Run `mise run check`.
 
+### Tool parameter descriptions
+
+When adding or reviewing tool parameters, use the repository skill at
+[`tool-parameter-descriptions`](.agents/skills/tool-parameter-descriptions/SKILL.md).
+It defines when a description adds useful information, when to omit one, and
+how to validate description changes. Apply it to the parameter schema and the
+corresponding handler behavior.
+
 ## Validating tools with MCP Inspector
 
 [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is useful for exercising tools and verifying their schemas. Node.js is included in the mise toolchain for this optional workflow.

--- a/pkg/buildkite/joblogs.go
+++ b/pkg/buildkite/joblogs.go
@@ -27,34 +27,34 @@ type JobLogsBaseParams struct {
 	ToolInput
 	OrgSlug      string `json:"org_slug"`
 	PipelineSlug string `json:"pipeline_slug"`
-	BuildNumber  string `json:"build_number"`
-	JobID        string `json:"job_id"`
-	CacheTTL     string `json:"cache_ttl,omitempty"`
-	ForceRefresh bool   `json:"force_refresh,omitempty"`
+	BuildNumber  string `json:"build_number" jsonschema:"Sequential build number, not the build UUID"`
+	JobID        string `json:"job_id" jsonschema:"Buildkite job UUID"`
+	CacheTTL     string `json:"cache_ttl,omitempty" jsonschema:"Go duration; defaults to 30s"`
+	ForceRefresh bool   `json:"force_refresh,omitempty" jsonschema:"Bypass cached log data"`
 }
 
 type SearchLogsParams struct {
 	JobLogsBaseParams
-	Pattern       string `json:"pattern"`
-	Context       int    `json:"context,omitempty"`
-	BeforeContext int    `json:"before_context,omitempty"`
-	AfterContext  int    `json:"after_context,omitempty"`
+	Pattern       string `json:"pattern" jsonschema:"Go regular expression"`
+	Context       int    `json:"context,omitempty" jsonschema:"Lines before and after each match"`
+	BeforeContext int    `json:"before_context,omitempty" jsonschema:"Lines before each match"`
+	AfterContext  int    `json:"after_context,omitempty" jsonschema:"Lines after each match"`
 	CaseSensitive bool   `json:"case_sensitive,omitempty"`
 	InvertMatch   bool   `json:"invert_match,omitempty"`
-	Reverse       bool   `json:"reverse,omitempty"`
-	SeekStart     int    `json:"seek_start,omitempty"`
-	Limit         int    `json:"limit,omitempty"`
+	Reverse       bool   `json:"reverse,omitempty" jsonschema:"Search from the end of the log"`
+	SeekStart     int    `json:"seek_start,omitempty" jsonschema:"Zero-based row at which to begin searching"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum matches to return; 0 returns all"`
 }
 
 type TailLogsParams struct {
 	JobLogsBaseParams
-	Tail int `json:"tail,omitempty"`
+	Tail int `json:"tail,omitempty" jsonschema:"Final log entries to return; defaults to 10"`
 }
 
 type ReadLogsParams struct {
 	JobLogsBaseParams
-	Seek  int `json:"seek,omitempty"`
-	Limit int `json:"limit,omitempty"`
+	Seek  int `json:"seek,omitempty" jsonschema:"Zero-based row at which to begin reading"`
+	Limit int `json:"limit,omitempty" jsonschema:"Maximum entries to return; 0 reads all remaining entries"`
 }
 
 type TerseLogEntry struct {

--- a/pkg/buildkite/joblogs.go
+++ b/pkg/buildkite/joblogs.go
@@ -36,13 +36,13 @@ type JobLogsBaseParams struct {
 type SearchLogsParams struct {
 	JobLogsBaseParams
 	Pattern       string `json:"pattern" jsonschema:"Go regular expression"`
-	Context       int    `json:"context,omitempty" jsonschema:"Lines before and after each match"`
-	BeforeContext int    `json:"before_context,omitempty" jsonschema:"Lines before each match"`
-	AfterContext  int    `json:"after_context,omitempty" jsonschema:"Lines after each match"`
+	Context       int    `json:"context,omitempty" jsonschema:"Lines before and after each match; overrides before_context and after_context when nonzero"`
+	BeforeContext int    `json:"before_context,omitempty" jsonschema:"Lines before each match; ignored when context is nonzero"`
+	AfterContext  int    `json:"after_context,omitempty" jsonschema:"Lines after each match; ignored when context is nonzero"`
 	CaseSensitive bool   `json:"case_sensitive,omitempty"`
 	InvertMatch   bool   `json:"invert_match,omitempty"`
 	Reverse       bool   `json:"reverse,omitempty" jsonschema:"Search from the end of the log"`
-	SeekStart     int    `json:"seek_start,omitempty" jsonschema:"Zero-based row at which to begin searching"`
+	SeekStart     int    `json:"seek_start,omitempty" jsonschema:"Zero-based starting row; 0 uses the default (log end when reverse)"`
 	Limit         int    `json:"limit,omitempty" jsonschema:"Maximum matches to return; 0 returns all"`
 }
 

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -189,12 +189,22 @@ func TestSearchLogsParamsSchema(t *testing.T) {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
 
-	require.Contains(t, s.Properties["build_number"].Description, "not the build UUID")
-	require.Contains(t, s.Properties["job_id"].Description, "UUID")
-	require.Contains(t, s.Properties["cache_ttl"].Description, "30s")
-	require.Contains(t, s.Properties["pattern"].Description, "regular expression")
-	require.Contains(t, s.Properties["seek_start"].Description, "Zero-based row")
-	require.Contains(t, s.Properties["limit"].Description, "0 returns all")
+	expectedDescriptions := map[string]string{
+		"build_number":   "Sequential build number, not the build UUID",
+		"job_id":         "Buildkite job UUID",
+		"cache_ttl":      "Go duration; defaults to 30s",
+		"force_refresh":  "Bypass cached log data",
+		"pattern":        "Go regular expression",
+		"context":        "Lines before and after each match; overrides before_context and after_context when nonzero",
+		"before_context": "Lines before each match; ignored when context is nonzero",
+		"after_context":  "Lines after each match; ignored when context is nonzero",
+		"reverse":        "Search from the end of the log",
+		"seek_start":     "Zero-based starting row; 0 uses the default (log end when reverse)",
+		"limit":          "Maximum matches to return; 0 returns all",
+	}
+	for property, description := range expectedDescriptions {
+		require.Equal(t, description, s.Properties[property].Description, "%s has the wrong description", property)
+	}
 }
 
 func TestTailLogsParamsSchema(t *testing.T) {

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -175,6 +175,9 @@ func TestReadLogsParamsSchema(t *testing.T) {
 	for _, opt := range []string{"cache_ttl", "force_refresh", "seek", "limit"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
+
+	require.Contains(t, s.Properties["seek"].Description, "Zero-based row")
+	require.Contains(t, s.Properties["limit"].Description, "0 reads all remaining entries")
 }
 
 func TestSearchLogsParamsSchema(t *testing.T) {
@@ -185,6 +188,13 @@ func TestSearchLogsParamsSchema(t *testing.T) {
 	for _, opt := range []string{"cache_ttl", "force_refresh", "context", "before_context", "after_context", "case_sensitive", "invert_match", "reverse", "seek_start", "limit"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
+
+	require.Contains(t, s.Properties["build_number"].Description, "not the build UUID")
+	require.Contains(t, s.Properties["job_id"].Description, "UUID")
+	require.Contains(t, s.Properties["cache_ttl"].Description, "30s")
+	require.Contains(t, s.Properties["pattern"].Description, "regular expression")
+	require.Contains(t, s.Properties["seek_start"].Description, "Zero-based row")
+	require.Contains(t, s.Properties["limit"].Description, "0 returns all")
 }
 
 func TestTailLogsParamsSchema(t *testing.T) {
@@ -195,6 +205,8 @@ func TestTailLogsParamsSchema(t *testing.T) {
 	for _, opt := range []string{"cache_ttl", "force_refresh", "tail"} {
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}
+
+	require.Contains(t, s.Properties["tail"].Description, "defaults to 10")
 }
 
 func TestListArtifactsForBuildArgsSchema(t *testing.T) {


### PR DESCRIPTION
## Summary

- add a repository skill for concise, behavior-focused MCP parameter descriptions
- document the skill in DEVELOPMENT.md without coupling it to a specific agent
- describe non-obvious log-tool syntax, defaults, identifier formats, row semantics, and limit behavior
- add schema assertions for the behaviorally important descriptions

## Testing

- [x] skill validation
- [x] `golangci-lint run --new-from-rev HEAD ./...`
- [x] `go test ./...`
- [ ] `mise run check` — blocked by pre-existing gci failures in `pkg/buildkite/cluster_secrets.go` and `pkg/buildkite/cluster_secrets_test.go`