### PR TITLE
Te 6840 add execution trace tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/alecthomas/kong v1.16.1
 	github.com/buildkite/buildkite-logs v0.13.1
-	github.com/buildkite/go-buildkite/v5 v5.15.0
+	github.com/buildkite/go-buildkite/v5 v5.16.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/buildkite-logs v0.13.1 h1:KIdVP0OisatvZ6XA2123r/aQlQcdPMfHPyVzhwAwj1Y=
 github.com/buildkite/buildkite-logs v0.13.1/go.mod h1:lgSJ08tjx8Y63d/WLz5sO8jmobRoNslLkyy2SosDl3U=
-github.com/buildkite/go-buildkite/v5 v5.15.0 h1:ae9F3FBvf8UEXYY7jXkaUyVt2PddH+QrifsGuY4ltzc=
-github.com/buildkite/go-buildkite/v5 v5.15.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
+github.com/buildkite/go-buildkite/v5 v5.16.0 h1:vmZJeyq9MPnG8SJQuYQvlA+MexY5uUR/0ylLjxjhIEQ=
+github.com/buildkite/go-buildkite/v5 v5.16.0/go.mod h1:a5uCFNQjMFxT7g4H4NDId+DRkfYBo+CqvryoDZRppPk=
 github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
 github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/internal/commands/http.go
+++ b/internal/commands/http.go
@@ -45,6 +45,7 @@ func (c *HTTPCmd) Run(ctx context.Context, globals *Globals) error {
 		TestRunsClient:          globals.Client.TestRuns,
 		TestSuitesClient:        globals.Client.TestSuites,
 		TestExecutionsClient:    globals.Client.TestRuns,
+		ExecutionTraceClient:    globals.Client.Executions,
 		TestsClient:             globals.Client.Tests,
 		BuildTestsClient:        globals.Client.BuildTests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,

--- a/internal/commands/stdio.go
+++ b/internal/commands/stdio.go
@@ -38,6 +38,7 @@ func (c *StdioCmd) Run(ctx context.Context, globals *Globals) error {
 		TestRunsClient:          globals.Client.TestRuns,
 		TestSuitesClient:        globals.Client.TestSuites,
 		TestExecutionsClient:    globals.Client.TestRuns,
+		ExecutionTraceClient:    globals.Client.Executions,
 		TestsClient:             globals.Client.Tests,
 		BuildTestsClient:        globals.Client.BuildTests,
 		BuildkiteLogsClient:     globals.BuildkiteLogsClient,

--- a/pkg/buildkite/dependencies.go
+++ b/pkg/buildkite/dependencies.go
@@ -30,6 +30,7 @@ type ToolDependencies struct {
 	TestRunsClient          TestRunsClient
 	TestSuitesClient        TestSuitesClient
 	TestExecutionsClient    TestExecutionsClient
+	ExecutionTraceClient    ExecutionTraceClient
 	TestsClient             TestsClient
 	BuildTestsClient        BuildTestsClient
 	BuildkiteLogsClient     BuildkiteLogsClient

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -79,8 +79,7 @@ func TestGetBuildArgsSchema(t *testing.T) {
 func TestReadExecutionTraceArgsSchema(t *testing.T) {
 	s := schemaFor[ReadExecutionTraceArgs](t)
 	require.Equal(t, []string{"execution_id", "org_slug", "test_suite_slug"}, sortedToolRequired(t, s))
-	require.Equal(t, "Trace view: 'summary' (default) or 'full'", s.Properties["view"].Description)
-	require.NotContains(t, s.Required, "view")
+	require.NotContains(t, s.Properties, "view")
 }
 
 func TestWaitForBuildArgsSchema(t *testing.T) {

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -76,6 +76,13 @@ func TestGetBuildArgsSchema(t *testing.T) {
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)
 }
 
+func TestReadExecutionTraceArgsSchema(t *testing.T) {
+	s := schemaFor[ReadExecutionTraceArgs](t)
+	require.Equal(t, []string{"execution_id", "org_slug", "test_suite_slug"}, sortedToolRequired(t, s))
+	require.Equal(t, "Trace view: 'summary' (default) or 'full'", s.Properties["view"].Description)
+	require.NotContains(t, s.Required, "view")
+}
+
 func TestWaitForBuildArgsSchema(t *testing.T) {
 	req := sortedRequired[WaitForBuildArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, req)

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
 	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
@@ -9,6 +10,8 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 )
+
+const executionTraceContentByteLimit = 256 * 1024
 
 type TestExecutionsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
@@ -18,12 +21,64 @@ type ExecutionTraceClient interface {
 	GetTrace(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error)
 }
 
+type executionTraceResult struct {
+	buildkite.ExecutionTrace
+	ContentBytes      int  `json:"content_bytes"`
+	ContentLimitBytes int  `json:"content_limit_bytes"`
+	ContentTruncated  bool `json:"content_truncated,omitempty"`
+}
+
 type ReadExecutionTraceArgs struct {
 	ToolInput
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	ExecutionID   string `json:"execution_id"`
 	View          string `json:"view,omitempty" jsonschema:"Trace view: 'summary' (default) or 'full'"`
+}
+
+func limitExecutionTraceSpans(result *executionTraceResult, limit int) error {
+	payload, err := marshalSanitizedJSON(result)
+	if err != nil {
+		return err
+	}
+	floor, err := payloadStructureBytes(payload, limit)
+	if err != nil {
+		return err
+	}
+	if floor <= limit {
+		return nil
+	}
+
+	spans := result.Spans
+	low, high := 0, len(spans)
+	var best *executionTraceResult
+	for low <= high {
+		mid := low + (high-low)/2
+		candidate := *result
+		candidate.Spans = spans[:mid]
+		candidate.ContentTruncated = mid < len(spans)
+
+		payload, err := marshalSanitizedJSON(&candidate)
+		if err != nil {
+			return err
+		}
+		floor, err := payloadStructureBytes(payload, limit)
+		if err != nil {
+			return err
+		}
+		if floor <= limit {
+			best = &candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if best == nil {
+		return fmt.Errorf("trace metadata exceeds %d byte limit", limit)
+	}
+
+	*result = *best
+	return nil
 }
 
 func ReadExecutionTrace() (mcp.Tool, mcp.ToolHandlerFor[ReadExecutionTraceArgs, any], []string) {
@@ -61,7 +116,15 @@ func ReadExecutionTrace() (mcp.Tool, mcp.ToolHandlerFor[ReadExecutionTraceArgs, 
 				return handleBuildkiteError(err)
 			}
 
-			return mcpTextResult(span, &executionTrace)
+			result := executionTraceResult{
+				ExecutionTrace:    executionTrace,
+				ContentLimitBytes: executionTraceContentByteLimit,
+			}
+			if err := limitExecutionTraceSpans(&result, executionTraceContentByteLimit); err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to limit execution trace: %v", err)), nil, nil
+			}
+
+			return mcpTextResultWithByteLimit(span, &result, executionTraceContentByteLimit)
 		}, []string{"read_suites"}
 }
 

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -2,16 +2,12 @@ package buildkite
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
-	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
 )
-
-const executionTraceContentByteLimit = 256 * 1024
 
 type TestExecutionsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
@@ -21,70 +17,17 @@ type ExecutionTraceClient interface {
 	GetTrace(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error)
 }
 
-type executionTraceResult struct {
-	buildkite.ExecutionTrace
-	ContentBytes      int  `json:"content_bytes"`
-	ContentLimitBytes int  `json:"content_limit_bytes"`
-	ContentTruncated  bool `json:"content_truncated,omitempty"`
-}
-
 type ReadExecutionTraceArgs struct {
 	ToolInput
 	OrgSlug       string `json:"org_slug"`
 	TestSuiteSlug string `json:"test_suite_slug"`
 	ExecutionID   string `json:"execution_id"`
-	View          string `json:"view,omitempty" jsonschema:"Trace view: 'summary' (default) or 'full'"`
-}
-
-func limitExecutionTraceSpans(result *executionTraceResult, limit int) error {
-	payload, err := marshalSanitizedJSON(result)
-	if err != nil {
-		return err
-	}
-	floor, err := payloadStructureBytes(payload, limit)
-	if err != nil {
-		return err
-	}
-	if floor <= limit {
-		return nil
-	}
-
-	spans := result.Spans
-	low, high := 0, len(spans)
-	var best *executionTraceResult
-	for low <= high {
-		mid := low + (high-low)/2
-		candidate := *result
-		candidate.Spans = spans[:mid]
-		candidate.ContentTruncated = mid < len(spans)
-
-		payload, err := marshalSanitizedJSON(&candidate)
-		if err != nil {
-			return err
-		}
-		floor, err := payloadStructureBytes(payload, limit)
-		if err != nil {
-			return err
-		}
-		if floor <= limit {
-			best = &candidate
-			low = mid + 1
-		} else {
-			high = mid - 1
-		}
-	}
-	if best == nil {
-		return fmt.Errorf("trace metadata exceeds %d byte limit", limit)
-	}
-
-	*result = *best
-	return nil
 }
 
 func ReadExecutionTrace() (mcp.Tool, mcp.ToolHandlerFor[ReadExecutionTraceArgs, any], []string) {
 	return mcp.Tool{
 			Name:        "read_execution_trace",
-			Description: "Read the OpenTelemetry trace for a Buildkite Test Engine execution. The summary view returns category rollups and slowest spans; the full view also returns the span list",
+			Description: "Read an OpenTelemetry trace summary for a Buildkite Test Engine execution, including category rollups and slowest spans",
 			Annotations: &mcp.ToolAnnotations{
 				Title:        "Read Execution Trace",
 				ReadOnlyHint: true,
@@ -94,37 +37,21 @@ func ReadExecutionTrace() (mcp.Tool, mcp.ToolHandlerFor[ReadExecutionTraceArgs, 
 			ctx, span := trace.Start(ctx, "buildkite.ReadExecutionTrace")
 			defer span.End()
 
-			if args.View == "" {
-				args.View = string(buildkite.TraceViewSummary)
-			}
-			if args.View != string(buildkite.TraceViewSummary) && args.View != string(buildkite.TraceViewFull) {
-				return utils.NewToolResultError("view must be 'summary' or 'full'"), nil, nil
-			}
-
 			span.SetAttributes(
 				attribute.String("org_slug", args.OrgSlug),
 				attribute.String("test_suite_slug", args.TestSuiteSlug),
 				attribute.String("execution_id", args.ExecutionID),
-				attribute.String("view", args.View),
 			)
 
 			deps := DepsFromContext(ctx)
 			executionTrace, _, err := deps.ExecutionTraceClient.GetTrace(ctx, args.OrgSlug, args.TestSuiteSlug, args.ExecutionID, &buildkite.ExecutionTraceOptions{
-				View: buildkite.TraceView(args.View),
+				View: buildkite.TraceViewSummary,
 			})
 			if err != nil {
 				return handleBuildkiteError(err)
 			}
 
-			result := executionTraceResult{
-				ExecutionTrace:    executionTrace,
-				ContentLimitBytes: executionTraceContentByteLimit,
-			}
-			if err := limitExecutionTraceSpans(&result, executionTraceContentByteLimit); err != nil {
-				return utils.NewToolResultError(fmt.Sprintf("failed to limit execution trace: %v", err)), nil, nil
-			}
-
-			return mcpTextResultWithByteLimit(span, &result, executionTraceContentByteLimit)
+			return mcpTextResult(span, &executionTrace)
 		}, []string{"read_suites"}
 }
 

--- a/pkg/buildkite/test_executions.go
+++ b/pkg/buildkite/test_executions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
 	"github.com/buildkite/go-buildkite/v5"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"go.opentelemetry.io/otel/attribute"
@@ -11,6 +12,57 @@ import (
 
 type TestExecutionsClient interface {
 	GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
+}
+
+type ExecutionTraceClient interface {
+	GetTrace(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error)
+}
+
+type ReadExecutionTraceArgs struct {
+	ToolInput
+	OrgSlug       string `json:"org_slug"`
+	TestSuiteSlug string `json:"test_suite_slug"`
+	ExecutionID   string `json:"execution_id"`
+	View          string `json:"view,omitempty" jsonschema:"Trace view: 'summary' (default) or 'full'"`
+}
+
+func ReadExecutionTrace() (mcp.Tool, mcp.ToolHandlerFor[ReadExecutionTraceArgs, any], []string) {
+	return mcp.Tool{
+			Name:        "read_execution_trace",
+			Description: "Read the OpenTelemetry trace for a Buildkite Test Engine execution. The summary view returns category rollups and slowest spans; the full view also returns the span list",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Read Execution Trace",
+				ReadOnlyHint: true,
+			},
+		},
+		func(ctx context.Context, request *mcp.CallToolRequest, args ReadExecutionTraceArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.ReadExecutionTrace")
+			defer span.End()
+
+			if args.View == "" {
+				args.View = string(buildkite.TraceViewSummary)
+			}
+			if args.View != string(buildkite.TraceViewSummary) && args.View != string(buildkite.TraceViewFull) {
+				return utils.NewToolResultError("view must be 'summary' or 'full'"), nil, nil
+			}
+
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("test_suite_slug", args.TestSuiteSlug),
+				attribute.String("execution_id", args.ExecutionID),
+				attribute.String("view", args.View),
+			)
+
+			deps := DepsFromContext(ctx)
+			executionTrace, _, err := deps.ExecutionTraceClient.GetTrace(ctx, args.OrgSlug, args.TestSuiteSlug, args.ExecutionID, &buildkite.ExecutionTraceOptions{
+				View: buildkite.TraceView(args.View),
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
+
+			return mcpTextResult(span, &executionTrace)
+		}, []string{"read_suites"}
 }
 
 type GetFailedTestExecutionsArgs struct {

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -118,6 +119,55 @@ func TestReadExecutionTraceWithError(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "API error")
+}
+
+func TestReadExecutionTraceBoundsFullView(t *testing.T) {
+	spans := make([]buildkite.TraceSpan, 2_000)
+	for i := range spans {
+		spans[i] = buildkite.TraceSpan{
+			SpanID:        fmt.Sprintf("span-%d", i),
+			ParentSpanID:  "parent",
+			Name:          "short span name",
+			Kind:          "internal",
+			ServiceName:   "service",
+			ScopeName:     "instrumentation",
+			Category:      buildkite.TraceCategoryOther,
+			Badge:         "OTHER",
+			Label:         "span label",
+			Detail:        "span detail",
+			Duration:      1,
+			SelfTime:      1,
+			Error:         true,
+			StatusMessage: "error status",
+		}
+	}
+
+	client := &MockExecutionTraceClient{
+		GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
+			return buildkite.ExecutionTrace{
+				ExecutionID: "execution",
+				View:        buildkite.TraceViewFull,
+				SpanCount:   len(spans),
+				Spans:       spans,
+			}, nil, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
+	_, handler, _ := ReadExecutionTrace()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "full"})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	text := result.Content[0].(*mcp.TextContent).Text
+	require.LessOrEqual(t, len(text), executionTraceContentByteLimit)
+
+	var traceResult executionTraceResult
+	require.NoError(t, json.Unmarshal([]byte(text), &traceResult))
+	require.True(t, traceResult.ContentTruncated)
+	require.Equal(t, executionTraceContentByteLimit, traceResult.ContentLimitBytes)
+	require.Equal(t, len(text), traceResult.ContentBytes)
+	require.Equal(t, len(spans), traceResult.SpanCount)
+	require.Less(t, len(traceResult.Spans), len(spans))
 }
 
 func TestGetFailedExecutions(t *testing.T) {

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,72 +37,42 @@ func (m *MockExecutionTraceClient) GetTrace(ctx context.Context, org, slug, exec
 var _ ExecutionTraceClient = (*MockExecutionTraceClient)(nil)
 
 func TestReadExecutionTrace(t *testing.T) {
-	for _, test := range []struct {
-		name     string
-		view     string
-		wantView buildkite.TraceView
-	}{
-		{name: "defaults to summary", wantView: buildkite.TraceViewSummary},
-		{name: "requests full trace", view: "full", wantView: buildkite.TraceViewFull},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			client := &MockExecutionTraceClient{
-				GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
-					require.Equal(t, "org", org)
-					require.Equal(t, "suite", slug)
-					require.Equal(t, "execution", executionID)
-					require.Equal(t, test.wantView, opt.View)
-
-					return buildkite.ExecutionTrace{
-						ExecutionID: "execution",
-						TraceID:     "trace",
-						View:        test.wantView,
-						SpanCount:   2,
-						SlowestSpans: []buildkite.TraceSpan{
-							{Name: "SELECT users", Category: buildkite.TraceCategorySQL},
-						},
-					}, nil, nil
-				},
-			}
-			ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
-			tool, handler, scopes := ReadExecutionTrace()
-
-			require.Equal(t, "read_execution_trace", tool.Name)
-			require.True(t, tool.Annotations.ReadOnlyHint)
-			require.Equal(t, []string{"read_suites"}, scopes)
-
-			result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{
-				OrgSlug:       "org",
-				TestSuiteSlug: "suite",
-				ExecutionID:   "execution",
-				View:          test.view,
-			})
-			require.NoError(t, err)
-			require.False(t, result.IsError)
-			text := result.Content[0].(*mcp.TextContent).Text
-			requireJSONPathEqual(t, text, "execution", "execution_id")
-			requireJSONPathEqual(t, text, string(test.wantView), "view")
-			require.Contains(t, text, "SELECT users")
-		})
-	}
-}
-
-func TestReadExecutionTraceRejectsInvalidView(t *testing.T) {
-	called := false
 	client := &MockExecutionTraceClient{
 		GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
-			called = true
-			return buildkite.ExecutionTrace{}, nil, nil
+			require.Equal(t, "org", org)
+			require.Equal(t, "suite", slug)
+			require.Equal(t, "execution", executionID)
+			require.Equal(t, buildkite.TraceViewSummary, opt.View)
+
+			return buildkite.ExecutionTrace{
+				ExecutionID: "execution",
+				TraceID:     "trace",
+				View:        buildkite.TraceViewSummary,
+				SpanCount:   2,
+				SlowestSpans: []buildkite.TraceSpan{
+					{Name: "SELECT users", Category: buildkite.TraceCategorySQL},
+				},
+			}, nil, nil
 		},
 	}
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
-	_, handler, _ := ReadExecutionTrace()
+	tool, handler, scopes := ReadExecutionTrace()
 
-	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "compact"})
+	require.Equal(t, "read_execution_trace", tool.Name)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.Equal(t, []string{"read_suites"}, scopes)
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{
+		OrgSlug:       "org",
+		TestSuiteSlug: "suite",
+		ExecutionID:   "execution",
+	})
 	require.NoError(t, err)
-	require.True(t, result.IsError)
-	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "view must be 'summary' or 'full'")
-	require.False(t, called)
+	require.False(t, result.IsError)
+	text := result.Content[0].(*mcp.TextContent).Text
+	requireJSONPathEqual(t, text, "execution", "execution_id")
+	requireJSONPathEqual(t, text, string(buildkite.TraceViewSummary), "view")
+	require.Contains(t, text, "SELECT users")
 }
 
 func TestReadExecutionTraceWithError(t *testing.T) {
@@ -115,59 +84,10 @@ func TestReadExecutionTraceWithError(t *testing.T) {
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
 	_, handler, _ := ReadExecutionTrace()
 
-	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "summary"})
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{})
 	require.NoError(t, err)
 	require.True(t, result.IsError)
 	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "API error")
-}
-
-func TestReadExecutionTraceBoundsFullView(t *testing.T) {
-	spans := make([]buildkite.TraceSpan, 2_000)
-	for i := range spans {
-		spans[i] = buildkite.TraceSpan{
-			SpanID:        fmt.Sprintf("span-%d", i),
-			ParentSpanID:  "parent",
-			Name:          "short span name",
-			Kind:          "internal",
-			ServiceName:   "service",
-			ScopeName:     "instrumentation",
-			Category:      buildkite.TraceCategoryOther,
-			Badge:         "OTHER",
-			Label:         "span label",
-			Detail:        "span detail",
-			Duration:      1,
-			SelfTime:      1,
-			Error:         true,
-			StatusMessage: "error status",
-		}
-	}
-
-	client := &MockExecutionTraceClient{
-		GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
-			return buildkite.ExecutionTrace{
-				ExecutionID: "execution",
-				View:        buildkite.TraceViewFull,
-				SpanCount:   len(spans),
-				Spans:       spans,
-			}, nil, nil
-		},
-	}
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
-	_, handler, _ := ReadExecutionTrace()
-
-	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "full"})
-	require.NoError(t, err)
-	require.False(t, result.IsError)
-	text := result.Content[0].(*mcp.TextContent).Text
-	require.LessOrEqual(t, len(text), executionTraceContentByteLimit)
-
-	var traceResult executionTraceResult
-	require.NoError(t, json.Unmarshal([]byte(text), &traceResult))
-	require.True(t, traceResult.ContentTruncated)
-	require.Equal(t, executionTraceContentByteLimit, traceResult.ContentLimitBytes)
-	require.Equal(t, len(text), traceResult.ContentBytes)
-	require.Equal(t, len(spans), traceResult.SpanCount)
-	require.Less(t, len(traceResult.Spans), len(spans))
 }
 
 func TestGetFailedExecutions(t *testing.T) {

--- a/pkg/buildkite/test_executions_test.go
+++ b/pkg/buildkite/test_executions_test.go
@@ -17,6 +17,10 @@ type MockTestExecutionsClient struct {
 	GetFailedExecutionsFunc func(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error)
 }
 
+type MockExecutionTraceClient struct {
+	GetTraceFunc func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error)
+}
+
 func (m *MockTestExecutionsClient) GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
 	if m.GetFailedExecutionsFunc != nil {
 		return m.GetFailedExecutionsFunc(ctx, org, slug, runID, opt)
@@ -25,6 +29,96 @@ func (m *MockTestExecutionsClient) GetFailedExecutions(ctx context.Context, org,
 }
 
 var _ TestExecutionsClient = (*MockTestExecutionsClient)(nil)
+
+func (m *MockExecutionTraceClient) GetTrace(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
+	return m.GetTraceFunc(ctx, org, slug, executionID, opt)
+}
+
+var _ ExecutionTraceClient = (*MockExecutionTraceClient)(nil)
+
+func TestReadExecutionTrace(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		view     string
+		wantView buildkite.TraceView
+	}{
+		{name: "defaults to summary", wantView: buildkite.TraceViewSummary},
+		{name: "requests full trace", view: "full", wantView: buildkite.TraceViewFull},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &MockExecutionTraceClient{
+				GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
+					require.Equal(t, "org", org)
+					require.Equal(t, "suite", slug)
+					require.Equal(t, "execution", executionID)
+					require.Equal(t, test.wantView, opt.View)
+
+					return buildkite.ExecutionTrace{
+						ExecutionID: "execution",
+						TraceID:     "trace",
+						View:        test.wantView,
+						SpanCount:   2,
+						SlowestSpans: []buildkite.TraceSpan{
+							{Name: "SELECT users", Category: buildkite.TraceCategorySQL},
+						},
+					}, nil, nil
+				},
+			}
+			ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
+			tool, handler, scopes := ReadExecutionTrace()
+
+			require.Equal(t, "read_execution_trace", tool.Name)
+			require.True(t, tool.Annotations.ReadOnlyHint)
+			require.Equal(t, []string{"read_suites"}, scopes)
+
+			result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{
+				OrgSlug:       "org",
+				TestSuiteSlug: "suite",
+				ExecutionID:   "execution",
+				View:          test.view,
+			})
+			require.NoError(t, err)
+			require.False(t, result.IsError)
+			text := result.Content[0].(*mcp.TextContent).Text
+			requireJSONPathEqual(t, text, "execution", "execution_id")
+			requireJSONPathEqual(t, text, string(test.wantView), "view")
+			require.Contains(t, text, "SELECT users")
+		})
+	}
+}
+
+func TestReadExecutionTraceRejectsInvalidView(t *testing.T) {
+	called := false
+	client := &MockExecutionTraceClient{
+		GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
+			called = true
+			return buildkite.ExecutionTrace{}, nil, nil
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
+	_, handler, _ := ReadExecutionTrace()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "compact"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "view must be 'summary' or 'full'")
+	require.False(t, called)
+}
+
+func TestReadExecutionTraceWithError(t *testing.T) {
+	client := &MockExecutionTraceClient{
+		GetTraceFunc: func(ctx context.Context, org, slug, executionID string, opt *buildkite.ExecutionTraceOptions) (buildkite.ExecutionTrace, *buildkite.Response, error) {
+			return buildkite.ExecutionTrace{}, nil, fmt.Errorf("API error")
+		},
+	}
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{ExecutionTraceClient: client})
+	_, handler, _ := ReadExecutionTrace()
+
+	result, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), ReadExecutionTraceArgs{View: "summary"})
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	require.Contains(t, result.Content[0].(*mcp.TextContent).Text, "API error")
+}
 
 func TestGetFailedExecutions(t *testing.T) {
 	assert := require.New(t)

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -411,6 +411,7 @@ func CreateBuiltinToolsets() map[string]Toolset {
 				newToolDef(buildkite.ListTestRuns),
 				newToolDef(buildkite.GetTestRun),
 				newToolDef(buildkite.GetFailedTestExecutions),
+				newToolDef(buildkite.ReadExecutionTrace),
 				newToolDef(buildkite.GetTest),
 				newToolDef(buildkite.ListTestSuitesForPipeline),
 			},

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -678,6 +678,7 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 	assert.Contains(toolNames, "list_tests")
 	assert.Contains(toolNames, "list_tests_for_build")
 	assert.Contains(toolNames, "list_test_suites_for_pipeline")
+	assert.Contains(toolNames, "read_execution_trace")
 }
 
 func TestBuiltinToolSchemasRequireTelemetryContext(t *testing.T) {


### PR DESCRIPTION
Adds a `read_execution_trace` tool to fetch OTel span data for a given Test Engine execution record.