### PR TITLE
Make pipeline webhook creation explicit and recoverable

### DIFF
--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -2,6 +2,9 @@ package buildkite
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net/http"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/go-buildkite/v5"
@@ -33,9 +36,11 @@ type CreatePipelineResult struct {
 }
 
 type WebhookInfo struct {
-	Created bool   `json:"created"`
-	Error   string `json:"error,omitempty"`
-	Note    string `json:"note,omitempty"`
+	Created   bool     `json:"created"`
+	Error     string   `json:"error,omitempty"`
+	Note      string   `json:"note,omitempty"`
+	SetupURL  string   `json:"setup_url,omitempty"`
+	NextSteps []string `json:"next_steps,omitempty"`
 }
 
 func ListPipelines() (mcp.Tool, mcp.ToolHandlerFor[ListPipelinesArgs, any], []string) {
@@ -252,7 +257,7 @@ type CreatePipelineArgs struct {
 	CancelRunningBranchBuilds bool              `json:"cancel_running_branch_builds,omitempty" jsonschema:"Cancel running builds when new builds are created on the same branch"`
 	Tags                      []string          `json:"tags,omitempty" jsonschema:"Tags to apply to the pipeline for filtering and organization"`
 	Teams                     map[string]string `json:"teams,omitempty" jsonschema:"Team UUIDs mapped to their access level on the pipeline: read_only, build_and_read or manage_build_and_read. Organizations with teams enabled require at least one team, unless the user is an organization administrator"`
-	CreateWebhook             bool              `json:"create_webhook,omitempty" jsonschema:"Create a GitHub webhook to trigger builds on pull-request and push events"`
+	CreateWebhook             bool              `json:"create_webhook" jsonschema:"Whether to create a GitHub webhook after creating the pipeline. Set true when GitHub push or pull-request events should trigger this pipeline automatically; if the repository is not connected through a compatible Buildkite GitHub App, the pipeline is still created and setup instructions are returned. Set false for non-GitHub repositories, centralized or manually managed webhooks, or pipelines that must not receive events yet."`
 }
 
 func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []string) {
@@ -309,6 +314,24 @@ func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []
 				if err != nil {
 					result.Webhook.Error = err.Error()
 					result.Webhook.Note = "Pipeline created successfully, but webhook creation failed."
+
+					var errResp *buildkite.ErrorResponse
+					if errors.As(err, &errResp) &&
+						errResp.Response != nil &&
+						errResp.Response.StatusCode == http.StatusUnprocessableEntity &&
+						errResp.Message == "Auto-creating webhooks is not supported for your repository." {
+						result.Webhook.Note = "Pipeline created successfully, but its GitHub webhook could not be created automatically. Do not recreate the pipeline."
+						result.Webhook.SetupURL = fmt.Sprintf(
+							"https://buildkite.com/organizations/%s/repository-providers",
+							args.OrgSlug,
+						)
+						result.Webhook.NextSteps = []string{
+							"Open setup_url and connect a compatible Buildkite GitHub App, or grant the existing app access to this repository.",
+							"Return to the pipeline using pipeline.web_url and open its GitHub settings.",
+							"Follow the webhook setup instructions shown there to finish connecting the existing pipeline.",
+							"Do not create another pipeline; the pipeline in this result was created successfully.",
+						}
+					}
 				}
 
 				return mcpTextResult(span, &result)

--- a/pkg/buildkite/pipelines_test.go
+++ b/pkg/buildkite/pipelines_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/buildkite/go-buildkite/v5"
@@ -201,7 +202,7 @@ steps:
 		Configuration: testPipelineDefinition,
 		Tags:          []string{"tag1", "tag2"},
 		Teams:         map[string]string{"team-uuid-1": "build_and_read"},
-		CreateWebhook: true, // should create webhook by default
+		CreateWebhook: true,
 	}
 
 	result, _, err := handler(ctx, request, args)
@@ -300,6 +301,13 @@ steps:
 
 func TestCreatePipelineWithWebhookError(t *testing.T) {
 	assert := require.New(t)
+	webhookErr := &buildkite.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusUnprocessableEntity,
+			Request:    httptest.NewRequest(http.MethodPost, "https://api.buildkite.com/v2/organizations/org/pipelines/test-pipeline/webhook", nil),
+		},
+		Message: "Auto-creating webhooks is not supported for your repository.",
+	}
 
 	testPipelineDefinition := `
 agents:
@@ -337,7 +345,7 @@ steps:
 		},
 		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
 			webhookCalled = true
-			return nil, errors.New("Auto-creating webhooks is not supported for your repository.")
+			return nil, webhookErr
 		},
 	}
 
@@ -366,8 +374,47 @@ steps:
 
 	textContent := getTextResult(t, result)
 	requireJSONPathEqual(t, textContent.Text, false, "webhook", "created")
-	requireJSONPathEqual(t, textContent.Text, "Auto-creating webhooks is not supported for your repository.", "webhook", "error")
-	requireJSONPathEqual(t, textContent.Text, "Pipeline created successfully, but webhook creation failed.", "webhook", "note")
+	requireJSONPathEqual(t, textContent.Text, webhookErr.Error(), "webhook", "error")
+	requireJSONPathEqual(t, textContent.Text, "Pipeline created successfully, but its GitHub webhook could not be created automatically. Do not recreate the pipeline.", "webhook", "note")
+	requireJSONPathEqual(t, textContent.Text, "https://buildkite.com/organizations/org/repository-providers", "webhook", "setup_url")
+	requireJSONPathEqual(t, textContent.Text, "Open setup_url and connect a compatible Buildkite GitHub App, or grant the existing app access to this repository.", "webhook", "next_steps", 0)
+	requireJSONPathEqual(t, textContent.Text, "Do not create another pipeline; the pipeline in this result was created successfully.", "webhook", "next_steps", 3)
+	requireJSONPathEqual(t, textContent.Text, "123", "pipeline", "id")
+}
+
+func TestCreatePipelineWithoutWebhook(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			t.Fatal("AddWebhook should not be called when CreateWebhook is false")
+			return nil, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipeline()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineArgs{CreateWebhook: false})
+	require.NoError(t, err)
+	require.NotContains(t, getTextResult(t, result).Text, `"webhook"`)
+}
+
+func TestCreatePipelineWithGenericWebhookError(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			return nil, errors.New("request timed out")
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipeline()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineArgs{CreateWebhook: true})
+	require.NoError(t, err)
+
+	text := getTextResult(t, result).Text
+	requireJSONPathEqual(t, text, false, "webhook", "created")
+	requireJSONPathEqual(t, text, "request timed out", "webhook", "error")
+	requireJSONPathEqual(t, text, "Pipeline created successfully, but webhook creation failed.", "webhook", "note")
+	require.NotContains(t, text, `"setup_url"`)
+	require.NotContains(t, text, `"next_steps"`)
 }
 
 func TestUpdatePipeline(t *testing.T) {

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -97,9 +97,14 @@ func TestGetPipelineArgsSchema(t *testing.T) {
 }
 
 func TestCreatePipelineArgsSchema(t *testing.T) {
-	req := sortedRequired[CreatePipelineArgs](t)
-	// Required: org_slug, name, repository_url, cluster_id, configuration
-	require.Equal(t, []string{"cluster_id", "configuration", "name", "org_slug", "repository_url"}, req)
+	s := schemaFor[CreatePipelineArgs](t)
+	// Required: org_slug, name, repository_url, cluster_id, configuration, create_webhook
+	require.Equal(t, []string{"cluster_id", "configuration", "create_webhook", "name", "org_slug", "repository_url"}, sortedToolRequired(t, s))
+
+	description := s.Properties["create_webhook"].Description
+	require.Contains(t, description, "Set true when GitHub push or pull-request events should trigger this pipeline automatically")
+	require.Contains(t, description, "the pipeline is still created and setup instructions are returned")
+	require.Contains(t, description, "Set false for non-GitHub repositories, centralized or manually managed webhooks")
 }
 
 func TestUpdatePipelineArgsSchema(t *testing.T) {


### PR DESCRIPTION
## Why

Creating a pipeline and creating its GitHub webhook are separate operations. When automatic webhook creation is unsupported, the pipeline already exists, but the generic error does not explain how to recover. MCP clients may stall or retry pipeline creation and create duplicates.

The `create_webhook` choice was also optional, leaving clients without enough guidance to decide whether GitHub state should be changed.

## What

- Require callers to explicitly set `create_webhook`.
- Explain when to choose `true` or `false`.
- Recognize the documented `422 Unprocessable Entity` response returned when automatic webhook creation is unsupported.
- Preserve the successfully created pipeline in the result.
- Return the repository-provider setup URL and steps for completing webhook setup manually.
- Explicitly warn clients not to recreate the pipeline.
- Keep existing generic handling for unrelated webhook failures.

This is a schema compatibility change: callers that omit `create_webhook` must now provide either `true` or `false`.

## After this PR

After merging, the change must be released before MCP clients receive the new behavior. It should also be validated end-to-end against an organization without a compatible GitHub App connection.

Installing or authorizing a GitHub App remains an interactive browser step. Connection discovery and a dedicated webhook retry tool can be considered separately; they are not required for this guided recovery path.