### PR TITLE
Add pipeline webhook recovery tool

### DIFF
--- a/pkg/buildkite/pipelines.go
+++ b/pkg/buildkite/pipelines.go
@@ -344,6 +344,70 @@ func CreatePipeline() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineArgs, any], []
 		}, []string{"write_pipelines"}
 }
 
+type CreatePipelineWebhookArgs struct {
+	ToolInput
+	OrgSlug      string `json:"org_slug"`
+	PipelineSlug string `json:"pipeline_slug"`
+}
+
+func CreatePipelineWebhook() (mcp.Tool, mcp.ToolHandlerFor[CreatePipelineWebhookArgs, any], []string) {
+	return mcp.Tool{
+		Name:        "create_pipeline_webhook",
+		Description: "Create a GitHub webhook for an existing pipeline configured with a compatible Buildkite GitHub App",
+		Annotations: &mcp.ToolAnnotations{
+			Title:           "Create Pipeline Webhook",
+			DestructiveHint: boolPtr(false),
+		},
+	}, func(ctx context.Context, request *mcp.CallToolRequest, args CreatePipelineWebhookArgs) (*mcp.CallToolResult, any, error) {
+		ctx, span := trace.Start(ctx, "buildkite.CreatePipelineWebhook")
+		defer span.End()
+
+		span.SetAttributes(
+			attribute.String("org_slug", args.OrgSlug),
+			attribute.String("pipeline_slug", args.PipelineSlug),
+		)
+
+		deps := DepsFromContext(ctx)
+		_, err := deps.PipelinesClient.AddWebhook(ctx, args.OrgSlug, args.PipelineSlug)
+		if err == nil {
+			result := WebhookInfo{
+				Created: true,
+				Note:    "Webhook created successfully.",
+			}
+			return mcpTextResult(span, &result)
+		}
+
+		var errResp *buildkite.ErrorResponse
+		if !errors.As(err, &errResp) || errResp.Response == nil || errResp.Response.StatusCode != http.StatusUnprocessableEntity {
+			return handleBuildkiteError(err)
+		}
+
+		result := WebhookInfo{
+			Created: false,
+			Error:   err.Error(),
+		}
+		switch errResp.Message {
+		case "Auto-creating webhooks is not supported for your repository.":
+			result.Note = "The webhook could not be created automatically because the pipeline is not connected through a compatible Buildkite GitHub App."
+			result.SetupURL = fmt.Sprintf("https://buildkite.com/organizations/%s/repository-providers", args.OrgSlug)
+			result.NextSteps = []string{
+				"Open setup_url and connect a compatible Buildkite GitHub App, or grant the existing app access to this repository.",
+				fmt.Sprintf("Open https://buildkite.com/%s/%s, then open Settings > GitHub > Setup Instructions.", args.OrgSlug, args.PipelineSlug),
+			}
+		case "Webhooks could not be created for your repository.":
+			result.Note = "Buildkite could not create another webhook. A webhook may already exist; inspect the pipeline's GitHub settings before retrying."
+			result.NextSteps = []string{
+				fmt.Sprintf("Open https://buildkite.com/%s/%s, then open Settings > GitHub > Setup Instructions and verify the webhook setup.", args.OrgSlug, args.PipelineSlug),
+				"Do not retry until you have confirmed that the pipeline does not already have a GitHub webhook.",
+			}
+		default:
+			return handleBuildkiteError(err)
+		}
+
+		return mcpTextResult(span, &result)
+	}, []string{"write_pipelines"}
+}
+
 type UpdatePipelineArgs struct {
 	ToolInput
 	OrgSlug                   string   `json:"org_slug"`

--- a/pkg/buildkite/pipelines_test.go
+++ b/pkg/buildkite/pipelines_test.go
@@ -417,6 +417,121 @@ func TestCreatePipelineWithGenericWebhookError(t *testing.T) {
 	require.NotContains(t, text, `"next_steps"`)
 }
 
+func TestCreatePipelineWebhook(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "pipeline", slug)
+			return &buildkite.Response{Response: &http.Response{StatusCode: http.StatusCreated}}, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	tool, handler, scopes := CreatePipelineWebhook()
+
+	require.Equal(t, "create_pipeline_webhook", tool.Name)
+	require.Equal(t, []string{"write_pipelines"}, scopes)
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineWebhookArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := getTextResult(t, result).Text
+	requireJSONPathEqual(t, text, true, "created")
+	requireJSONPathEqual(t, text, "Webhook created successfully.", "note")
+}
+
+func TestCreatePipelineWebhookWithUnsupportedRepository(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			return nil, &buildkite.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusUnprocessableEntity,
+					Request:    httptest.NewRequest(http.MethodPost, "https://api.buildkite.com/v2/organizations/org/pipelines/pipeline/webhook", nil),
+				},
+				Message: "Auto-creating webhooks is not supported for your repository.",
+			}
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipelineWebhook()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineWebhookArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := getTextResult(t, result).Text
+	requireJSONPathEqual(t, text, false, "created")
+	requireJSONPathEqual(t, text, "https://buildkite.com/organizations/org/repository-providers", "setup_url")
+	requireJSONPathEqual(t, text, "Open setup_url and connect a compatible Buildkite GitHub App, or grant the existing app access to this repository.", "next_steps", 0)
+	requireJSONPathEqual(t, text, "Open https://buildkite.com/org/pipeline, then open Settings > GitHub > Setup Instructions.", "next_steps", 1)
+}
+
+func TestCreatePipelineWebhookWhenWebhookMayExist(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			return nil, &buildkite.ErrorResponse{
+				Response: &http.Response{
+					StatusCode: http.StatusUnprocessableEntity,
+					Request:    httptest.NewRequest(http.MethodPost, "https://api.buildkite.com/v2/organizations/org/pipelines/pipeline/webhook", nil),
+				},
+				Message: "Webhooks could not be created for your repository.",
+			}
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipelineWebhook()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineWebhookArgs{
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := getTextResult(t, result).Text
+	requireJSONPathEqual(t, text, false, "created")
+	requireJSONPathEqual(t, text, "Buildkite could not create another webhook. A webhook may already exist; inspect the pipeline's GitHub settings before retrying.", "note")
+	requireJSONPathEqual(t, text, "Do not retry until you have confirmed that the pipeline does not already have a GitHub webhook.", "next_steps", 1)
+}
+
+func TestCreatePipelineWebhookWithForbiddenError(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			return nil, &buildkite.ErrorResponse{
+				Response: &http.Response{StatusCode: http.StatusForbidden},
+				Message:  "Forbidden",
+			}
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipelineWebhook()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineWebhookArgs{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Equal(t, "Forbidden", getTextResult(t, result).Text)
+}
+
+func TestCreatePipelineWebhookWithGenericError(t *testing.T) {
+	client := &MockPipelinesClient{
+		AddWebhookFunc: func(ctx context.Context, org string, slug string) (*buildkite.Response, error) {
+			return nil, errors.New("request timed out")
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{PipelinesClient: client})
+	_, handler, _ := CreatePipelineWebhook()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), CreatePipelineWebhookArgs{})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Equal(t, "request timed out", getTextResult(t, result).Text)
+}
+
 func TestUpdatePipeline(t *testing.T) {
 	assert := require.New(t)
 

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -107,6 +107,11 @@ func TestCreatePipelineArgsSchema(t *testing.T) {
 	require.Contains(t, description, "Set false for non-GitHub repositories, centralized or manually managed webhooks")
 }
 
+func TestCreatePipelineWebhookArgsSchema(t *testing.T) {
+	req := sortedRequired[CreatePipelineWebhookArgs](t)
+	require.Equal(t, []string{"org_slug", "pipeline_slug"}, req)
+}
+
 func TestUpdatePipelineArgsSchema(t *testing.T) {
 	req := sortedRequired[UpdatePipelineArgs](t)
 	require.Equal(t, []string{"org_slug", "pipeline_slug"}, req)

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -366,6 +366,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.GetPipeline),
 				newToolDef(buildkite.ListPipelines),
 				newToolDef(buildkite.CreatePipeline),
+				newToolDef(buildkite.CreatePipelineWebhook),
 				newToolDef(buildkite.UpdatePipeline),
 				newToolDef(buildkite.ListPipelineSchedules),
 				newToolDef(buildkite.GetPipelineSchedule),

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -678,6 +678,14 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	assert.Contains(toolNames, "list_tests")
 	assert.Contains(toolNames, "list_tests_for_build")
 	assert.Contains(toolNames, "list_test_suites_for_pipeline")
+
+	pipelines, exists := registry.Get(ToolsetPipelines)
+	assert.True(exists)
+	toolNames = toolNames[:0]
+	for _, tool := range pipelines.Tools {
+		toolNames = append(toolNames, tool.Tool.Name)
+	}
+	assert.Contains(toolNames, "create_pipeline_webhook")
 }
 
 func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {


### PR DESCRIPTION
## Why

Webhook creation is currently only available as part of `create_pipeline`. If a pipeline already exists without a webhook, an MCP client cannot recover without leaving MCP or recreating the pipeline.

## What

- Add `create_pipeline_webhook` for existing GitHub pipelines.
- Return actionable setup guidance when the repository lacks a compatible GitHub App connection.
- Warn when Buildkite’s response indicates a webhook may already exist, avoiding blind retries.
- Preserve standard handling for permission and unexpected API errors.

This is stacked on #400, which makes webhook creation explicit and recoverable during initial pipeline creation.

Related to [PB-2391](https://linear.app/buildkite/issue/PB-2391/onboarding-papercut-quick-win-agent-created-pipeline-never-triggers).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>