### PR TITLE
Add `truncated: false` to `job_state_counts` in failure summary so LLM trusts `job_state_counts` contains all job states

### DIFF
--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -59,16 +59,24 @@ type GetBuildFailureSummaryArgs struct {
 	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded test failure details such as stack traces within the summary's bounded test-content budget"`
 }
 
+// FailureSummaryJobStateCounts wraps buildkite.JobStateCounts and adds
+// Truncated, which is always false — the API returns a complete server-side
+// tally, so callers can rely on it without paginating list_jobs.
+type FailureSummaryJobStateCounts struct {
+	buildkite.JobStateCounts
+	Truncated bool `json:"truncated"`
+}
+
 type BuildFailureSummaryBuild struct {
 	BuildSummary
 	Blocked bool `json:"blocked"`
 	// JobStateCounts tallies every job in the build by state, so the jobs
 	// below can be confirmed as the build's only problems without listing
 	// jobs. Omitted when the API does not return it.
-	JobStateCounts *buildkite.JobStateCounts `json:"job_state_counts,omitempty"`
-	ScheduledAt    *buildkite.Timestamp      `json:"scheduled_at,omitempty"`
-	StartedAt      *buildkite.Timestamp      `json:"started_at,omitempty"`
-	FinishedAt     *buildkite.Timestamp      `json:"finished_at,omitempty"`
+	JobStateCounts *FailureSummaryJobStateCounts `json:"job_state_counts,omitempty"`
+	ScheduledAt    *buildkite.Timestamp          `json:"scheduled_at,omitempty"`
+	StartedAt      *buildkite.Timestamp          `json:"started_at,omitempty"`
+	FinishedAt     *buildkite.Timestamp          `json:"finished_at,omitempty"`
 }
 
 type FailureSummaryLogEntry struct {
@@ -145,10 +153,14 @@ func boundedFailureSummaryJobs(value, configuredMax int) int {
 }
 
 func failureSummaryBuild(build buildkite.Build) BuildFailureSummaryBuild {
+	var jobStateCounts *FailureSummaryJobStateCounts
+	if build.JobStateCounts != nil {
+		jobStateCounts = &FailureSummaryJobStateCounts{JobStateCounts: *build.JobStateCounts}
+	}
 	return BuildFailureSummaryBuild{
 		BuildSummary:   summarizeBuild(build),
 		Blocked:        build.Blocked,
-		JobStateCounts: build.JobStateCounts,
+		JobStateCounts: jobStateCounts,
 		ScheduledAt:    build.ScheduledAt,
 		StartedAt:      build.StartedAt,
 		FinishedAt:     build.FinishedAt,

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -179,6 +179,7 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	require.NotNil(t, summary.Build.JobStateCounts)
 	require.Equal(t, 5, summary.Build.JobStateCounts.Total)
 	require.Equal(t, map[string]int{"passed": 2, "failed": 1, "running": 1, "broken": 1}, summary.Build.JobStateCounts.States)
+	require.Contains(t, text, `"truncated": false`)
 	require.Len(t, summary.Jobs, 3)
 	require.False(t, summary.JobsTruncated)
 


### PR DESCRIPTION
### Description

Agents calling `get_build_failure_summary` sometimes follow up with a redundant `list_jobs` call to verify the build's job state breakdown — even when the summary already contained `job_state_counts` with the complete picture. The uncertainty came from `job_state_counts` having no signal about whether the counts were complete or partial. Agents may be further misled by `jobs_truncated: true`, which indicates that we returned fewer job logs, etc. than we have because of default/specified payload limit. 

This adds `truncated: false` inside the existing `job_state_counts` object. Since the API returns a server-side tally (not a paginated list), it is always complete — and the field makes that explicit to agents reading the response.

### Context

https://linear.app/buildkite/issue/PB-3250

### Changes

- Introduced `FailureSummaryJobStateCounts` wrapping `buildkite.JobStateCounts`, adding a `Truncated bool` field that always serialises as `false`
- Updated `BuildFailureSummaryBuild.JobStateCounts` to use the new wrapper type
- `failureSummaryBuild` wraps the SDK value when present; field remains omitted when the API does not return counts

The JSON output now looks like:
```json
"job_state_counts": {
  "total": 318,
  "states": {"broken": 153, "failed": 2, "passed": 162, "waiting_failed": 1},
  "truncated": false
}
```

### Verification

- Existing tests pass (`go test ./pkg/buildkite/...`)
- No behaviour change — only an additional field in the response

### Deployment

Low risk. Additive-only change to the JSON response. No migrations, no sequencing requirements.

### Rollback

This change is safe to revert — it only adds a field to the response. Reverting removes `truncated` from `job_state_counts` with no other side effects.