### PR TITLE
Add a tool for comparing builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The response identifies the baseline and selection rule, counts outcomes across 
 
 Execution times and deltas cover final attempts only. Scheduling time is `scheduled_at` to `started_at`, not dependency or manual waiting. These are not build wall-clock comparisons or total retry costs. Missing or inconsistent timestamps omit the corresponding timing. Unfinished builds are explicitly identified as changing snapshots.
 
-By default, up to three newly failing jobs include their last 20 log entries, bounded to 8 KiB of log content each. Set `include_logs: false` to omit logs. Log errors do not discard the comparison. The tool requires `read_builds` and `read_build_logs` scopes. Use `get_build_failure_summary` or `tail_logs` to investigate further; a shared failing step does not establish a shared root cause or make a retry safe.
+Transitions between soft and hard failures are reported as `state_changed`, even when both jobs have state `failed`. A passed baseline build can contain soft-failed jobs.
+
+By default, up to three newly failing jobs include their last 20 log entries, bounded to 8 KiB of log content each. Set `include_logs: false` to omit logs. Log errors do not discard the comparison, except HTTP 401 authentication errors, which propagate through the server's reauthentication path. The tool requires `read_builds` and `read_build_logs` scopes. Use `get_build_failure_summary` or `tail_logs` to investigate further; a shared failing step does not establish a shared root cause or make a retry safe.
 
 Baseline discovery searches at most 500 candidates. If none is found, the response says no comparison was performed and asks for an explicit baseline. Job inventories are limited to 1,000 jobs per build; larger inventories return an error instead of misleading partial added/removed results. Output omissions are reported separately from the complete outcome counts.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ Full documentation is available at [buildkite.com/docs/apis/mcp-server](https://
 
 ---
 
+## Comparing builds
+
+The read-only `compare_builds` tool in the `investigations` toolset answers questions such as “What changed since this build last worked on main?” Supply `org_slug`, `pipeline_slug`, and the target `build_number`. It selects the most recently created earlier build that is currently passed on the same pipeline and exact branch. It does not require that the baseline had already passed when the target started. Supply `baseline_build_number` to compare against a specific build in that pipeline instead, including a failed build or one on another branch.
+
+The response identifies the baseline and selection rule, counts outcomes across all jobs, and returns up to 100 job comparisons, prioritizing newly failing, recovered, and still-failing steps. Matching uses step keys, job type, matrix values, and parallel index/total. When both jobs lack keys, it falls back to the exact nonblank name plus type, group key, matrix values, and parallel index/total, only when that combination is unique in each build. Matched pairs expose `match_method: "step_key"` or `"name_fallback"`; fallback matches carry a warning that they are heuristic. Unnamed unkeyed jobs and duplicate identities remain unmatched. Explicit keys never fall back to names, even when a key was added, removed, or changed between builds. Added/removed means a job identity is present in only one build, so renaming unkeyed jobs or changing matrix values or parallelism can also produce added/removed entries. Retried attempts are excluded; final-attempt states and retry counts remain visible.
+
+Execution times and deltas cover final attempts only. Scheduling time is `scheduled_at` to `started_at`, not dependency or manual waiting. These are not build wall-clock comparisons or total retry costs. Missing or inconsistent timestamps omit the corresponding timing. Unfinished builds are explicitly identified as changing snapshots.
+
+By default, up to three newly failing jobs include their last 20 log entries, bounded to 8 KiB of log content each. Set `include_logs: false` to omit logs. Log errors do not discard the comparison. The tool requires `read_builds` and `read_build_logs` scopes. Use `get_build_failure_summary` or `tail_logs` to investigate further; a shared failing step does not establish a shared root cause or make a retry safe.
+
+Baseline discovery searches at most 500 candidates. If none is found, the response says no comparison was performed and asks for an explicit baseline. Job inventories are limited to 1,000 jobs per build; larger inventories return an error instead of misleading partial added/removed results. Output omissions are reported separately from the complete outcome counts.
+
+---
+
 ## Library Usage
 
 The exported Go API of this module should be considered unstable, and subject to breaking changes as we evolve this project.

--- a/pkg/buildkite/compare_builds.go
+++ b/pkg/buildkite/compare_builds.go
@@ -124,9 +124,11 @@ func compareJobOutcomes(target, baseline *ComparisonJob) string {
 		return "newly_failing"
 	case target.State == "passed" && comparisonFailed(baseline):
 		return "recovered"
+	case target.SoftFailed != baseline.SoftFailed:
+		return "state_changed"
 	case comparisonFailed(target) && comparisonFailed(baseline):
 		return "still_failing"
-	case target.State != baseline.State || target.SoftFailed != baseline.SoftFailed:
+	case target.State != baseline.State:
 		return "state_changed"
 	case target.RetriesCount != baseline.RetriesCount:
 		return "retries_changed"
@@ -352,6 +354,9 @@ func CompareBuilds() (mcp.Tool, mcp.ToolHandlerFor[CompareBuildsArgs, any], []st
 				entries, _, truncated, contentTruncated, _, logErr := readFailureLogTail(ctx, deps.BuildkiteLogsClient,
 					GetBuildFailureSummaryArgs{OrgSlug: args.OrgSlug, PipelineSlug: args.PipelineSlug, BuildNumber: args.BuildNumber}, buildkite.Job{ID: step.Target.ID}, 20)
 				if logErr != nil {
+					if isBuildkiteUnauthorized(logErr) {
+						return nil, nil, ErrUnauthorized
+					}
 					step.Target.LogError = logErr.Error()
 					continue
 				}

--- a/pkg/buildkite/compare_builds.go
+++ b/pkg/buildkite/compare_builds.go
@@ -1,0 +1,364 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/buildkite/buildkite-mcp-server/pkg/trace"
+	"github.com/buildkite/buildkite-mcp-server/pkg/utils"
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const comparisonJobPages = 10
+const comparisonResultLimit = 100
+
+type CompareBuildsArgs struct {
+	ToolInput
+	OrgSlug             string `json:"org_slug"`
+	PipelineSlug        string `json:"pipeline_slug"`
+	BuildNumber         string `json:"build_number" jsonschema:"Target build number, not a UUID"`
+	BaselineBuildNumber string `json:"baseline_build_number,omitempty" jsonschema:"Baseline in the same pipeline. Omit to select the most recently created earlier successful build on the target branch (at most 500 candidates searched)."`
+	IncludeLogs         *bool  `json:"include_logs,omitempty" jsonschema:"Include bounded target log tails for up to three newly failing jobs (default true)"`
+}
+
+// ComparisonJob describes the final attempt, not the sum of all retry attempts.
+type ComparisonJob struct {
+	ID                string                   `json:"id"`
+	Name              string                   `json:"name"`
+	State             string                   `json:"state"`
+	SoftFailed        bool                     `json:"soft_failed,omitempty"`
+	ExitStatus        *int                     `json:"exit_status,omitempty"`
+	SignalReason      string                   `json:"signal_reason,omitempty"`
+	RetriesCount      int                      `json:"retries_count"`
+	WebURL            string                   `json:"web_url"`
+	ExecutionSeconds  *float64                 `json:"execution_seconds,omitempty"`
+	SchedulingSeconds *float64                 `json:"scheduling_seconds,omitempty"`
+	LogTail           []FailureSummaryLogEntry `json:"log_tail,omitempty"`
+	LogTruncated      bool                     `json:"log_truncated,omitempty"`
+	LogError          string                   `json:"log_error,omitempty"`
+}
+
+type BuildStepComparison struct {
+	Change                string         `json:"change"`
+	MatchMethod           string         `json:"match_method,omitempty"`
+	StepKey               string         `json:"step_key,omitempty"`
+	Matrix                any            `json:"matrix,omitempty"`
+	ParallelIndex         *int           `json:"parallel_index,omitempty"`
+	ParallelTotal         *int           `json:"parallel_total,omitempty"`
+	UnmatchedReason       string         `json:"unmatched_reason,omitempty"`
+	Target                *ComparisonJob `json:"target,omitempty"`
+	Baseline              *ComparisonJob `json:"baseline,omitempty"`
+	ExecutionDeltaSeconds *float64       `json:"execution_delta_seconds,omitempty"`
+}
+
+type BuildComparison struct {
+	Target            BuildSummary          `json:"target"`
+	Baseline          *BuildSummary         `json:"baseline,omitempty"`
+	BaselineSelection string                `json:"baseline_selection"`
+	CandidatesScanned int                   `json:"candidates_scanned"`
+	TargetJobs        int                   `json:"target_jobs"`
+	BaselineJobs      int                   `json:"baseline_jobs"`
+	ChangeCounts      map[string]int        `json:"change_counts"`
+	Steps             []BuildStepComparison `json:"steps"`
+	StepsOmitted      int                   `json:"steps_omitted"`
+	Warnings          []string              `json:"warnings,omitempty"`
+}
+
+func comparisonDuration(start, end *buildkite.Timestamp) *float64 {
+	if start == nil || end == nil || end.Before(start.Time) {
+		return nil
+	}
+	seconds := end.Sub(start.Time).Seconds()
+	return &seconds
+}
+
+func comparisonJob(job buildkite.Job, build BuildSummary) *ComparisonJob {
+	webURL := job.WebURL
+	if webURL == "" && job.Step != nil && job.Step.ID != "" {
+		webURL = fmt.Sprintf("%s/list?sid=%s&tab=output", build.WebURL, job.Step.ID)
+	}
+	return &ComparisonJob{
+		ID: job.ID, Name: job.Name, State: job.State, SoftFailed: job.SoftFailed,
+		ExitStatus: job.ExitStatus, SignalReason: job.SignalReason, RetriesCount: job.RetriesCount,
+		WebURL:            webURL,
+		ExecutionSeconds:  comparisonDuration(job.StartedAt, job.FinishedAt),
+		SchedulingSeconds: comparisonDuration(job.ScheduledAt, job.StartedAt),
+	}
+}
+
+// Unkeyed jobs use exact names within their group and execution coordinates.
+// The caller rejects duplicate identities on either side before matching.
+// Separate namespaces prevent a name from matching an explicit step key.
+func comparisonIdentity(job buildkite.Job) string {
+	method, identifier, group := "step_key", job.StepKey, ""
+	if identifier == "" {
+		if strings.TrimSpace(job.Name) == "" {
+			return ""
+		}
+		method, identifier, group = "name_fallback", job.Name, job.GroupKey
+	}
+	identity, err := json.Marshal([]any{method, identifier, group, job.Type, job.Matrix, job.ParallelGroupIndex, job.ParallelGroupTotal})
+	if err != nil {
+		return ""
+	}
+	return string(identity)
+}
+
+func comparisonFailed(job *ComparisonJob) bool {
+	return job != nil && (job.State == "failed" || job.State == "timed_out" || job.State == "expired")
+}
+
+func compareJobOutcomes(target, baseline *ComparisonJob) string {
+	switch {
+	case baseline == nil:
+		return "added"
+	case target == nil:
+		return "removed"
+	case comparisonFailed(target) && baseline.State == "passed":
+		return "newly_failing"
+	case target.State == "passed" && comparisonFailed(baseline):
+		return "recovered"
+	case comparisonFailed(target) && comparisonFailed(baseline):
+		return "still_failing"
+	case target.State != baseline.State || target.SoftFailed != baseline.SoftFailed:
+		return "state_changed"
+	case target.RetriesCount != baseline.RetriesCount:
+		return "retries_changed"
+	default:
+		return "unchanged"
+	}
+}
+
+func compareBuildJobs(target, baseline []buildkite.Job, result *BuildComparison) {
+	targetByKey, baselineByKey := map[string][]buildkite.Job{}, map[string][]buildkite.Job{}
+	for _, job := range target {
+		targetByKey[comparisonIdentity(job)] = append(targetByKey[comparisonIdentity(job)], job)
+	}
+	for _, job := range baseline {
+		baselineByKey[comparisonIdentity(job)] = append(baselineByKey[comparisonIdentity(job)], job)
+	}
+	usedFallback := false
+	appendStep := func(job buildkite.Job, t, b *ComparisonJob, reason string) {
+		step := BuildStepComparison{StepKey: job.StepKey, Matrix: job.Matrix,
+			ParallelIndex: job.ParallelGroupIndex, ParallelTotal: job.ParallelGroupTotal,
+			Target: t, Baseline: b, UnmatchedReason: reason, Change: compareJobOutcomes(t, b)}
+		if reason != "" {
+			step.Change = "unmatched"
+		}
+		if reason == "" && t != nil && b != nil {
+			step.MatchMethod = "step_key"
+			if job.StepKey == "" {
+				step.MatchMethod = "name_fallback"
+				usedFallback = true
+			}
+		}
+		if t != nil && b != nil && t.ExecutionSeconds != nil && b.ExecutionSeconds != nil {
+			delta := *t.ExecutionSeconds - *b.ExecutionSeconds
+			step.ExecutionDeltaSeconds = &delta
+		}
+		result.ChangeCounts[step.Change]++
+		result.Steps = append(result.Steps, step)
+	}
+	for _, job := range target {
+		key := comparisonIdentity(job)
+		reason := ""
+		if key == "" {
+			reason = "missing step key and usable name"
+		} else if len(targetByKey[key]) > 1 || len(baselineByKey[key]) > 1 {
+			reason = "ambiguous step identity"
+		}
+		var b *ComparisonJob
+		if reason == "" && len(baselineByKey[key]) == 1 {
+			b = comparisonJob(baselineByKey[key][0], *result.Baseline)
+		}
+		appendStep(job, comparisonJob(job, result.Target), b, reason)
+	}
+	for _, job := range baseline {
+		key := comparisonIdentity(job)
+		reason := ""
+		switch {
+		case key == "":
+			reason = "missing step key and usable name"
+		case len(targetByKey[key]) > 1 || len(baselineByKey[key]) > 1:
+			reason = "ambiguous step identity"
+		case len(targetByKey[key]) == 1:
+			continue
+		}
+		appendStep(job, nil, comparisonJob(job, *result.Baseline), reason)
+	}
+	if usedFallback {
+		result.Warnings = append(result.Warnings, "Some unkeyed jobs were matched by unique exact name, type, group, matrix and parallel coordinates (match_method=name_fallback). These are heuristic matches, not stable step identities; renamed jobs appear as added/removed.")
+	}
+	// Outcomes first, then largest execution regressions within each category.
+	priority := map[string]int{"newly_failing": 0, "recovered": 1, "still_failing": 2,
+		"state_changed": 3, "retries_changed": 4, "added": 5, "removed": 6, "unmatched": 7, "unchanged": 8}
+	sort.SliceStable(result.Steps, func(i, j int) bool {
+		a, b := result.Steps[i], result.Steps[j]
+		if priority[a.Change] != priority[b.Change] {
+			return priority[a.Change] < priority[b.Change]
+		}
+		var da, db float64
+		if a.ExecutionDeltaSeconds != nil {
+			da = *a.ExecutionDeltaSeconds
+		}
+		if b.ExecutionDeltaSeconds != nil {
+			db = *b.ExecutionDeltaSeconds
+		}
+		return da > db
+	})
+	if len(result.Steps) > comparisonResultLimit {
+		result.StepsOmitted = len(result.Steps) - comparisonResultLimit
+		result.Steps = result.Steps[:comparisonResultLimit]
+		result.Warnings = append(result.Warnings, "Only the first 100 comparisons are shown; change_counts covers all jobs. Use list_jobs with step_key for drill-down.")
+	}
+}
+
+func loadComparisonJobs(ctx context.Context, client JobsClient, args CompareBuildsArgs, number string) ([]buildkite.Job, error) {
+	includeRetried := false
+	options := &buildkite.JobsListOptions{PerPage: 100, IncludeRetriedJobs: &includeRetried}
+	var jobs []buildkite.Job
+	for page := 0; page < comparisonJobPages; page++ {
+		list, _, err := client.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, number, options)
+		if err != nil {
+			return nil, err
+		}
+		for _, job := range list.Items {
+			if !job.Retried {
+				jobs = append(jobs, job)
+			}
+		}
+		if list.Links.Next == "" {
+			return jobs, nil
+		}
+		options, err = list.Links.Next.ToOptions()
+		if err != nil {
+			return nil, err
+		}
+		options.PerPage = 100
+		options.IncludeRetriedJobs = &includeRetried
+	}
+	return nil, fmt.Errorf("build %s exceeds the comparison scan limit of 1000 jobs; use list_jobs with step_key to compare individual steps. No partial added/removed classification was produced", number)
+}
+
+func CompareBuilds() (mcp.Tool, mcp.ToolHandlerFor[CompareBuildsArgs, any], []string) {
+	return mcp.Tool{
+		Name:        "compare_builds",
+		Description: "Compare step outcomes, final-attempt retry counts and execution/scheduling times between builds in one pipeline. Defaults to the most recently created earlier successful build on the same branch; baseline_build_number overrides this. Matches step keys or, for unkeyed jobs, unique exact names with matching type, group, matrix and parallel coordinates. match_method identifies heuristic name_fallback matches; ambiguous or unnamed unkeyed jobs remain unmatched. Returns at most 100 comparisons, prioritizing failures, and optional bounded log evidence for three newly failing jobs. Scans at most 1000 jobs per build; refuses incomplete inventories. Historical co-occurrence does not prove a cause or that retrying is safe. Use get_build_failure_summary for deeper failure diagnosis.",
+		Annotations: &mcp.ToolAnnotations{Title: "Compare Builds", ReadOnlyHint: true},
+	}, func(ctx context.Context, _ *mcp.CallToolRequest, args CompareBuildsArgs) (*mcp.CallToolResult, any, error) {
+		ctx, span := trace.Start(ctx, "buildkite.CompareBuilds")
+		defer span.End()
+		span.SetAttributes(
+			attribute.String("org_slug", args.OrgSlug),
+			attribute.String("pipeline_slug", args.PipelineSlug),
+			attribute.String("build_number", args.BuildNumber),
+			attribute.String("baseline_build_number", args.BaselineBuildNumber),
+		)
+		deps := DepsFromContext(ctx)
+		for _, number := range []string{args.BuildNumber, args.BaselineBuildNumber} {
+			if number == "" && args.BuildNumber != "" {
+				continue
+			}
+			if n, err := strconv.Atoi(number); err != nil || n <= 0 {
+				return utils.NewToolResultError("Build numbers must be positive integers, not UUIDs or URLs"), nil, nil
+			}
+		}
+		options := &buildkite.BuildGetOptions{BuildsListOptions: buildkite.BuildsListOptions{ExcludeJobs: true, ExcludePipeline: true}}
+		target, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, options)
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
+		result := BuildComparison{Target: summarizeBuild(target), BaselineSelection: "explicit",
+			ChangeCounts: map[string]int{}, Steps: []BuildStepComparison{}}
+		baselineNumber := args.BaselineBuildNumber
+		if baselineNumber == "" {
+			result.BaselineSelection = "most_recently_created_earlier_passed_build_on_same_branch"
+			if target.CreatedAt == nil || target.Branch == "" {
+				return utils.NewToolResultError("Target has no creation time or branch; provide baseline_build_number explicitly"), nil, nil
+			}
+			listOptions := &buildkite.BuildsListOptions{Branch: []string{target.Branch}, State: []string{"passed"},
+				CreatedTo: target.CreatedAt.Time, ExcludeJobs: true, ExcludePipeline: true,
+				ListOptions: buildkite.ListOptions{Page: 1, PerPage: 100}}
+			for page := 0; page < 5 && baselineNumber == ""; page++ {
+				builds, response, listErr := deps.BuildsClient.ListByPipeline(ctx, args.OrgSlug, args.PipelineSlug, listOptions)
+				if listErr != nil {
+					return handleBuildkiteError(listErr)
+				}
+				for _, b := range builds {
+					result.CandidatesScanned++
+					if b.Number < target.Number && b.State == "passed" && b.Branch == target.Branch && b.CreatedAt != nil && b.CreatedAt.Before(target.CreatedAt.Time) {
+						baselineNumber = strconv.Itoa(b.Number)
+						break
+					}
+				}
+				if response == nil || response.NextPage == 0 {
+					break
+				}
+				listOptions.Page = response.NextPage
+			}
+			if baselineNumber == "" {
+				result.Warnings = append(result.Warnings, "No earlier successful build found on the target branch within the bounded search. Provide baseline_build_number explicitly; no comparison was performed.")
+				return mcpTextResult(span, result)
+			}
+		}
+		if n, _ := strconv.Atoi(baselineNumber); n == target.Number {
+			return utils.NewToolResultError("Target and baseline must be different builds"), nil, nil
+		}
+		baseline, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, baselineNumber, options)
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
+		baseSummary := summarizeBuild(baseline)
+		result.Baseline = &baseSummary
+		if baseline.Branch != target.Branch {
+			result.Warnings = append(result.Warnings, "Explicit baseline is on a different branch.")
+		}
+		if target.FinishedAt == nil || baseline.FinishedAt == nil {
+			result.Warnings = append(result.Warnings, "One or both builds are unfinished; jobs may change or be uploaded after this snapshot. Added/removed means present/absent in this snapshot only.")
+		}
+		targetJobs, err := loadComparisonJobs(ctx, deps.JobsClient, args, args.BuildNumber)
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
+		baselineJobs, err := loadComparisonJobs(ctx, deps.JobsClient, args, baselineNumber)
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
+		result.TargetJobs, result.BaselineJobs = len(targetJobs), len(baselineJobs)
+		compareBuildJobs(targetJobs, baselineJobs, &result)
+		result.Warnings = append(result.Warnings, "Timings cover final attempts only; scheduling_seconds is scheduled_at to started_at, not dependency/manual waiting. Execution deltas are not build wall-clock deltas. Still-failing steps may have different failure causes.")
+		if defaultTrue(args.IncludeLogs) {
+			loaded := 0
+			for i := range result.Steps {
+				step := &result.Steps[i]
+				if step.Change != "newly_failing" || step.Target.State == "expired" {
+					continue
+				}
+				if loaded == 3 {
+					result.Warnings = append(result.Warnings, "Log evidence is limited to three newly failing jobs; use tail_logs with the remaining target job IDs.")
+					break
+				}
+				loaded++
+				if deps.BuildkiteLogsClient == nil {
+					step.Target.LogError = "Log client unavailable; use tail_logs for this job."
+					continue
+				}
+				entries, _, truncated, contentTruncated, _, logErr := readFailureLogTail(ctx, deps.BuildkiteLogsClient,
+					GetBuildFailureSummaryArgs{OrgSlug: args.OrgSlug, PipelineSlug: args.PipelineSlug, BuildNumber: args.BuildNumber}, buildkite.Job{ID: step.Target.ID}, 20)
+				if logErr != nil {
+					step.Target.LogError = logErr.Error()
+					continue
+				}
+				entries, _, bounded := boundFailureLogEntries(entries, 8*1024)
+				step.Target.LogTail, step.Target.LogTruncated = entries, truncated || contentTruncated || bounded
+			}
+		}
+		return mcpTextResult(span, result)
+	}, []string{"read_builds", "read_build_logs"}
+}

--- a/pkg/buildkite/compare_builds_test.go
+++ b/pkg/buildkite/compare_builds_test.go
@@ -1,0 +1,358 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	buildkitelogs "github.com/buildkite/buildkite-logs"
+	"github.com/buildkite/go-buildkite/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareBuildsDefinition(t *testing.T) {
+	tool, handler, scopes := CompareBuilds()
+	require.Equal(t, "compare_builds", tool.Name)
+	require.True(t, tool.Annotations.ReadOnlyHint)
+	require.NotNil(t, handler)
+	require.Equal(t, []string{"read_builds", "read_build_logs"}, scopes)
+	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[CompareBuildsArgs](t))
+}
+
+func TestCompareJobOutcomes(t *testing.T) {
+	for _, tc := range []struct{ target, baseline, want string }{
+		{"failed", "passed", "newly_failing"}, {"timed_out", "passed", "newly_failing"},
+		{"expired", "passed", "newly_failing"}, {"passed", "failed", "recovered"},
+		{"failed", "failed", "still_failing"}, {"broken", "passed", "state_changed"},
+		{"running", "failed", "state_changed"}, {"failed", "skipped", "state_changed"},
+		{"passed", "passed", "unchanged"},
+	} {
+		t.Run(tc.target+"_"+tc.baseline, func(t *testing.T) {
+			require.Equal(t, tc.want, compareJobOutcomes(&ComparisonJob{State: tc.target}, &ComparisonJob{State: tc.baseline}))
+		})
+	}
+	require.Equal(t, "retries_changed", compareJobOutcomes(&ComparisonJob{State: "passed", RetriesCount: 1}, &ComparisonJob{State: "passed"}))
+	require.Equal(t, "state_changed", compareJobOutcomes(&ComparisonJob{State: "passed", SoftFailed: true}, &ComparisonJob{State: "passed"}))
+}
+
+func TestCompareBuildJobsIdentityAndTimings(t *testing.T) {
+	stamp := func(seconds int) *buildkite.Timestamp { return buildkite.NewTimestamp(time.Unix(int64(seconds), 0)) }
+	base := []buildkite.Job{
+		{ID: "base-linux", StepKey: "test", Matrix: map[string]any{"os": "linux"}, State: "passed", StartedAt: stamp(10), FinishedAt: stamp(20)},
+		{ID: "base-mac", StepKey: "test", Matrix: map[string]any{"os": "mac"}, State: "failed"},
+		{ID: "base-shard0", StepKey: "parallel", ParallelGroupIndex: testPtr(0), ParallelGroupTotal: testPtr(2), State: "passed"},
+		{ID: "base-shard1", StepKey: "parallel", ParallelGroupIndex: testPtr(1), ParallelGroupTotal: testPtr(2), State: "passed"},
+		{ID: "base-no-key", Name: "same name", State: "passed"},
+		{ID: "base-duplicate", StepKey: "duplicate", State: "passed"},
+		{ID: "base-removed", StepKey: "removed", State: "passed"},
+	}
+	target := []buildkite.Job{
+		{ID: "target-mac", StepKey: "test", Matrix: map[string]any{"os": "mac"}, State: "passed", RetriesCount: 1},
+		{ID: "target-linux", StepKey: "test", Matrix: map[string]any{"os": "linux"}, State: "failed", ScheduledAt: stamp(90), StartedAt: stamp(100), FinishedAt: stamp(130)},
+		{ID: "target-shard1", StepKey: "parallel", ParallelGroupIndex: testPtr(1), ParallelGroupTotal: testPtr(2), State: "failed"},
+		{ID: "target-shard0", StepKey: "parallel", ParallelGroupIndex: testPtr(0), ParallelGroupTotal: testPtr(2), State: "passed"},
+		{ID: "target-no-key", Name: "same name", State: "failed"},
+		{ID: "target-duplicate1", StepKey: "duplicate", State: "passed"},
+		{ID: "target-duplicate2", StepKey: "duplicate", State: "passed"},
+		{ID: "target-added", StepKey: "added", State: "passed"},
+	}
+	result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+	compareBuildJobs(target, base, &result)
+	require.Equal(t, map[string]int{"newly_failing": 3, "recovered": 1, "unchanged": 1, "added": 1, "removed": 1, "unmatched": 3}, result.ChangeCounts)
+	require.Equal(t, "step_key", result.Steps[0].MatchMethod)
+	require.Equal(t, "name_fallback", result.Steps[2].MatchMethod)
+	require.Equal(t, "target-linux", result.Steps[0].Target.ID)
+	require.Equal(t, "base-linux", result.Steps[0].Baseline.ID)
+	require.InDelta(t, 20.0, *result.Steps[0].ExecutionDeltaSeconds, 0.001)
+	require.InDelta(t, 10.0, *result.Steps[0].Target.SchedulingSeconds, 0.001)
+	require.Nil(t, result.Steps[0].Baseline.SchedulingSeconds)
+	require.Equal(t, "base-shard1", result.Steps[1].Baseline.ID)
+	require.Nil(t, comparisonDuration(stamp(20), stamp(10)))
+	require.Nil(t, comparisonDuration(nil, stamp(10)))
+	// Different parallel group sizes must not produce misleading timing deltas.
+	require.NotEqual(t, comparisonIdentity(base[2]), comparisonIdentity(buildkite.Job{StepKey: "parallel", ParallelGroupIndex: testPtr(0), ParallelGroupTotal: testPtr(3)}))
+}
+
+func TestCompareBuildJobsNameFallback(t *testing.T) {
+	job := buildkite.Job{Name: ":go: test", Type: "script", State: "passed"}
+	for _, tc := range []struct {
+		name string
+		edit func(*buildkite.Job)
+	}{
+		{"exact match", func(*buildkite.Job) {}},
+		{"renamed", func(j *buildkite.Job) { j.Name = "renamed" }},
+		{"different type", func(j *buildkite.Job) { j.Type = "trigger" }},
+		{"different group", func(j *buildkite.Job) { j.GroupKey = "other" }},
+		{"different matrix", func(j *buildkite.Job) { j.Matrix = map[string]any{"os": "linux"} }},
+		{"different shard", func(j *buildkite.Job) { j.ParallelGroupIndex = testPtr(1) }},
+		{"different parallelism", func(j *buildkite.Job) { j.ParallelGroupTotal = testPtr(3) }},
+		{"key cannot match name", func(j *buildkite.Job) { j.StepKey = job.Name }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			target := job
+			tc.edit(&target)
+			result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+			compareBuildJobs([]buildkite.Job{target}, []buildkite.Job{job}, &result)
+			if tc.name == "exact match" {
+				require.Len(t, result.Steps, 1)
+				require.Equal(t, "name_fallback", result.Steps[0].MatchMethod)
+				require.Contains(t, result.Warnings[0], "heuristic")
+			} else {
+				require.Equal(t, map[string]int{"added": 1, "removed": 1}, result.ChangeCounts)
+				for _, step := range result.Steps {
+					require.Empty(t, step.MatchMethod)
+				}
+			}
+		})
+	}
+	for _, targetDuplicates := range []bool{false, true} {
+		target, baseline := []buildkite.Job{job}, []buildkite.Job{job}
+		if targetDuplicates {
+			target = append(target, job)
+		} else {
+			baseline = append(baseline, job)
+		}
+		result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+		compareBuildJobs(target, baseline, &result)
+		require.Equal(t, map[string]int{"unmatched": 3}, result.ChangeCounts)
+		for _, step := range result.Steps {
+			require.Equal(t, "ambiguous step identity", step.UnmatchedReason)
+			require.Empty(t, step.MatchMethod)
+		}
+	}
+	for _, name := range []string{"", "  "} {
+		job.Name = name
+		result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+		compareBuildJobs([]buildkite.Job{job}, []buildkite.Job{job}, &result)
+		require.Equal(t, map[string]int{"unmatched": 2}, result.ChangeCounts)
+	}
+}
+
+func TestCompareBuildJobsUnkeyedPipeline(t *testing.T) {
+	// Shape of the live MCP server pipeline: seven named jobs and an unnamed
+	// broken job on each side. Matrix values still distinguish the build jobs.
+	jobs := []buildkite.Job{{State: "broken"}}
+	for _, name := range []string{":pipeline:", ":golangci-lint: lint", ":go: test", ":docker: build image"} {
+		jobs = append(jobs, buildkite.Job{Name: name, Type: "script", State: "passed"})
+	}
+	for _, os := range []string{"darwin", "linux", "windows"} {
+		jobs = append(jobs, buildkite.Job{Name: ":terminal: build", Type: "script", State: "passed", Matrix: map[string]any{"": os}})
+	}
+	result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+	compareBuildJobs(jobs, jobs, &result)
+	require.Equal(t, map[string]int{"unchanged": 7, "unmatched": 2}, result.ChangeCounts)
+	for _, step := range result.Steps {
+		if step.Change == "unchanged" {
+			require.Equal(t, "name_fallback", step.MatchMethod)
+		}
+	}
+}
+
+func TestCompareBuildJobsOutputLimit(t *testing.T) {
+	var jobs []buildkite.Job
+	for i := 0; i < 110; i++ {
+		jobs = append(jobs, buildkite.Job{StepKey: fmt.Sprint(i), State: "passed"})
+	}
+	result := BuildComparison{Baseline: &BuildSummary{}, ChangeCounts: map[string]int{}}
+	compareBuildJobs(jobs, jobs, &result)
+	require.Len(t, result.Steps, 100)
+	require.Equal(t, 10, result.StepsOmitted)
+	require.Equal(t, 110, result.ChangeCounts["unchanged"])
+}
+
+func TestLoadComparisonJobsPaginationAndLimit(t *testing.T) {
+	calls := 0
+	client := &MockJobsClient{ListByBuildFunc: func(_ context.Context, _, _, _ string, opts *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+		calls++
+		require.False(t, *opts.IncludeRetriedJobs)
+		require.Equal(t, 100, opts.PerPage)
+		if calls == 1 {
+			return buildkite.JobsList{Items: []buildkite.Job{{ID: "old", Retried: true}, {ID: "final", RetriesCount: 1}}, Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/jobs?after=cursor"}}, nil, nil
+		}
+		require.Equal(t, "cursor", opts.After)
+		return buildkite.JobsList{Items: []buildkite.Job{{ID: "second"}}}, nil, nil
+	}}
+	jobs, err := loadComparisonJobs(context.Background(), client, CompareBuildsArgs{}, "42")
+	require.NoError(t, err)
+	require.Len(t, jobs, 2)
+	require.Equal(t, "final", jobs[0].ID)
+	require.Equal(t, 1, jobs[0].RetriesCount)
+	calls = 0
+	client.ListByBuildFunc = func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+		calls++
+		return buildkite.JobsList{Links: buildkite.JobsListLinks{Next: "https://api.buildkite.com/jobs?after=next"}}, nil, nil
+	}
+	jobs, err = loadComparisonJobs(context.Background(), client, CompareBuildsArgs{}, "42")
+	require.ErrorContains(t, err, "No partial added/removed")
+	require.Nil(t, jobs)
+	require.Equal(t, 10, calls)
+}
+
+func TestCompareBuildsBaselineSelection(t *testing.T) {
+	now := time.Now()
+	for _, explicit := range []bool{false, true} {
+		t.Run(fmt.Sprint(explicit), func(t *testing.T) {
+			gets, lists := []string{}, 0
+			builds := &MockBuildsClient{
+				GetFunc: func(_ context.Context, org, pipeline, number string, opts *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+					require.Equal(t, "org", org)
+					require.Equal(t, "pipeline", pipeline)
+					require.True(t, opts.ExcludeJobs)
+					require.True(t, opts.ExcludePipeline)
+					gets = append(gets, number)
+					if number == "42" {
+						return buildkite.Build{Number: 42, Branch: "main", State: "failed", CreatedAt: buildkite.NewTimestamp(now)}, nil, nil
+					}
+					return buildkite.Build{Number: 40, Branch: "main", State: "passed"}, nil, nil
+				},
+				ListByPipelineFunc: func(_ context.Context, _, _ string, opts *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+					lists++
+					require.False(t, explicit)
+					require.Equal(t, []string{"main"}, opts.Branch)
+					require.Equal(t, []string{"passed"}, opts.State)
+					require.Equal(t, now, opts.CreatedTo)
+					if opts.Page == 1 {
+						return []buildkite.Build{{Number: 43, Branch: "main", State: "passed", CreatedAt: buildkite.NewTimestamp(now.Add(time.Hour))}}, &buildkite.Response{NextPage: 2}, nil
+					}
+					require.Equal(t, 2, opts.Page)
+					return []buildkite.Build{
+						{Number: 41, Branch: "other", State: "passed", CreatedAt: buildkite.NewTimestamp(now.Add(-time.Hour))},
+						{Number: 40, Branch: "main", State: "passed", CreatedAt: buildkite.NewTimestamp(now.Add(-2 * time.Hour))},
+						{Number: 39, Branch: "main", State: "passed", CreatedAt: buildkite.NewTimestamp(now.Add(-3 * time.Hour))},
+					}, nil, nil
+				},
+			}
+			jobs := &MockJobsClient{ListByBuildFunc: func(_ context.Context, _, _, number string, _ *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				state := "passed"
+				if number == "42" {
+					state = "failed"
+				}
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: number + "-job", StepKey: "test", State: state}}}, nil, nil
+			}}
+			args := CompareBuildsArgs{OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "42", IncludeLogs: testPtr(false)}
+			if explicit {
+				args.BaselineBuildNumber = "40"
+			}
+			_, handler, _ := CompareBuilds()
+			res, _, err := handler(ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: builds, JobsClient: jobs}), nil, args)
+			require.NoError(t, err)
+			require.False(t, res.IsError)
+			var result BuildComparison
+			require.NoError(t, json.Unmarshal([]byte(getTextResult(t, res).Text), &result))
+			require.Equal(t, []string{"42", "40"}, gets)
+			require.Equal(t, 40, result.Baseline.Number)
+			require.Equal(t, 1, result.ChangeCounts["newly_failing"])
+			if explicit {
+				require.Zero(t, lists)
+			} else {
+				require.Equal(t, 2, lists)
+				require.Equal(t, 3, result.CandidatesScanned)
+			}
+		})
+	}
+}
+
+func TestCompareBuildsNoBaselineAndErrors(t *testing.T) {
+	for _, scenario := range []string{"no baseline", "history limit", "bad target", "bad baseline", "same build", "missing branch", "api error", "job error"} {
+		t.Run(scenario, func(t *testing.T) {
+			calls := 0
+			builds := &MockBuildsClient{
+				GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+					if scenario == "api error" {
+						return buildkite.Build{}, nil, errors.New("api unavailable")
+					}
+					b := buildkite.Build{Number: 42, Branch: "main", CreatedAt: buildkite.NewTimestamp(time.Now())}
+					if scenario == "missing branch" {
+						b.Branch = ""
+					}
+					return b, nil, nil
+				},
+				ListByPipelineFunc: func(context.Context, string, string, *buildkite.BuildsListOptions) ([]buildkite.Build, *buildkite.Response, error) {
+					calls++
+					if scenario == "history limit" {
+						return nil, &buildkite.Response{NextPage: calls + 1}, nil
+					}
+					return nil, nil, nil
+				},
+			}
+			args := CompareBuildsArgs{BuildNumber: "42"}
+			switch scenario {
+			case "bad target":
+				args.BuildNumber = "uuid"
+			case "bad baseline":
+				args.BaselineBuildNumber = "-1"
+			case "same build":
+				args.BaselineBuildNumber = "042"
+			case "job error":
+				args.BaselineBuildNumber = "40"
+			}
+			jobs := &MockJobsClient{ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				return buildkite.JobsList{}, nil, errors.New("jobs unavailable")
+			}}
+			_, handler, _ := CompareBuilds()
+			res, _, err := handler(ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: builds, JobsClient: jobs}), nil, args)
+			require.NoError(t, err)
+			if scenario == "no baseline" || scenario == "history limit" {
+				require.False(t, res.IsError)
+				var result BuildComparison
+				require.NoError(t, json.Unmarshal([]byte(getTextResult(t, res).Text), &result))
+				require.Nil(t, result.Baseline)
+				require.Empty(t, result.Steps)
+				require.Contains(t, result.Warnings[0], "No earlier successful build")
+				if scenario == "history limit" {
+					require.Equal(t, 5, calls)
+				}
+			} else {
+				require.True(t, res.IsError)
+			}
+		})
+	}
+}
+
+func TestCompareBuildsLogEvidence(t *testing.T) {
+	path := t.TempDir() + "/logs.parquet"
+	writeTestParquetFile(t, path, []string{strings.Repeat("x", 10000), "failure evidence"})
+	builds := &MockBuildsClient{GetFunc: func(_ context.Context, _, _, number string, _ *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+		if number == "42" {
+			return buildkite.Build{Number: 42, Branch: "main"}, nil, nil
+		}
+		return buildkite.Build{Number: 40, Branch: "other"}, nil, nil
+	}}
+	jobs := &MockJobsClient{ListByBuildFunc: func(_ context.Context, _, _, number string, _ *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+		var list buildkite.JobsList
+		for i := 0; i < 4; i++ {
+			state := "passed"
+			if number == "42" {
+				state = "failed"
+			}
+			list.Items = append(list.Items, buildkite.Job{ID: fmt.Sprint(i), StepKey: fmt.Sprint(i), State: state})
+		}
+		return list, nil, nil
+	}}
+	calls := 0
+	logs := &MockBuildkiteLogsClient{NewReaderFunc: func(ctx context.Context, _, _, number, job string, _ time.Duration, _ bool) (*buildkitelogs.ParquetReader, error) {
+		calls++
+		require.Equal(t, "42", number)
+		if job == "1" {
+			return nil, errors.New("logs unavailable")
+		}
+		return buildkitelogs.NewParquetReader(path), nil
+	}}
+	_, handler, _ := CompareBuilds()
+	res, _, err := handler(ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: builds, JobsClient: jobs, BuildkiteLogsClient: logs}), nil, CompareBuildsArgs{BuildNumber: "42", BaselineBuildNumber: "40"})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var result BuildComparison
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, res).Text), &result))
+	require.Equal(t, 3, calls)
+	require.Equal(t, "failure evidence", result.Steps[0].Target.LogTail[1].C)
+	require.True(t, result.Steps[0].Target.LogTruncated)
+	require.Contains(t, result.Steps[1].Target.LogError, "logs unavailable")
+	require.Empty(t, result.Steps[3].Target.LogTail)
+	require.Contains(t, strings.Join(result.Warnings, " "), "different branch")
+	require.Contains(t, strings.Join(result.Warnings, " "), "limited to three")
+}

--- a/pkg/buildkite/compare_builds_test.go
+++ b/pkg/buildkite/compare_builds_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +39,25 @@ func TestCompareJobOutcomes(t *testing.T) {
 	}
 	require.Equal(t, "retries_changed", compareJobOutcomes(&ComparisonJob{State: "passed", RetriesCount: 1}, &ComparisonJob{State: "passed"}))
 	require.Equal(t, "state_changed", compareJobOutcomes(&ComparisonJob{State: "passed", SoftFailed: true}, &ComparisonJob{State: "passed"}))
+}
+
+func TestCompareBuildJobsSoftFailureTransitions(t *testing.T) {
+	for _, targetSoft := range []bool{false, true} {
+		for _, baselineSoft := range []bool{false, true} {
+			t.Run(fmt.Sprintf("target_soft=%t/baseline_soft=%t", targetSoft, baselineSoft), func(t *testing.T) {
+				result := BuildComparison{Baseline: &BuildSummary{State: "passed"}, ChangeCounts: map[string]int{}}
+				compareBuildJobs(
+					[]buildkite.Job{{StepKey: "test", State: "failed", SoftFailed: targetSoft}},
+					[]buildkite.Job{{StepKey: "test", State: "failed", SoftFailed: baselineSoft}}, &result)
+				want := "still_failing"
+				if targetSoft != baselineSoft {
+					want = "state_changed"
+				}
+				require.Equal(t, map[string]int{want: 1}, result.ChangeCounts)
+				require.Equal(t, want, result.Steps[0].Change)
+			})
+		}
+	}
 }
 
 func TestCompareBuildJobsIdentityAndTimings(t *testing.T) {
@@ -355,4 +376,50 @@ func TestCompareBuildsLogEvidence(t *testing.T) {
 	require.Empty(t, result.Steps[3].Target.LogTail)
 	require.Contains(t, strings.Join(result.Warnings, " "), "different branch")
 	require.Contains(t, strings.Join(result.Warnings, " "), "limited to three")
+}
+
+func TestCompareBuildsLogAuthenticationErrors(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "https://api.buildkite.com/log", nil)
+	for _, tc := range []struct {
+		name         string
+		err          error
+		unauthorized bool
+	}{
+		{"401", &buildkite.ErrorResponse{Response: &http.Response{StatusCode: http.StatusUnauthorized, Request: request}, Message: "expired token"}, true},
+		{"wrapped sentinel", fmt.Errorf("log access: %w", ErrUnauthorized), true},
+		{"403", &buildkite.ErrorResponse{Response: &http.Response{StatusCode: http.StatusForbidden, Request: request}, Message: "missing log scope"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builds := &MockBuildsClient{GetFunc: func(_ context.Context, _, _, number string, _ *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+				if number == "42" {
+					return buildkite.Build{Number: 42}, nil, nil
+				}
+				return buildkite.Build{Number: 40}, nil, nil
+			}}
+			jobs := &MockJobsClient{ListByBuildFunc: func(_ context.Context, _, _, number string, _ *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+				state := "passed"
+				if number == "42" {
+					state = "failed"
+				}
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: number, StepKey: "test", State: state}}}, nil, nil
+			}}
+			logs := &MockBuildkiteLogsClient{NewReaderFunc: func(context.Context, string, string, string, string, time.Duration, bool) (*buildkitelogs.ParquetReader, error) {
+				return nil, tc.err
+			}}
+			_, handler, _ := CompareBuilds()
+			res, structured, err := handler(ContextWithDeps(context.Background(), ToolDependencies{BuildsClient: builds, JobsClient: jobs, BuildkiteLogsClient: logs}), nil, CompareBuildsArgs{BuildNumber: "42", BaselineBuildNumber: "40"})
+			if tc.unauthorized {
+				require.ErrorIs(t, err, ErrUnauthorized)
+				require.Nil(t, res)
+				require.Nil(t, structured)
+			} else {
+				require.NoError(t, err)
+				require.False(t, res.IsError)
+				var result BuildComparison
+				require.NoError(t, json.Unmarshal([]byte(getTextResult(t, res).Text), &result))
+				require.Equal(t, 1, result.ChangeCounts["newly_failing"])
+				require.Contains(t, result.Steps[0].Target.LogError, "missing log scope")
+			}
+		})
+	}
 }

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -90,6 +90,10 @@ var instructionSections = []instructionSection{
 		text:    "Build failure investigation: start with get_build_failure_summary. It combines build state, failed and broken jobs, promised failures from running jobs, bounded log tails, relevant annotations, and failed tests in one response. Use the individual build, job, log, annotation, and test tools only when the summary identifies an area that needs deeper inspection.",
 	},
 	{
+		toolset: toolsets.ToolsetInvestigations,
+		text:    "Build comparison: use compare_builds when asked what changed since a build worked, or to compare two builds. Without an explicit baseline it selects an earlier successful build on the same pipeline and branch. Report the selected baseline and unmatched steps; shared failing steps do not establish a shared cause or justify a retry. Timings cover final attempts, not total retry cost or build wall-clock duration.",
+	},
+	{
 		toolset: toolsets.ToolsetBuilds,
 		text:    "Job state \"broken\" means the job did not run because something inside the build prevented execution: an if conditional evaluated to false, a branch filter did not match, or an upstream dependency failed. It does not mean the job's command failed. Distinguish: broken = build configuration or dependencies prevented execution; failed = job ran but exited non-zero; skipped = external factor (e.g. a newer build superseded it). When both failed and broken jobs are present, investigate failed upstream jobs first.",
 	},

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -434,9 +434,10 @@ func CreateBuiltinToolsets() map[string]Toolset {
 		},
 		ToolsetInvestigations: {
 			Name:        "Build Investigations",
-			Description: "Cross-domain tools for diagnosing Buildkite build failures",
+			Description: "Cross-domain tools for diagnosing failures and comparing builds",
 			Tools: []ToolDefinition{
 				newToolDef(buildkite.GetBuildFailureSummary),
+				newToolDef(buildkite.CompareBuilds),
 			},
 		},
 		ToolsetUser: {

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -665,8 +665,9 @@ func TestCreateBuiltinToolsets(t *testing.T) {
 
 	investigations, exists := registry.Get(ToolsetInvestigations)
 	assert.True(exists)
-	assert.Len(investigations.Tools, 1)
+	assert.Len(investigations.Tools, 2)
 	assert.Equal("get_build_failure_summary", investigations.Tools[0].Tool.Name)
+	assert.Equal("compare_builds", investigations.Tools[1].Tool.Name)
 	assert.Equal([]string{"read_build_logs", "read_builds", "read_suites"}, investigations.GetRequiredScopes())
 
 	tests, exists := registry.Get(ToolsetTests)


### PR DESCRIPTION
## Description

When an agent wants to produce a failure summary, it will do so with the context of the build it has checked, but we can add more context in a _what has changed_ sense.

## Changes

Adds a read-only `compare_builds` tool to the investigations toolset. It compares a target build with the most recent earlier successful build on the same pipeline and branch, or an explicitly supplied baseline.

The comparison reports:
- Newly failing, recovered, and still-failing jobs, plus added, removed, and unmatched jobs
- Final-attempt execution and scheduling times, execution-time deltas, and retry counts
- Bounded log evidence for up to three newly failing jobs

Jobs are matched by step `key`s and matrix/parallel coordinates. Unkeyed jobs can use a unique exact-name fallback, explicitly labelled as heuristic; ambiguous or unnamed jobs remain unmatched.

History searches and responses are bounded. Incomplete job inventories return an error rather than misleading added/removed results. The tool provides historical context for diagnosis without claiming causality or recommending retries automatically.

