### PR TITLE
Add server instructions for step upload tools

### DIFF
--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -99,7 +99,7 @@ var instructionSections = []instructionSection{
 	},
 	{
 		toolset: toolsets.ToolsetBuilds,
-		text:    "Dynamic pipeline uploads: steps added at runtime via `buildkite-agent pipeline upload` do not appear in the pipeline's static configuration. To see what dynamic steps actually ran, call list_step_uploads (returns each step's state, source_job_id, created_jobs_count, rejection details), then get_step_upload with an upload_uuid to read its dynamic pipeline definition YAML (definition_yaml field). Large definitions are omitted from get_step_upload. Build is only retrievable within its ~30 day maximum lifetime.",
+		text:    "Dynamic pipeline uploads: steps added at runtime via `buildkite-agent pipeline upload` do not appear in the pipeline's static configuration. To inspect what was dynamically uploaded, call list_step_uploads (returns each upload's state, source_job_id, created_jobs_count, and rejection details), then get_step_upload with an upload_uuid to read its dynamic pipeline definition YAML (definition_yaml field). Large definitions are omitted from get_step_upload. Step-upload data is only available while the build is within its maximum lifetime (~30 days).",
 	},
 	{
 		toolset: toolsets.ToolsetLogs,

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -98,6 +98,10 @@ var instructionSections = []instructionSection{
 		text:    "Job output links: Job summaries expose a step ID as step_id; full job responses expose it as step.id. To link directly to that job's output, use https://buildkite.com/{org_slug}/{pipeline_slug}/builds/{build_number}/list?sid={step_id}&tab=output.",
 	},
 	{
+		toolset: toolsets.ToolsetBuilds,
+		text:    "Dynamic pipeline uploads: steps added at runtime via `buildkite-agent pipeline upload` do not appear in the pipeline's static configuration. To see what dynamic steps actually ran, call list_step_uploads (returns each step's state, source_job_id, created_jobs_count, rejection details), then get_step_upload with an upload_uuid to read its dynamic pipeline definition YAML (definition_yaml field). Large definitions are omitted from get_step_upload. Build is only retrievable within its ~30 day maximum lifetime.",
+	},
+	{
 		toolset: toolsets.ToolsetLogs,
 		text:    "Log investigation order: start with tail_logs to see recent output (cheapest, catches most failures), then search_logs with a pattern and limit for targeted investigation, and only use read_logs with seek and limit for deep sequential inspection. Avoid calling read_logs without a limit on large logs.",
 	},

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -20,6 +20,7 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		buildNumber      = "build_number is a sequential"
 		jobStateBroken   = `Job state "broken"`
 		jobOutputLinks   = "Job output links:"
+		dynamicUploads   = "Dynamic pipeline uploads:"
 		logInvestigation = "Log investigation order:"
 		annotationScope  = "Annotation scope:"
 		failureSummary   = "Build failure investigation:"
@@ -37,45 +38,45 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		{
 			name:    "all toolsets includes every section",
 			enabled: []string{"all"},
-			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope),
+			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope),
 		},
 		{
 			name:    "builds alone",
 			enabled: []string{"builds"},
-			want:    append(append([]string{}, always...), jobStateBroken, jobOutputLinks),
+			want:    append(append([]string{}, always...), jobStateBroken, jobOutputLinks, dynamicUploads),
 			notWant: []string{startHere, skillDiscovery, failureSummary, logInvestigation, annotationScope},
 		},
 		{
 			name:    "skills alone",
 			enabled: []string{"skills"},
 			want:    append(append([]string{}, always...), skillDiscovery),
-			notWant: []string{startHere, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
+			notWant: []string{startHere, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:    "user alone",
 			enabled: []string{"user"},
 			want:    append(append([]string{}, always...), startHere),
-			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
+			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:     "all toolsets, read-only, omits annotation scope",
 			enabled:  []string{"all"},
 			readOnly: true,
-			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, logInvestigation),
+			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation),
 			notWant:  []string{annotationScope},
 		},
 		{
 			name:    "investigations alone",
 			enabled: []string{"investigations"},
 			want:    append(append([]string{}, always...), failureSummary),
-			notWant: []string{startHere, skillDiscovery, jobStateBroken, jobOutputLinks, logInvestigation, annotationScope},
+			notWant: []string{startHere, skillDiscovery, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:     "annotations toolset, read-only, omits annotation scope",
 			enabled:  []string{"annotations"},
 			readOnly: true,
 			want:     append([]string{}, always...),
-			notWant:  []string{jobOutputLinks, annotationScope},
+			notWant:  []string{jobOutputLinks, dynamicUploads, annotationScope},
 		},
 	}
 


### PR DESCRIPTION
### Description

The MCP server instruction set didn't mention `list_step_uploads` or `get_step_upload`, so  there are evidence that clients may have had no guidance on how to inspect a build's dynamic pipeline uploads. This adds a short instruction paragraph explaining that steps added at runtime via `buildkite-agent pipeline upload` don't appear in a pipeline's static configuration, and how to use the two tools together to see what dynamic steps actually ran.

### Context

https://linear.app/buildkite/issue/PB-3004

### Changes

- `pkg/server/mcp.go`: new `instructionSection` for step uploads, gated on the `builds` toolset (where both tools are registered) — read-only safe.
- `pkg/server/mcp_test.go`: added a `dynamicUploads` marker and wired it into the existing want/notWant cases so the section is asserted present when `builds` is enabled and absent otherwise.

`remote-mcp-server` reuses `BuildkiteServerInstructions`, so it picks up the new guidance automatically.

### Verification

`go test ./pkg/server/ -run TestBuildkiteServerInstructions` passes; `go build ./pkg/server/` compiles.

### Deployment

Very low risk — text-only change to server instructions. No migrations, no ordering concerns.

### Rollback

This change is safe to revert; it only changes the instruction string sent to MCP clients.