### PR TITLE
Pb 3259 failure summary build tests

### DIFF
--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -22,19 +22,11 @@ const (
 	maxFailureSummaryAnnotations         = 100
 	failureSummaryAnnotationPageSize     = 100
 	failureSummaryAnnotationScanPages    = 5
-	defaultFailureSummaryTestRuns        = 5
-	maxFailureSummaryTestRuns            = 20
-	defaultFailureSummaryTestsPerRun     = 20
-	maxFailureSummaryTestsPerRun         = 100
-	defaultFailureSummaryFailedTests     = 100
-	maxFailureSummaryFailedTests         = 200
 	failureSummaryEntryContentByteLimit  = 4 * 1024
-	failureSummaryExecutionByteLimit     = 16 * 1024
 	failureSummaryLogJobContentByteLimit = 64 * 1024
 	failureSummaryLogContentByteLimit    = 128 * 1024
 	failureSummaryAnnotationContentLimit = 64 * 1024
-	failureSummaryTestContentByteLimit   = 64 * 1024
-	failureSummaryContentByteLimit       = failureSummaryLogContentByteLimit + failureSummaryAnnotationContentLimit + failureSummaryTestContentByteLimit
+	failureSummaryContentByteLimit       = failureSummaryLogContentByteLimit + failureSummaryAnnotationContentLimit
 	failureSummaryConcurrency            = 4
 )
 
@@ -46,17 +38,12 @@ type GetBuildFailureSummaryArgs struct {
 	OrgSlug                string `json:"org_slug"`
 	PipelineSlug           string `json:"pipeline_slug"`
 	BuildNumber            string `json:"build_number"`
-	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
-	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, server may enforce a lower maximum, absolute max 50)"`
-	MaxAnnotations         int    `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
-	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to inspect (default 5, max 20)"`
-	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed test executions to return across all Test Engine runs (default 100, max 200)"`
-	MaxFailedTestsPerRun   int    `json:"max_failed_tests_per_run,omitempty" jsonschema:"Maximum failed test executions to return per Test Engine run (default 20, max 100)"`
-	ContentLimitBytes      int    `json:"content_limit_bytes,omitempty" jsonschema:"Maximum bytes for the response payload (default and max 262144); lower it to fit clients with small tool-result limits, combining with log_tail and max_jobs for finer trimming"`
-	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
-	IncludeAnnotations     *bool  `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
-	IncludeFailedTests     *bool  `json:"include_failed_tests,omitempty" jsonschema:"Include failed Test Engine executions when the build has Test Engine runs (default true)"`
-	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded test failure details such as stack traces within the summary's bounded test-content budget"`
+	LogTail            int   `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
+	MaxJobs            int   `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, server may enforce a lower maximum, absolute max 50)"`
+	MaxAnnotations     int   `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
+	ContentLimitBytes  int   `json:"content_limit_bytes,omitempty" jsonschema:"Maximum bytes for the response payload (default and max 196608); lower it to fit clients with small tool-result limits, combining with log_tail and max_jobs for finer trimming"`
+	IncludeLogs        *bool `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
+	IncludeAnnotations *bool `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
 }
 
 type BuildFailureSummaryBuild struct {
@@ -95,20 +82,6 @@ type FailureSummaryAnnotation struct {
 	BodyTruncated bool   `json:"body_truncated,omitempty"`
 }
 
-type FailureSummaryFailedExecution struct {
-	buildkite.FailedExecution
-	ContentTruncated bool `json:"content_truncated,omitempty"`
-}
-
-type FailureSummaryTestRun struct {
-	RunID            string                          `json:"run_id"`
-	TestSuiteSlug    string                          `json:"test_suite_slug"`
-	FailedExecutions []FailureSummaryFailedExecution `json:"failed_executions,omitempty"`
-	Truncated        bool                            `json:"truncated,omitempty"`
-	ContentTruncated bool                            `json:"content_truncated,omitempty"`
-	Error            string                          `json:"error,omitempty"`
-}
-
 type BuildFailureSummary struct {
 	Build                BuildFailureSummaryBuild   `json:"build"`
 	Jobs                 []FailureSummaryJob        `json:"jobs"`
@@ -116,9 +89,6 @@ type BuildFailureSummary struct {
 	JobsTruncated        bool                       `json:"jobs_truncated,omitempty"`
 	Annotations          []FailureSummaryAnnotation `json:"annotations,omitempty"`
 	AnnotationsTruncated bool                       `json:"annotations_truncated,omitempty"`
-	TestRuns             []FailureSummaryTestRun    `json:"test_runs,omitempty"`
-	TestRunsTruncated    bool                       `json:"test_runs_truncated,omitempty"`
-	FailedTestsTruncated bool                       `json:"failed_tests_truncated,omitempty"`
 	ContentBytes         int                        `json:"content_bytes"`
 	ContentLimitBytes    int                        `json:"content_limit_bytes"`
 	ContentTruncated     bool                       `json:"content_truncated,omitempty"`
@@ -383,78 +353,6 @@ func loadFailureLogs(ctx context.Context, client BuildkiteLogsClient, args GetBu
 	}
 }
 
-func loadFailureTestRuns(ctx context.Context, client TestExecutionsClient, args GetBuildFailureSummaryArgs, runs []buildkite.TestEngineRun, maxRuns, maxPerRun, maxTotal int) ([]FailureSummaryTestRun, bool, bool, error) {
-	selectedRunCount := min(len(runs), maxRuns)
-	runsTruncated := selectedRunCount < len(runs)
-	perRunLimit := min(maxPerRun, maxTotal)
-	results := make([]FailureSummaryTestRun, selectedRunCount)
-	semaphore := make(chan struct{}, failureSummaryConcurrency)
-	unauthorized := make(chan error, selectedRunCount)
-	var waitGroup sync.WaitGroup
-
-	for i := range results {
-		waitGroup.Add(1)
-		go func(index int) {
-			defer waitGroup.Done()
-			semaphore <- struct{}{}
-			defer func() { <-semaphore }()
-
-			run := runs[index]
-			result := FailureSummaryTestRun{RunID: run.ID, TestSuiteSlug: run.Suite.Slug}
-			executions, response, err := client.GetFailedExecutions(ctx, args.OrgSlug, run.Suite.Slug, run.ID, &buildkite.FailedExecutionsOptions{
-				IncludeFailureExpanded: args.IncludeFailureExpanded,
-				Page:                   1,
-				PerPage:                perRunLimit,
-			})
-			if err != nil {
-				if isBuildkiteUnauthorized(err) {
-					unauthorized <- ErrUnauthorized
-					return
-				}
-				result.Error = err.Error()
-				result.Truncated = true
-			} else {
-				if len(executions) > perRunLimit {
-					executions = executions[:perRunLimit]
-					result.Truncated = true
-				}
-				result.FailedExecutions = make([]FailureSummaryFailedExecution, len(executions))
-				for i, execution := range executions {
-					result.FailedExecutions[i].FailedExecution = execution
-				}
-				result.Truncated = result.Truncated || (response != nil && response.NextPage > 0)
-			}
-			results[index] = result
-		}(i)
-	}
-
-	waitGroup.Wait()
-	select {
-	case err := <-unauthorized:
-		return nil, false, false, err
-	default:
-	}
-
-	remaining := maxTotal
-	for i := range results {
-		if len(results[i].FailedExecutions) > remaining {
-			results[i].FailedExecutions = results[i].FailedExecutions[:remaining]
-			results[i].Truncated = true
-		}
-		remaining -= len(results[i].FailedExecutions)
-	}
-
-	failedTestsTruncated := runsTruncated
-	for _, result := range results {
-		if result.Truncated {
-			failedTestsTruncated = true
-			break
-		}
-	}
-
-	return results, runsTruncated, failedTestsTruncated, nil
-}
-
 func limitFailureSummaryString(value string, fieldLimit int, entryRemaining, sectionRemaining *int) (string, bool) {
 	limit := min(fieldLimit, *entryRemaining, *sectionRemaining)
 	result, truncated := truncateUTF8Bytes(value, limit)
@@ -470,105 +368,6 @@ func failureSummaryLogContentBytes(entries []FailureSummaryLogEntry) int {
 		total += len(entry.C)
 	}
 	return total
-}
-
-func consumeFailureSummaryBytes(size int, entryRemaining, sectionRemaining *int) bool {
-	if size > *entryRemaining || size > *sectionRemaining {
-		return false
-	}
-	*entryRemaining -= size
-	*sectionRemaining -= size
-	return true
-}
-
-func limitFailureExpanded(values []buildkite.FailureExpanded, entryRemaining, sectionRemaining *int) ([]buildkite.FailureExpanded, bool) {
-	result := make([]buildkite.FailureExpanded, 0, len(values))
-	truncated := false
-	if len(values) > 0 && !consumeFailureSummaryBytes(len(`"failure_expanded":[]`), entryRemaining, sectionRemaining) {
-		return result, true
-	}
-	for _, value := range values {
-		objectBytes := len(`{}`)
-		if len(result) > 0 {
-			objectBytes++ // comma between failure_expanded items
-		}
-		if !consumeFailureSummaryBytes(objectBytes, entryRemaining, sectionRemaining) {
-			truncated = true
-			break
-		}
-
-		bounded := buildkite.FailureExpanded{}
-		for _, backtrace := range value.Backtrace {
-			structureBytes := len(`""`)
-			if len(bounded.Backtrace) == 0 {
-				structureBytes += len(`"backtrace":[]`)
-			} else {
-				structureBytes++ // comma between backtrace items
-			}
-			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
-				truncated = true
-				break
-			}
-			line, lineTruncated := limitFailureSummaryString(backtrace, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
-			bounded.Backtrace = append(bounded.Backtrace, line)
-			truncated = truncated || lineTruncated
-		}
-		if len(bounded.Backtrace) < len(value.Backtrace) {
-			truncated = true
-		}
-		for _, expanded := range value.Expanded {
-			structureBytes := len(`""`)
-			if len(bounded.Expanded) == 0 {
-				structureBytes += len(`"expanded":[]`)
-				if len(bounded.Backtrace) > 0 {
-					structureBytes++ // comma between object fields
-				}
-			} else {
-				structureBytes++ // comma between expanded items
-			}
-			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
-				truncated = true
-				break
-			}
-			line, lineTruncated := limitFailureSummaryString(expanded, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
-			bounded.Expanded = append(bounded.Expanded, line)
-			truncated = truncated || lineTruncated
-		}
-		if len(bounded.Expanded) < len(value.Expanded) {
-			truncated = true
-		}
-		result = append(result, bounded)
-		if *entryRemaining <= 0 || *sectionRemaining <= 0 {
-			if len(result) < len(values) {
-				truncated = true
-			}
-			break
-		}
-	}
-	return result, truncated
-}
-
-func limitFailureExecution(execution *FailureSummaryFailedExecution, limit int, sectionRemaining *int) bool {
-	entryRemaining := limit
-	truncated := execution.ContentTruncated
-	fields := []*string{
-		&execution.FailureReason,
-		&execution.TestName,
-		&execution.Location,
-		&execution.RunName,
-		&execution.Branch,
-	}
-	for _, field := range fields {
-		var fieldTruncated bool
-		*field, fieldTruncated = limitFailureSummaryString(*field, failureSummaryEntryContentByteLimit, &entryRemaining, sectionRemaining)
-		truncated = truncated || fieldTruncated
-	}
-
-	var expandedTruncated bool
-	execution.FailureExpanded, expandedTruncated = limitFailureExpanded(execution.FailureExpanded, &entryRemaining, sectionRemaining)
-	truncated = truncated || expandedTruncated
-	execution.ContentTruncated = truncated
-	return truncated
 }
 
 func applyFailureSummaryContentLimits(result *BuildFailureSummary) {
@@ -621,32 +420,6 @@ func applyFailureSummaryContentLimits(result *BuildFailureSummary) {
 		result.ContentTruncated = result.ContentTruncated || annotation.BodyTruncated
 	}
 
-	testRemaining := failureSummaryTestContentByteLimit
-	testItemsRemaining := 0
-	for _, run := range result.TestRuns {
-		testItemsRemaining += len(run.FailedExecutions)
-		if run.Error != "" {
-			testItemsRemaining++
-		}
-	}
-	for i := range result.TestRuns {
-		run := &result.TestRuns[i]
-		if run.Error != "" {
-			itemLimit := min(failureSummaryExecutionByteLimit, testRemaining/testItemsRemaining)
-			entryRemaining := itemLimit
-			var truncated bool
-			run.Error, truncated = limitFailureSummaryString(run.Error, failureSummaryEntryContentByteLimit, &entryRemaining, &testRemaining)
-			run.ContentTruncated = run.ContentTruncated || truncated
-			testItemsRemaining--
-		}
-		for j := range run.FailedExecutions {
-			itemLimit := min(failureSummaryExecutionByteLimit, testRemaining/testItemsRemaining)
-			truncated := limitFailureExecution(&run.FailedExecutions[j], itemLimit, &testRemaining)
-			run.ContentTruncated = run.ContentTruncated || truncated
-			testItemsRemaining--
-		}
-		result.ContentTruncated = result.ContentTruncated || run.ContentTruncated
-	}
 }
 
 func failureSummaryWithLogEntryLimit(result *BuildFailureSummary, perJobLimit int) BuildFailureSummary {
@@ -682,28 +455,6 @@ func marshalFailureSummaryWithContentBytes(result *BuildFailureSummary) ([]byte,
 	}
 }
 
-// failureSummaryWithExecutionLimit returns a copy of the summary where every
-// test run keeps at most its first perRunLimit failed executions.
-func failureSummaryWithExecutionLimit(result *BuildFailureSummary, perRunLimit int) BuildFailureSummary {
-	limited := *result
-	limited.TestRuns = append([]FailureSummaryTestRun(nil), result.TestRuns...)
-	for i := range limited.TestRuns {
-		executions := result.TestRuns[i].FailedExecutions
-		if len(executions) <= perRunLimit {
-			continue
-		}
-
-		limited.TestRuns[i].FailedExecutions = executions[:perRunLimit]
-		limited.TestRuns[i].Truncated = true
-		limited.FailedTestsTruncated = true
-		limited.ContentTruncated = true
-	}
-	return limited
-}
-
-// failureSummaryWithAnnotationLimit returns a copy of the summary keeping at
-// most the first maxAnnotations annotations (the API returns them in priority
-// order).
 func failureSummaryWithAnnotationLimit(result *BuildFailureSummary, maxAnnotations int) BuildFailureSummary {
 	limited := *result
 	if len(result.Annotations) <= maxAnnotations {
@@ -797,45 +548,20 @@ func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) erro
 		return err
 	}
 
-	structureReductions := []struct {
-		maxEntries func(*BuildFailureSummary) int
-		withLimit  func(*BuildFailureSummary, int) BuildFailureSummary
-	}{
-		{
-			maxEntries: func(r *BuildFailureSummary) int {
-				entries := 0
-				for _, run := range r.TestRuns {
-					entries = max(entries, len(run.FailedExecutions))
-				}
-				return entries
-			},
-			withLimit: failureSummaryWithExecutionLimit,
-		},
-		{
-			maxEntries: func(r *BuildFailureSummary) int { return len(r.Annotations) },
-			withLimit:  failureSummaryWithAnnotationLimit,
-		},
+	floor, err := failureSummaryStructureBytes(result, limit)
+	if err != nil {
+		return err
 	}
-
-	for _, reduction := range structureReductions {
-		floor, err := failureSummaryStructureBytes(result, limit)
-		if err != nil {
-			return err
-		}
-		if floor <= limit {
-			return nil
-		}
-		if err := shrinkFailureSummaryToFit(result, limit, reduction.maxEntries(result), reduction.withLimit, failureSummaryStructureBytes); err != nil {
-			return err
-		}
+	if floor <= limit {
+		return nil
 	}
-	return nil
+	return shrinkFailureSummaryToFit(result, limit, len(result.Annotations), failureSummaryWithAnnotationLimit, failureSummaryStructureBytes)
 }
 
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
 		Name:        "get_build_failure_summary",
-		Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine executions. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
+		Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs and annotations. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, or annotation tools.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:        "Get Build Failure Summary",
 			ReadOnlyHint: true,
@@ -848,9 +574,6 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 		logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
 		maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
 		maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
-		maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
-		maxFailedTestsPerRun := boundedValue(args.MaxFailedTestsPerRun, defaultFailureSummaryTestsPerRun, maxFailureSummaryTestsPerRun)
-		maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
 		contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
 
 		span.SetAttributes(
@@ -859,12 +582,9 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			attribute.String("build_number", args.BuildNumber),
 			attribute.Int("log_tail", logTail),
 			attribute.Int("max_jobs", maxJobs),
-			attribute.Int("max_test_runs", maxTestRuns),
-			attribute.Int("max_failed_tests", maxFailedTests),
 			attribute.Int("content_limit_bytes", contentLimit),
 			attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
 			attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
-			attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
 		)
 
 		build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
@@ -872,7 +592,6 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 				ExcludeJobs:     true,
 				ExcludePipeline: true,
 			},
-			IncludeTestEngine: true,
 		})
 		if err != nil {
 			return handleBuildkiteError(err)
@@ -973,21 +692,6 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 			}
 		}
 
-		if defaultTrue(args.IncludeFailedTests) && deps.TestExecutionsClient != nil && build.TestEngine != nil {
-			result.TestRuns, result.TestRunsTruncated, result.FailedTestsTruncated, err = loadFailureTestRuns(
-				ctx,
-				deps.TestExecutionsClient,
-				args,
-				build.TestEngine.Runs,
-				maxTestRuns,
-				maxFailedTestsPerRun,
-				maxFailedTests,
-			)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-
 		applyFailureSummaryContentLimits(&result)
 		if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
 			return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
@@ -996,9 +700,8 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 		span.SetAttributes(
 			attribute.Int("failure_job_count", len(result.Jobs)),
 			attribute.Int("annotation_count", len(result.Annotations)),
-			attribute.Int("test_run_count", len(result.TestRuns)),
 		)
 
 		return mcpTextResultWithByteLimit(span, &result, contentLimit)
-	}, []string{"read_builds", "read_build_logs", "read_suites"}
+	}, []string{"read_builds", "read_build_logs"}
 }

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -836,68 +836,90 @@ func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) erro
 
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
-			Name:        "get_build_failure_summary",
-			Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine tests. The failed_tests section lists only tests whose executions in this build all failed — a test that passed on retry is excluded, matching the terminal-state job view — with failure_reason joined from the newest failed execution where available; call get_failed_executions for full execution detail. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
-			Annotations: &mcp.ToolAnnotations{
-				Title:        "Get Build Failure Summary",
-				ReadOnlyHint: true,
+		Name:        "get_build_failure_summary",
+		Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine tests. The failed_tests section lists only tests whose executions in this build all failed — a test that passed on retry is excluded, matching the terminal-state job view — with failure_reason joined from the newest failed execution where available; call get_failed_executions for full execution detail. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
+		Annotations: &mcp.ToolAnnotations{
+			Title:        "Get Build Failure Summary",
+			ReadOnlyHint: true,
+		},
+	}, func(ctx context.Context, request *mcp.CallToolRequest, args GetBuildFailureSummaryArgs) (*mcp.CallToolResult, any, error) {
+		ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
+		defer span.End()
+
+		deps := DepsFromContext(ctx)
+		logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
+		maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
+		maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
+		maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
+		maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
+		contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
+
+		span.SetAttributes(
+			attribute.String("org_slug", args.OrgSlug),
+			attribute.String("pipeline_slug", args.PipelineSlug),
+			attribute.String("build_number", args.BuildNumber),
+			attribute.Int("log_tail", logTail),
+			attribute.Int("max_jobs", maxJobs),
+			attribute.Int("max_test_runs", maxTestRuns),
+			attribute.Int("max_failed_tests", maxFailedTests),
+			attribute.Int("content_limit_bytes", contentLimit),
+			attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
+			attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
+			attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
+		)
+
+		build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
+			BuildsListOptions: buildkite.BuildsListOptions{
+				ExcludeJobs:     true,
+				ExcludePipeline: true,
 			},
-		}, func(ctx context.Context, request *mcp.CallToolRequest, args GetBuildFailureSummaryArgs) (*mcp.CallToolResult, any, error) {
-			ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
-			defer span.End()
+			IncludeTestEngine: true,
+		})
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
 
-			deps := DepsFromContext(ctx)
-			logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
-			maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
-			maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
-			maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
-			maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
-			contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
+		result := BuildFailureSummary{Build: failureSummaryBuild(build), JobLimit: maxJobs}
 
-			span.SetAttributes(
-				attribute.String("org_slug", args.OrgSlug),
-				attribute.String("pipeline_slug", args.PipelineSlug),
-				attribute.String("build_number", args.BuildNumber),
-				attribute.Int("log_tail", logTail),
-				attribute.Int("max_jobs", maxJobs),
-				attribute.Int("max_test_runs", maxTestRuns),
-				attribute.Int("max_failed_tests", maxFailedTests),
-				attribute.Int("content_limit_bytes", contentLimit),
-				attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
-				attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
-				attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
-			)
+		includeRetriedJobs := false
+		primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+			// The API's failed filter includes running jobs with a hard promised
+			// failure. Querying running separately can include promises covered by
+			// soft-fail or retry rules that do not put the build into failing.
+			State:              []string{"failed", "timed_out", "expired"},
+			IncludeRetriedJobs: &includeRetriedJobs,
+			PerPage:            maxJobs + 1,
+		})
+		if err != nil {
+			return handleBuildkiteError(err)
+		}
 
-			build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
-				BuildsListOptions: buildkite.BuildsListOptions{
-					ExcludeJobs:     true,
-					ExcludePipeline: true,
-				},
-				IncludeTestEngine: true,
-			})
-			if err != nil {
-				return handleBuildkiteError(err)
+		sourceJobs := make([]buildkite.Job, 0, maxJobs)
+		jobsTruncated := primaryJobsList.Links.Next != ""
+		for _, job := range primaryJobsList.Items {
+			if !isPrimaryFailureSummaryJob(job) {
+				continue
 			}
+			if len(sourceJobs) < maxJobs {
+				sourceJobs = append(sourceJobs, job)
+			} else {
+				jobsTruncated = true
+			}
+		}
 
-			result := BuildFailureSummary{Build: failureSummaryBuild(build), JobLimit: maxJobs}
-
-			includeRetriedJobs := false
-			primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				// The API's failed filter includes running jobs with a hard promised
-				// failure. Querying running separately can include promises covered by
-				// soft-fail or retry rules that do not put the build into failing.
-				State:              []string{"failed", "timed_out", "expired"},
+		remainingJobs := maxJobs - len(sourceJobs)
+		if remainingJobs > 0 || !jobsTruncated {
+			canceledJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"canceled"},
 				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            maxJobs + 1,
+				PerPage:            remainingJobs + 1,
 			})
-			if err != nil {
-				return handleBuildkiteError(err)
+			if listErr != nil {
+				return handleBuildkiteError(listErr)
 			}
-
-			sourceJobs := make([]buildkite.Job, 0, maxJobs)
-			jobsTruncated := primaryJobsList.Links.Next != ""
-			for _, job := range primaryJobsList.Items {
-				if !isPrimaryFailureSummaryJob(job) {
+			jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
+			for _, job := range canceledJobsList.Items {
+				if !isCanceledFailureSummaryJob(job) {
 					continue
 				}
 				if len(sourceJobs) < maxJobs {
@@ -906,94 +928,72 @@ func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSumma
 					jobsTruncated = true
 				}
 			}
+		}
 
-			remainingJobs := maxJobs - len(sourceJobs)
-			if remainingJobs > 0 || !jobsTruncated {
-				canceledJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-					State:              []string{"canceled"},
-					IncludeRetriedJobs: &includeRetriedJobs,
-					PerPage:            remainingJobs + 1,
-				})
-				if listErr != nil {
-					return handleBuildkiteError(listErr)
-				}
-				jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
-				for _, job := range canceledJobsList.Items {
-					if !isCanceledFailureSummaryJob(job) {
-						continue
-					}
-					if len(sourceJobs) < maxJobs {
-						sourceJobs = append(sourceJobs, job)
-					} else {
-						jobsTruncated = true
-					}
-				}
+		remainingJobs = maxJobs - len(sourceJobs)
+		if remainingJobs > 0 || !jobsTruncated {
+			downstreamJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
+				IncludeRetriedJobs: &includeRetriedJobs,
+				PerPage:            remainingJobs + 1,
+			})
+			if listErr != nil {
+				return handleBuildkiteError(listErr)
 			}
-
-			remainingJobs = maxJobs - len(sourceJobs)
-			if remainingJobs > 0 || !jobsTruncated {
-				downstreamJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-					State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
-					IncludeRetriedJobs: &includeRetriedJobs,
-					PerPage:            remainingJobs + 1,
-				})
-				if listErr != nil {
-					return handleBuildkiteError(listErr)
+			jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
+			for _, job := range downstreamJobsList.Items {
+				if !isDownstreamFailureSummaryJob(job) {
+					continue
 				}
-				jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
-				for _, job := range downstreamJobsList.Items {
-					if !isDownstreamFailureSummaryJob(job) {
-						continue
-					}
-					if len(sourceJobs) < maxJobs {
-						sourceJobs = append(sourceJobs, job)
-					} else {
-						jobsTruncated = true
-					}
+				if len(sourceJobs) < maxJobs {
+					sourceJobs = append(sourceJobs, job)
+				} else {
+					jobsTruncated = true
 				}
 			}
-			result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
-			for i, job := range sourceJobs {
-				result.Jobs[i] = failureSummaryJob(job)
-			}
-			result.JobsTruncated = jobsTruncated
+		}
+		result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
+		for i, job := range sourceJobs {
+			result.Jobs[i] = failureSummaryJob(job)
+		}
+		result.JobsTruncated = jobsTruncated
 
-			if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
-				if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {
-					return nil, nil, err
+		if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
+			if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if defaultTrue(args.IncludeAnnotations) && deps.AnnotationsClient != nil {
+			result.Annotations, result.AnnotationsTruncated, err = loadFailureAnnotations(ctx, deps.AnnotationsClient, args, maxAnnotations)
+			if err != nil {
+				if isBuildkiteUnauthorized(err) {
+					return nil, nil, ErrUnauthorized
 				}
+				result.Warnings = append(result.Warnings, fmt.Sprintf("annotations unavailable after partial scan: %v", err))
 			}
+		}
 
-			if defaultTrue(args.IncludeAnnotations) && deps.AnnotationsClient != nil {
-				result.Annotations, result.AnnotationsTruncated, err = loadFailureAnnotations(ctx, deps.AnnotationsClient, args, maxAnnotations)
-				if err != nil {
-					if isBuildkiteUnauthorized(err) {
-						return nil, nil, ErrUnauthorized
-					}
-					result.Warnings = append(result.Warnings, fmt.Sprintf("annotations unavailable after partial scan: %v", err))
-				}
+		if defaultTrue(args.IncludeFailedTests) && deps.BuildTestsClient != nil && build.TestEngine != nil && len(build.TestEngine.Runs) > 0 {
+			var testWarnings []string
+			result.FailedTests, result.FailedTestsTruncated, testWarnings, err = loadFailureTests(ctx, deps, args, build, maxFailedTests, maxTestRuns)
+			if err != nil {
+				return nil, nil, err
 			}
+			result.Warnings = append(result.Warnings, testWarnings...)
+		}
 
-			if defaultTrue(args.IncludeFailedTests) && deps.BuildTestsClient != nil && build.TestEngine != nil && len(build.TestEngine.Runs) > 0 {
-				var testWarnings []string
-				result.FailedTests, result.FailedTestsTruncated, testWarnings, err = loadFailureTests(ctx, deps, args, build, maxFailedTests, maxTestRuns)
-				if err != nil {
-					return nil, nil, err
-				}
-				result.Warnings = append(result.Warnings, testWarnings...)
-			}
+		applyFailureSummaryContentLimits(&result)
+		if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
+			return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
+		}
 
-			applyFailureSummaryContentLimits(&result)
-			if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
-				return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
-			}
+		span.SetAttributes(
+			attribute.Int("failure_job_count", len(result.Jobs)),
+			attribute.Int("annotation_count", len(result.Annotations)),
+			attribute.Int("failed_test_count", len(result.FailedTests)),
+		)
 
-			span.SetAttributes(
-				attribute.Int("failure_job_count", len(result.Jobs)),
-				attribute.Int("annotation_count", len(result.Annotations)),
-				attribute.Int("failed_test_count", len(result.FailedTests)),
-			)
-
-			return mcpTextResultWithByteLimit(span, &result, contentLimit)
-		}, []string{"read_builds", "read_build_logs", "read_suites"}
+		return mcpTextResultWithByteLimit(span, &result, contentLimit)
+	}, []string{"read_builds", "read_build_logs", "read_suites"}
 }

--- a/pkg/buildkite/failure_summary.go
+++ b/pkg/buildkite/failure_summary.go
@@ -22,11 +22,18 @@ const (
 	maxFailureSummaryAnnotations         = 100
 	failureSummaryAnnotationPageSize     = 100
 	failureSummaryAnnotationScanPages    = 5
+	defaultFailureSummaryTestRuns        = 5
+	maxFailureSummaryTestRuns            = 20
+	defaultFailureSummaryFailedTests     = 50
+	maxFailureSummaryFailedTests         = 100
+	failureSummaryRunExecutionsPageSize  = 100
 	failureSummaryEntryContentByteLimit  = 4 * 1024
+	failureSummaryTestByteLimit          = 16 * 1024
 	failureSummaryLogJobContentByteLimit = 64 * 1024
 	failureSummaryLogContentByteLimit    = 128 * 1024
 	failureSummaryAnnotationContentLimit = 64 * 1024
-	failureSummaryContentByteLimit       = failureSummaryLogContentByteLimit + failureSummaryAnnotationContentLimit
+	failureSummaryTestContentByteLimit   = 64 * 1024
+	failureSummaryContentByteLimit       = failureSummaryLogContentByteLimit + failureSummaryAnnotationContentLimit + failureSummaryTestContentByteLimit
 	failureSummaryConcurrency            = 4
 )
 
@@ -38,12 +45,16 @@ type GetBuildFailureSummaryArgs struct {
 	OrgSlug                string `json:"org_slug"`
 	PipelineSlug           string `json:"pipeline_slug"`
 	BuildNumber            string `json:"build_number"`
-	LogTail            int   `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
-	MaxJobs            int   `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, server may enforce a lower maximum, absolute max 50)"`
-	MaxAnnotations     int   `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
-	ContentLimitBytes  int   `json:"content_limit_bytes,omitempty" jsonschema:"Maximum bytes for the response payload (default and max 196608); lower it to fit clients with small tool-result limits, combining with log_tail and max_jobs for finer trimming"`
-	IncludeLogs        *bool `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
-	IncludeAnnotations *bool `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
+	LogTail                int    `json:"log_tail,omitempty" jsonschema:"Log lines to include for each failed, timed-out, canceled, or promised-failing job (default 50, max 200)"`
+	MaxJobs                int    `json:"max_jobs,omitempty" jsonschema:"Maximum terminal problem or downstream-failed jobs to return (default 10, server may enforce a lower maximum, absolute max 50)"`
+	MaxAnnotations         int    `json:"max_annotations,omitempty" jsonschema:"Maximum error or warning annotations to return (default 20, max 100); the server scans at most 500 total annotations"`
+	MaxTestRuns            int    `json:"max_test_runs,omitempty" jsonschema:"Maximum Test Engine runs to scan for failure details of the returned failed tests (default 5, max 20)"`
+	MaxFailedTests         int    `json:"max_failed_tests,omitempty" jsonschema:"Maximum failed Test Engine tests to return for the build (default 50, max 100)"`
+	ContentLimitBytes      int    `json:"content_limit_bytes,omitempty" jsonschema:"Maximum bytes for the response payload (default and max 262144); lower it to fit clients with small tool-result limits, combining with log_tail and max_jobs for finer trimming"`
+	IncludeLogs            *bool  `json:"include_logs,omitempty" jsonschema:"Include a bounded log tail for failed, timed-out, canceled, and promised-failing jobs (default true)"`
+	IncludeAnnotations     *bool  `json:"include_annotations,omitempty" jsonschema:"Include error and warning annotation bodies (default true)"`
+	IncludeFailedTests     *bool  `json:"include_failed_tests,omitempty" jsonschema:"Include Test Engine tests whose executions in this build all failed, when the build has Test Engine runs (default true)"`
+	IncludeFailureExpanded bool   `json:"include_failure_expanded,omitempty" jsonschema:"Include expanded test failure details such as stack traces within the summary's bounded test-content budget"`
 }
 
 type BuildFailureSummaryBuild struct {
@@ -82,6 +93,21 @@ type FailureSummaryAnnotation struct {
 	BodyTruncated bool   `json:"body_truncated,omitempty"`
 }
 
+// FailureSummaryFailedTest is a Test Engine test whose executions in the build
+// all failed — tests rescued by a retry are excluded (the build tests API's
+// "result:^failed" tag filter). Failure detail fields come from the newest
+// matching failed execution found while scanning the build's Test Engine runs;
+// they stay empty when the bounded scan did not reach an execution for the
+// test, in which case get_failed_executions can fetch the detail.
+type FailureSummaryFailedTest struct {
+	buildkite.TestWithMetrics
+	RunID            string                      `json:"run_id,omitempty"`
+	TestSuiteSlug    string                      `json:"test_suite_slug,omitempty"`
+	FailureReason    string                      `json:"failure_reason,omitempty"`
+	FailureExpanded  []buildkite.FailureExpanded `json:"failure_expanded,omitempty"`
+	ContentTruncated bool                        `json:"content_truncated,omitempty"`
+}
+
 type BuildFailureSummary struct {
 	Build                BuildFailureSummaryBuild   `json:"build"`
 	Jobs                 []FailureSummaryJob        `json:"jobs"`
@@ -89,6 +115,8 @@ type BuildFailureSummary struct {
 	JobsTruncated        bool                       `json:"jobs_truncated,omitempty"`
 	Annotations          []FailureSummaryAnnotation `json:"annotations,omitempty"`
 	AnnotationsTruncated bool                       `json:"annotations_truncated,omitempty"`
+	FailedTests          []FailureSummaryFailedTest `json:"failed_tests,omitempty"`
+	FailedTestsTruncated bool                       `json:"failed_tests_truncated,omitempty"`
 	ContentBytes         int                        `json:"content_bytes"`
 	ContentLimitBytes    int                        `json:"content_limit_bytes"`
 	ContentTruncated     bool                       `json:"content_truncated,omitempty"`
@@ -353,6 +381,113 @@ func loadFailureLogs(ctx context.Context, client BuildkiteLogsClient, args GetBu
 	}
 }
 
+// loadFailureTests returns the build's genuinely failed Test Engine tests. The
+// build tests API's "result:^failed" tag filter keeps only tests for which
+// every execution in the build failed, so a test rescued by a retry never
+// appears — the same terminal-state view the jobs section gives. Failure
+// detail (failure_reason, failure_expanded) is then joined from a bounded scan
+// of each run's failed executions, keeping the newest execution per test.
+// Non-auth errors degrade to warnings so a token without the read_suites scope
+// still gets the rest of the summary.
+func loadFailureTests(ctx context.Context, deps ToolDependencies, args GetBuildFailureSummaryArgs, build buildkite.Build, maxTests, maxRuns int) ([]FailureSummaryFailedTest, bool, []string, error) {
+	tests, response, err := deps.BuildTestsClient.List(ctx, args.OrgSlug, build.ID, &buildkite.BuildTestsListOptions{
+		ListOptions: buildkite.ListOptions{Page: 1, PerPage: maxTests},
+		Tags:        "result:^failed",
+	})
+	if err != nil {
+		if isBuildkiteUnauthorized(err) {
+			return nil, false, nil, ErrUnauthorized
+		}
+		return nil, false, []string{fmt.Sprintf("failed tests unavailable: %v", err)}, nil
+	}
+
+	truncated := response != nil && response.NextPage > 0
+	if len(tests) > maxTests {
+		tests = tests[:maxTests]
+		truncated = true
+	}
+	if len(tests) == 0 {
+		return nil, truncated, nil, nil
+	}
+
+	results := make([]FailureSummaryFailedTest, len(tests))
+	indexByTestID := make(map[string]int, len(tests))
+	for i, test := range tests {
+		results[i] = FailureSummaryFailedTest{TestWithMetrics: test}
+		indexByTestID[test.ID] = i
+	}
+
+	if deps.TestExecutionsClient == nil {
+		return results, truncated, nil, nil
+	}
+
+	var warnings []string
+	runs := build.TestEngine.Runs
+	if len(runs) > maxRuns {
+		warnings = append(warnings, fmt.Sprintf("test failure details cover only the first %d of %d Test Engine runs", maxRuns, len(runs)))
+		runs = runs[:maxRuns]
+	}
+
+	executionsByRun := make([][]buildkite.FailedExecution, len(runs))
+	runErrors := make([]error, len(runs))
+	semaphore := make(chan struct{}, failureSummaryConcurrency)
+	var waitGroup sync.WaitGroup
+	for i := range runs {
+		waitGroup.Add(1)
+		go func(index int) {
+			defer waitGroup.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+
+			executions, _, executionsErr := deps.TestExecutionsClient.GetFailedExecutions(ctx, args.OrgSlug, runs[index].Suite.Slug, runs[index].ID, &buildkite.FailedExecutionsOptions{
+				IncludeFailureExpanded: args.IncludeFailureExpanded,
+				Page:                   1,
+				PerPage:                failureSummaryRunExecutionsPageSize,
+			})
+			if executionsErr != nil {
+				runErrors[index] = executionsErr
+				return
+			}
+			executionsByRun[index] = executions
+		}(i)
+	}
+	waitGroup.Wait()
+
+	hasDetail := make([]bool, len(results))
+	detailAt := make([]*buildkite.Timestamp, len(results))
+	for i, run := range runs {
+		if runErrors[i] != nil {
+			if isBuildkiteUnauthorized(runErrors[i]) {
+				return nil, false, nil, ErrUnauthorized
+			}
+			warnings = append(warnings, fmt.Sprintf("test failure details unavailable for run %s: %v", run.ID, runErrors[i]))
+			continue
+		}
+		for _, execution := range executionsByRun[i] {
+			index, ok := indexByTestID[execution.TestID]
+			if !ok {
+				// A failure that a later retry rescued, or a test beyond
+				// maxTests — not part of the returned set.
+				continue
+			}
+			if hasDetail[index] {
+				newer := execution.CreatedAt != nil && (detailAt[index] == nil || execution.CreatedAt.After(detailAt[index].Time))
+				if !newer {
+					continue
+				}
+			}
+			hasDetail[index] = true
+			detailAt[index] = execution.CreatedAt
+			results[index].RunID = run.ID
+			results[index].TestSuiteSlug = run.Suite.Slug
+			results[index].FailureReason = execution.FailureReason
+			results[index].FailureExpanded = execution.FailureExpanded
+		}
+	}
+
+	return results, truncated, warnings, nil
+}
+
 func limitFailureSummaryString(value string, fieldLimit int, entryRemaining, sectionRemaining *int) (string, bool) {
 	limit := min(fieldLimit, *entryRemaining, *sectionRemaining)
 	result, truncated := truncateUTF8Bytes(value, limit)
@@ -368,6 +503,103 @@ func failureSummaryLogContentBytes(entries []FailureSummaryLogEntry) int {
 		total += len(entry.C)
 	}
 	return total
+}
+
+func consumeFailureSummaryBytes(size int, entryRemaining, sectionRemaining *int) bool {
+	if size > *entryRemaining || size > *sectionRemaining {
+		return false
+	}
+	*entryRemaining -= size
+	*sectionRemaining -= size
+	return true
+}
+
+func limitFailureExpanded(values []buildkite.FailureExpanded, entryRemaining, sectionRemaining *int) ([]buildkite.FailureExpanded, bool) {
+	result := make([]buildkite.FailureExpanded, 0, len(values))
+	truncated := false
+	if len(values) > 0 && !consumeFailureSummaryBytes(len(`"failure_expanded":[]`), entryRemaining, sectionRemaining) {
+		return result, true
+	}
+	for _, value := range values {
+		objectBytes := len(`{}`)
+		if len(result) > 0 {
+			objectBytes++ // comma between failure_expanded items
+		}
+		if !consumeFailureSummaryBytes(objectBytes, entryRemaining, sectionRemaining) {
+			truncated = true
+			break
+		}
+
+		bounded := buildkite.FailureExpanded{}
+		for _, backtrace := range value.Backtrace {
+			structureBytes := len(`""`)
+			if len(bounded.Backtrace) == 0 {
+				structureBytes += len(`"backtrace":[]`)
+			} else {
+				structureBytes++ // comma between backtrace items
+			}
+			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
+				truncated = true
+				break
+			}
+			line, lineTruncated := limitFailureSummaryString(backtrace, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
+			bounded.Backtrace = append(bounded.Backtrace, line)
+			truncated = truncated || lineTruncated
+		}
+		if len(bounded.Backtrace) < len(value.Backtrace) {
+			truncated = true
+		}
+		for _, expanded := range value.Expanded {
+			structureBytes := len(`""`)
+			if len(bounded.Expanded) == 0 {
+				structureBytes += len(`"expanded":[]`)
+				if len(bounded.Backtrace) > 0 {
+					structureBytes++ // comma between object fields
+				}
+			} else {
+				structureBytes++ // comma between expanded items
+			}
+			if !consumeFailureSummaryBytes(structureBytes, entryRemaining, sectionRemaining) {
+				truncated = true
+				break
+			}
+			line, lineTruncated := limitFailureSummaryString(expanded, failureSummaryEntryContentByteLimit, entryRemaining, sectionRemaining)
+			bounded.Expanded = append(bounded.Expanded, line)
+			truncated = truncated || lineTruncated
+		}
+		if len(bounded.Expanded) < len(value.Expanded) {
+			truncated = true
+		}
+		result = append(result, bounded)
+		if *entryRemaining <= 0 || *sectionRemaining <= 0 {
+			if len(result) < len(values) {
+				truncated = true
+			}
+			break
+		}
+	}
+	return result, truncated
+}
+
+func limitFailureTest(test *FailureSummaryFailedTest, limit int, sectionRemaining *int) bool {
+	entryRemaining := limit
+	truncated := test.ContentTruncated
+	fields := []*string{
+		&test.FailureReason,
+		&test.Name,
+		&test.Location,
+	}
+	for _, field := range fields {
+		var fieldTruncated bool
+		*field, fieldTruncated = limitFailureSummaryString(*field, failureSummaryEntryContentByteLimit, &entryRemaining, sectionRemaining)
+		truncated = truncated || fieldTruncated
+	}
+
+	var expandedTruncated bool
+	test.FailureExpanded, expandedTruncated = limitFailureExpanded(test.FailureExpanded, &entryRemaining, sectionRemaining)
+	truncated = truncated || expandedTruncated
+	test.ContentTruncated = truncated
+	return truncated
 }
 
 func applyFailureSummaryContentLimits(result *BuildFailureSummary) {
@@ -420,6 +652,14 @@ func applyFailureSummaryContentLimits(result *BuildFailureSummary) {
 		result.ContentTruncated = result.ContentTruncated || annotation.BodyTruncated
 	}
 
+	testRemaining := failureSummaryTestContentByteLimit
+	testItemsRemaining := len(result.FailedTests)
+	for i := range result.FailedTests {
+		itemLimit := min(failureSummaryTestByteLimit, testRemaining/testItemsRemaining)
+		truncated := limitFailureTest(&result.FailedTests[i], itemLimit, &testRemaining)
+		result.ContentTruncated = result.ContentTruncated || truncated
+		testItemsRemaining--
+	}
 }
 
 func failureSummaryWithLogEntryLimit(result *BuildFailureSummary, perJobLimit int) BuildFailureSummary {
@@ -455,6 +695,23 @@ func marshalFailureSummaryWithContentBytes(result *BuildFailureSummary) ([]byte,
 	}
 }
 
+// failureSummaryWithFailedTestLimit returns a copy of the summary keeping at
+// most the first maxTests failed tests.
+func failureSummaryWithFailedTestLimit(result *BuildFailureSummary, maxTests int) BuildFailureSummary {
+	limited := *result
+	if len(result.FailedTests) <= maxTests {
+		return limited
+	}
+
+	limited.FailedTests = append([]FailureSummaryFailedTest(nil), result.FailedTests[:maxTests]...)
+	limited.FailedTestsTruncated = true
+	limited.ContentTruncated = true
+	return limited
+}
+
+// failureSummaryWithAnnotationLimit returns a copy of the summary keeping at
+// most the first maxAnnotations annotations (the API returns them in priority
+// order).
 func failureSummaryWithAnnotationLimit(result *BuildFailureSummary, maxAnnotations int) BuildFailureSummary {
 	limited := *result
 	if len(result.Annotations) <= maxAnnotations {
@@ -527,7 +784,7 @@ func shrinkFailureSummaryToFit(result *BuildFailureSummary, limit, maxEntries in
 // so the generic payload limiter that runs afterwards can fit the limit by
 // shortening strings alone — it never drops array items. Per-job log tails
 // are trimmed against the full serialized size (newest lines kept, the
-// long-standing behavior). Failed test executions and annotations are only
+// long-standing behavior). Failed tests and annotations are only
 // reduced while the strings-emptied structure floor exceeds the limit — the
 // exact condition under which the generic limiter would fail — so a payload
 // oversized by string content alone keeps its default collection membership.
@@ -548,160 +805,195 @@ func limitFailureSummaryCollections(result *BuildFailureSummary, limit int) erro
 		return err
 	}
 
-	floor, err := failureSummaryStructureBytes(result, limit)
-	if err != nil {
-		return err
+	structureReductions := []struct {
+		maxEntries func(*BuildFailureSummary) int
+		withLimit  func(*BuildFailureSummary, int) BuildFailureSummary
+	}{
+		{
+			maxEntries: func(r *BuildFailureSummary) int { return len(r.FailedTests) },
+			withLimit:  failureSummaryWithFailedTestLimit,
+		},
+		{
+			maxEntries: func(r *BuildFailureSummary) int { return len(r.Annotations) },
+			withLimit:  failureSummaryWithAnnotationLimit,
+		},
 	}
-	if floor <= limit {
-		return nil
+
+	for _, reduction := range structureReductions {
+		floor, err := failureSummaryStructureBytes(result, limit)
+		if err != nil {
+			return err
+		}
+		if floor <= limit {
+			return nil
+		}
+		if err := shrinkFailureSummaryToFit(result, limit, reduction.maxEntries(result), reduction.withLimit, failureSummaryStructureBytes); err != nil {
+			return err
+		}
 	}
-	return shrinkFailureSummaryToFit(result, limit, len(result.Annotations), failureSummaryWithAnnotationLimit, failureSummaryStructureBytes)
+	return nil
 }
 
 func GetBuildFailureSummary() (mcp.Tool, mcp.ToolHandlerFor[GetBuildFailureSummaryArgs, any], []string) {
 	return mcp.Tool{
-		Name:        "get_build_failure_summary",
-		Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs and annotations. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, or annotation tools.",
-		Annotations: &mcp.ToolAnnotations{
-			Title:        "Get Build Failure Summary",
-			ReadOnlyHint: true,
-		},
-	}, func(ctx context.Context, request *mcp.CallToolRequest, args GetBuildFailureSummaryArgs) (*mcp.CallToolResult, any, error) {
-		ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
-		defer span.End()
-
-		deps := DepsFromContext(ctx)
-		logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
-		maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
-		maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
-		contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
-
-		span.SetAttributes(
-			attribute.String("org_slug", args.OrgSlug),
-			attribute.String("pipeline_slug", args.PipelineSlug),
-			attribute.String("build_number", args.BuildNumber),
-			attribute.Int("log_tail", logTail),
-			attribute.Int("max_jobs", maxJobs),
-			attribute.Int("content_limit_bytes", contentLimit),
-			attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
-			attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
-		)
-
-		build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
-			BuildsListOptions: buildkite.BuildsListOptions{
-				ExcludeJobs:     true,
-				ExcludePipeline: true,
+			Name:        "get_build_failure_summary",
+			Description: "Diagnose a Buildkite build failure in one call. Returns build.state, build.job_state_counts tallying every job in the build by state (when present, use it to confirm the returned problem jobs are the build's only problems without calling list_jobs), terminal problem jobs, downstream failed or broken jobs, promised failures from running jobs, and size-bounded diagnostic content from logs, annotations, and failed Test Engine tests. The failed_tests section lists only tests whose executions in this build all failed — a test that passed on retry is excluded, matching the terminal-state job view — with failure_reason joined from the newest failed execution where available; call get_failed_executions for full execution detail. Annotation content is in the body_html field; there is no body field. Start with this tool before calling individual job, log, annotation, or test tools.",
+			Annotations: &mcp.ToolAnnotations{
+				Title:        "Get Build Failure Summary",
+				ReadOnlyHint: true,
 			},
-		})
-		if err != nil {
-			return handleBuildkiteError(err)
-		}
+		}, func(ctx context.Context, request *mcp.CallToolRequest, args GetBuildFailureSummaryArgs) (*mcp.CallToolResult, any, error) {
+			ctx, span := trace.Start(ctx, "buildkite.GetBuildFailureSummary")
+			defer span.End()
 
-		result := BuildFailureSummary{Build: failureSummaryBuild(build), JobLimit: maxJobs}
+			deps := DepsFromContext(ctx)
+			logTail := boundedValue(args.LogTail, defaultFailureSummaryLogTail, maxFailureSummaryLogTail)
+			maxJobs := boundedFailureSummaryJobs(args.MaxJobs, deps.FailureSummary.MaxJobs)
+			maxAnnotations := boundedValue(args.MaxAnnotations, defaultFailureSummaryAnnotations, maxFailureSummaryAnnotations)
+			maxTestRuns := boundedValue(args.MaxTestRuns, defaultFailureSummaryTestRuns, maxFailureSummaryTestRuns)
+			maxFailedTests := boundedValue(args.MaxFailedTests, defaultFailureSummaryFailedTests, maxFailureSummaryFailedTests)
+			contentLimit := boundedValue(args.ContentLimitBytes, failureSummaryContentByteLimit, failureSummaryContentByteLimit)
 
-		includeRetriedJobs := false
-		primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-			// The API's failed filter includes running jobs with a hard promised
-			// failure. Querying running separately can include promises covered by
-			// soft-fail or retry rules that do not put the build into failing.
-			State:              []string{"failed", "timed_out", "expired"},
-			IncludeRetriedJobs: &includeRetriedJobs,
-			PerPage:            maxJobs + 1,
-		})
-		if err != nil {
-			return handleBuildkiteError(err)
-		}
+			span.SetAttributes(
+				attribute.String("org_slug", args.OrgSlug),
+				attribute.String("pipeline_slug", args.PipelineSlug),
+				attribute.String("build_number", args.BuildNumber),
+				attribute.Int("log_tail", logTail),
+				attribute.Int("max_jobs", maxJobs),
+				attribute.Int("max_test_runs", maxTestRuns),
+				attribute.Int("max_failed_tests", maxFailedTests),
+				attribute.Int("content_limit_bytes", contentLimit),
+				attribute.Bool("include_logs", defaultTrue(args.IncludeLogs)),
+				attribute.Bool("include_annotations", defaultTrue(args.IncludeAnnotations)),
+				attribute.Bool("include_failed_tests", defaultTrue(args.IncludeFailedTests)),
+			)
 
-		sourceJobs := make([]buildkite.Job, 0, maxJobs)
-		jobsTruncated := primaryJobsList.Links.Next != ""
-		for _, job := range primaryJobsList.Items {
-			if !isPrimaryFailureSummaryJob(job) {
-				continue
-			}
-			if len(sourceJobs) < maxJobs {
-				sourceJobs = append(sourceJobs, job)
-			} else {
-				jobsTruncated = true
-			}
-		}
-
-		remainingJobs := maxJobs - len(sourceJobs)
-		if remainingJobs > 0 || !jobsTruncated {
-			canceledJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"canceled"},
-				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            remainingJobs + 1,
+			build, _, err := deps.BuildsClient.Get(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.BuildGetOptions{
+				BuildsListOptions: buildkite.BuildsListOptions{
+					ExcludeJobs:     true,
+					ExcludePipeline: true,
+				},
+				IncludeTestEngine: true,
 			})
-			if listErr != nil {
-				return handleBuildkiteError(listErr)
-			}
-			jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
-			for _, job := range canceledJobsList.Items {
-				if !isCanceledFailureSummaryJob(job) {
-					continue
-				}
-				if len(sourceJobs) < maxJobs {
-					sourceJobs = append(sourceJobs, job)
-				} else {
-					jobsTruncated = true
-				}
-			}
-		}
-
-		remainingJobs = maxJobs - len(sourceJobs)
-		if remainingJobs > 0 || !jobsTruncated {
-			downstreamJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
-				State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
-				IncludeRetriedJobs: &includeRetriedJobs,
-				PerPage:            remainingJobs + 1,
-			})
-			if listErr != nil {
-				return handleBuildkiteError(listErr)
-			}
-			jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
-			for _, job := range downstreamJobsList.Items {
-				if !isDownstreamFailureSummaryJob(job) {
-					continue
-				}
-				if len(sourceJobs) < maxJobs {
-					sourceJobs = append(sourceJobs, job)
-				} else {
-					jobsTruncated = true
-				}
-			}
-		}
-		result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
-		for i, job := range sourceJobs {
-			result.Jobs[i] = failureSummaryJob(job)
-		}
-		result.JobsTruncated = jobsTruncated
-
-		if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
-			if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {
-				return nil, nil, err
-			}
-		}
-
-		if defaultTrue(args.IncludeAnnotations) && deps.AnnotationsClient != nil {
-			result.Annotations, result.AnnotationsTruncated, err = loadFailureAnnotations(ctx, deps.AnnotationsClient, args, maxAnnotations)
 			if err != nil {
-				if isBuildkiteUnauthorized(err) {
-					return nil, nil, ErrUnauthorized
-				}
-				result.Warnings = append(result.Warnings, fmt.Sprintf("annotations unavailable after partial scan: %v", err))
+				return handleBuildkiteError(err)
 			}
-		}
 
-		applyFailureSummaryContentLimits(&result)
-		if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
-			return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
-		}
+			result := BuildFailureSummary{Build: failureSummaryBuild(build), JobLimit: maxJobs}
 
-		span.SetAttributes(
-			attribute.Int("failure_job_count", len(result.Jobs)),
-			attribute.Int("annotation_count", len(result.Annotations)),
-		)
+			includeRetriedJobs := false
+			primaryJobsList, _, err := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+				// The API's failed filter includes running jobs with a hard promised
+				// failure. Querying running separately can include promises covered by
+				// soft-fail or retry rules that do not put the build into failing.
+				State:              []string{"failed", "timed_out", "expired"},
+				IncludeRetriedJobs: &includeRetriedJobs,
+				PerPage:            maxJobs + 1,
+			})
+			if err != nil {
+				return handleBuildkiteError(err)
+			}
 
-		return mcpTextResultWithByteLimit(span, &result, contentLimit)
-	}, []string{"read_builds", "read_build_logs"}
+			sourceJobs := make([]buildkite.Job, 0, maxJobs)
+			jobsTruncated := primaryJobsList.Links.Next != ""
+			for _, job := range primaryJobsList.Items {
+				if !isPrimaryFailureSummaryJob(job) {
+					continue
+				}
+				if len(sourceJobs) < maxJobs {
+					sourceJobs = append(sourceJobs, job)
+				} else {
+					jobsTruncated = true
+				}
+			}
+
+			remainingJobs := maxJobs - len(sourceJobs)
+			if remainingJobs > 0 || !jobsTruncated {
+				canceledJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+					State:              []string{"canceled"},
+					IncludeRetriedJobs: &includeRetriedJobs,
+					PerPage:            remainingJobs + 1,
+				})
+				if listErr != nil {
+					return handleBuildkiteError(listErr)
+				}
+				jobsTruncated = jobsTruncated || canceledJobsList.Links.Next != ""
+				for _, job := range canceledJobsList.Items {
+					if !isCanceledFailureSummaryJob(job) {
+						continue
+					}
+					if len(sourceJobs) < maxJobs {
+						sourceJobs = append(sourceJobs, job)
+					} else {
+						jobsTruncated = true
+					}
+				}
+			}
+
+			remainingJobs = maxJobs - len(sourceJobs)
+			if remainingJobs > 0 || !jobsTruncated {
+				downstreamJobsList, _, listErr := deps.JobsClient.ListByBuild(ctx, args.OrgSlug, args.PipelineSlug, args.BuildNumber, &buildkite.JobsListOptions{
+					State:              []string{"broken", "waiting_failed", "blocked_failed", "unblocked_failed"},
+					IncludeRetriedJobs: &includeRetriedJobs,
+					PerPage:            remainingJobs + 1,
+				})
+				if listErr != nil {
+					return handleBuildkiteError(listErr)
+				}
+				jobsTruncated = jobsTruncated || downstreamJobsList.Links.Next != ""
+				for _, job := range downstreamJobsList.Items {
+					if !isDownstreamFailureSummaryJob(job) {
+						continue
+					}
+					if len(sourceJobs) < maxJobs {
+						sourceJobs = append(sourceJobs, job)
+					} else {
+						jobsTruncated = true
+					}
+				}
+			}
+			result.Jobs = make([]FailureSummaryJob, len(sourceJobs))
+			for i, job := range sourceJobs {
+				result.Jobs[i] = failureSummaryJob(job)
+			}
+			result.JobsTruncated = jobsTruncated
+
+			if defaultTrue(args.IncludeLogs) && deps.BuildkiteLogsClient != nil {
+				if err := loadFailureLogs(ctx, deps.BuildkiteLogsClient, args, sourceJobs, result.Jobs, logTail); err != nil {
+					return nil, nil, err
+				}
+			}
+
+			if defaultTrue(args.IncludeAnnotations) && deps.AnnotationsClient != nil {
+				result.Annotations, result.AnnotationsTruncated, err = loadFailureAnnotations(ctx, deps.AnnotationsClient, args, maxAnnotations)
+				if err != nil {
+					if isBuildkiteUnauthorized(err) {
+						return nil, nil, ErrUnauthorized
+					}
+					result.Warnings = append(result.Warnings, fmt.Sprintf("annotations unavailable after partial scan: %v", err))
+				}
+			}
+
+			if defaultTrue(args.IncludeFailedTests) && deps.BuildTestsClient != nil && build.TestEngine != nil && len(build.TestEngine.Runs) > 0 {
+				var testWarnings []string
+				result.FailedTests, result.FailedTestsTruncated, testWarnings, err = loadFailureTests(ctx, deps, args, build, maxFailedTests, maxTestRuns)
+				if err != nil {
+					return nil, nil, err
+				}
+				result.Warnings = append(result.Warnings, testWarnings...)
+			}
+
+			applyFailureSummaryContentLimits(&result)
+			if err := limitFailureSummaryCollections(&result, contentLimit); err != nil {
+				return utils.NewToolResultError(fmt.Sprintf("failed to limit failure summary logs: %v", err)), nil, nil
+			}
+
+			span.SetAttributes(
+				attribute.Int("failure_job_count", len(result.Jobs)),
+				attribute.Int("annotation_count", len(result.Annotations)),
+				attribute.Int("failed_test_count", len(result.FailedTests)),
+			)
+
+			return mcpTextResultWithByteLimit(span, &result, contentLimit)
+		}, []string{"read_builds", "read_build_logs", "read_suites"}
 }

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -24,7 +24,7 @@ func TestGetBuildFailureSummaryToolDefinition(t *testing.T) {
 	require.Equal(t, "get_build_failure_summary", tool.Name)
 	require.True(t, tool.Annotations.ReadOnlyHint)
 	require.Contains(t, tool.Description, "one call")
-	require.Equal(t, []string{"read_builds", "read_build_logs"}, scopes)
+	require.Equal(t, []string{"read_builds", "read_build_logs", "read_suites"}, scopes)
 	require.NotNil(t, handler)
 }
 
@@ -603,10 +603,10 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		requested := 6 * 1024
 		include := false
 		callResult, _, err := handler(logCtx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-			OrgSlug:           "org",
-			PipelineSlug:      "pipeline",
-			BuildNumber:       "1",
-			ContentLimitBytes: requested,
+			OrgSlug:            "org",
+			PipelineSlug:       "pipeline",
+			BuildNumber:        "1",
+			ContentLimitBytes:  requested,
 			IncludeAnnotations: &include,
 		})
 
@@ -870,7 +870,6 @@ func TestApplyFailureSummaryContentLimitsBoundsAggregateContent(t *testing.T) {
 	require.True(t, result.Annotations[len(result.Annotations)-1].BodyTruncated)
 }
 
-
 func TestLimitFailureSummaryLogCollectionsRetainsNewestRowsAndUpdatesMetadata(t *testing.T) {
 	const jobCount = 50
 	const entriesPerJob = 200
@@ -965,4 +964,298 @@ func TestLoadFailureAnnotationsStopsAtScanLimit(t *testing.T) {
 	require.Empty(t, annotations)
 	require.True(t, truncated)
 	require.Equal(t, failureSummaryAnnotationScanPages, pages)
+}
+
+func TestGetBuildFailureSummaryIncludesGenuinelyFailedTests(t *testing.T) {
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(_ context.Context, _, _, _ string, options *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			require.True(t, options.IncludeTestEngine)
+			return buildkite.Build{
+				ID:     "build-uuid",
+				Number: 42,
+				State:  "failed",
+				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{
+					{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
+					{ID: "run-2", Suite: buildkite.TestEngineSuite{Slug: "suite-2"}},
+				}},
+			}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+	buildTestsClient := &MockBuildTestsClient{
+		ListFunc: func(_ context.Context, org, buildUUID string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, "build-uuid", buildUUID)
+			require.Equal(t, "result:^failed", opt.Tags)
+			require.Equal(t, defaultFailureSummaryFailedTests, opt.PerPage)
+			return []buildkite.TestWithMetrics{
+				{Test: buildkite.Test{ID: "test-a", Name: "a always fails"}},
+				{Test: buildkite.Test{ID: "test-b", Name: "b always fails"}},
+			}, &buildkite.Response{}, nil
+		},
+	}
+	older := buildkite.NewTimestamp(time.Date(2026, 9, 10, 10, 0, 0, 0, time.UTC))
+	newer := buildkite.NewTimestamp(time.Date(2026, 9, 10, 11, 0, 0, 0, time.UTC))
+	testExecutionsClient := &MockTestExecutionsClient{
+		GetFailedExecutionsFunc: func(_ context.Context, org, slug, runID string, opt *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+			require.Equal(t, "org", org)
+			require.Equal(t, failureSummaryRunExecutionsPageSize, opt.PerPage)
+			switch runID {
+			case "run-1":
+				require.Equal(t, "suite-1", slug)
+				return []buildkite.FailedExecution{
+					{TestID: "test-a", FailureReason: "older failure", CreatedAt: older},
+					{TestID: "test-rescued", FailureReason: "passed on retry", CreatedAt: older},
+				}, &buildkite.Response{}, nil
+			case "run-2":
+				require.Equal(t, "suite-2", slug)
+				return []buildkite.FailedExecution{
+					{TestID: "test-a", FailureReason: "newest failure", CreatedAt: newer},
+					{TestID: "test-b", FailureReason: "b failed", CreatedAt: older},
+				}, &buildkite.Response{}, nil
+			default:
+				return nil, nil, fmt.Errorf("unexpected run: %s", runID)
+			}
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:         buildsClient,
+		JobsClient:           jobsClient,
+		BuildTestsClient:     buildTestsClient,
+		TestExecutionsClient: testExecutionsClient,
+	})
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "42",
+	})
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+
+	text := getTextResult(t, callResult).Text
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(text), &summary))
+	require.Len(t, summary.FailedTests, 2)
+	require.False(t, summary.FailedTestsTruncated)
+	require.Empty(t, summary.Warnings)
+
+	require.Equal(t, "test-a", summary.FailedTests[0].ID)
+	require.Equal(t, "newest failure", summary.FailedTests[0].FailureReason)
+	require.Equal(t, "run-2", summary.FailedTests[0].RunID)
+	require.Equal(t, "suite-2", summary.FailedTests[0].TestSuiteSlug)
+
+	require.Equal(t, "test-b", summary.FailedTests[1].ID)
+	require.Equal(t, "b failed", summary.FailedTests[1].FailureReason)
+	require.NotContains(t, text, "test-rescued")
+}
+
+func TestGetBuildFailureSummarySkipsFailedTestsWithoutTestEngine(t *testing.T) {
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{ID: "build-uuid", Number: 42, State: "failed"}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+	buildTestsClient := &MockBuildTestsClient{
+		ListFunc: func(context.Context, string, string, *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			require.Fail(t, "build tests must not be listed for builds without Test Engine data")
+			return nil, nil, nil
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:     buildsClient,
+		JobsClient:       jobsClient,
+		BuildTestsClient: buildTestsClient,
+	})
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "42",
+	})
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+	require.NotContains(t, getTextResult(t, callResult).Text, "failed_tests")
+}
+
+func TestGetBuildFailureSummaryFailedTestsForbiddenBecomesWarning(t *testing.T) {
+	forbidden := &buildkite.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "https", Host: "api.buildkite.com"},
+			},
+		},
+		Message: "Your access token is missing the read_suites scope",
+	}
+	buildsClient := &MockBuildsClient{
+		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
+			return buildkite.Build{
+				ID:     "build-uuid",
+				Number: 42,
+				State:  "failed",
+				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{
+					{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
+				}},
+			}, &buildkite.Response{}, nil
+		},
+	}
+	jobsClient := &MockJobsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
+			if options.State[0] == "failed" {
+				return buildkite.JobsList{Items: []buildkite.Job{{ID: "job", State: "failed"}}}, &buildkite.Response{}, nil
+			}
+			return buildkite.JobsList{}, &buildkite.Response{}, nil
+		},
+	}
+	buildTestsClient := &MockBuildTestsClient{
+		ListFunc: func(context.Context, string, string, *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+			return nil, nil, forbidden
+		},
+	}
+
+	ctx := ContextWithDeps(context.Background(), ToolDependencies{
+		BuildsClient:     buildsClient,
+		JobsClient:       jobsClient,
+		BuildTestsClient: buildTestsClient,
+	})
+	_, handler, _ := GetBuildFailureSummary()
+	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
+		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "42",
+	})
+	require.NoError(t, err)
+	require.False(t, callResult.IsError)
+
+	var summary BuildFailureSummary
+	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
+	require.Len(t, summary.Jobs, 1)
+	require.Empty(t, summary.FailedTests)
+	require.Len(t, summary.Warnings, 1)
+	require.Contains(t, summary.Warnings[0], forbidden.Message)
+}
+
+func TestLoadFailureTestsPropagatesUnauthorized(t *testing.T) {
+	unauthorized := fmt.Errorf("wrapped API failure: %w", &buildkite.ErrorResponse{
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Request: &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Scheme: "https", Host: "api.buildkite.com"},
+			},
+		},
+	})
+	args := GetBuildFailureSummaryArgs{OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1"}
+	build := buildkite.Build{
+		ID: "build-uuid",
+		TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{
+			{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
+		}},
+	}
+
+	t.Run("build tests list", func(t *testing.T) {
+		deps := ToolDependencies{
+			BuildTestsClient: &MockBuildTestsClient{
+				ListFunc: func(context.Context, string, string, *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+					return nil, nil, unauthorized
+				},
+			},
+		}
+		_, _, _, err := loadFailureTests(context.Background(), deps, args, build, defaultFailureSummaryFailedTests, defaultFailureSummaryTestRuns)
+		require.ErrorIs(t, err, ErrUnauthorized)
+	})
+
+	t.Run("failed executions", func(t *testing.T) {
+		deps := ToolDependencies{
+			BuildTestsClient: &MockBuildTestsClient{
+				ListFunc: func(context.Context, string, string, *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+					return []buildkite.TestWithMetrics{{Test: buildkite.Test{ID: "test-a"}}}, &buildkite.Response{}, nil
+				},
+			},
+			TestExecutionsClient: &MockTestExecutionsClient{
+				GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+					return nil, nil, unauthorized
+				},
+			},
+		}
+		_, _, _, err := loadFailureTests(context.Background(), deps, args, build, defaultFailureSummaryFailedTests, defaultFailureSummaryTestRuns)
+		require.ErrorIs(t, err, ErrUnauthorized)
+	})
+}
+
+func TestLoadFailureTestsBoundsRunsAndReportsWarnings(t *testing.T) {
+	args := GetBuildFailureSummaryArgs{OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1"}
+	build := buildkite.Build{
+		ID: "build-uuid",
+		TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{
+			{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
+			{ID: "run-2", Suite: buildkite.TestEngineSuite{Slug: "suite-2"}},
+			{ID: "run-3", Suite: buildkite.TestEngineSuite{Slug: "suite-3"}},
+		}},
+	}
+	deps := ToolDependencies{
+		BuildTestsClient: &MockBuildTestsClient{
+			ListFunc: func(_ context.Context, _, _ string, opt *buildkite.BuildTestsListOptions) ([]buildkite.TestWithMetrics, *buildkite.Response, error) {
+				require.Equal(t, 2, opt.PerPage)
+				return []buildkite.TestWithMetrics{
+					{Test: buildkite.Test{ID: "test-a"}},
+					{Test: buildkite.Test{ID: "test-b"}},
+				}, &buildkite.Response{NextPage: 2}, nil
+			},
+		},
+		TestExecutionsClient: &MockTestExecutionsClient{
+			GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, _ *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
+				switch runID {
+				case "run-1":
+					return []buildkite.FailedExecution{{TestID: "test-a", FailureReason: "boom"}}, &buildkite.Response{}, nil
+				case "run-2":
+					return nil, nil, errors.New("executions endpoint unavailable")
+				default:
+					return nil, nil, fmt.Errorf("unexpected run scanned: %s", runID)
+				}
+			},
+		},
+	}
+
+	tests, truncated, warnings, err := loadFailureTests(context.Background(), deps, args, build, 2, 2)
+	require.NoError(t, err)
+	require.True(t, truncated)
+	require.Len(t, tests, 2)
+	require.Equal(t, "boom", tests[0].FailureReason)
+	require.Equal(t, "run-1", tests[0].RunID)
+	require.Empty(t, tests[1].FailureReason)
+	require.Len(t, warnings, 2)
+	require.Contains(t, warnings[0], "first 2 of 3 Test Engine runs")
+	require.Contains(t, warnings[1], "run-2")
+	require.Contains(t, warnings[1], "executions endpoint unavailable")
+}
+
+func TestApplyFailureSummaryContentLimitsBoundsFailedTestContent(t *testing.T) {
+	summary := &BuildFailureSummary{
+		FailedTests: []FailureSummaryFailedTest{{
+			TestWithMetrics: buildkite.TestWithMetrics{Test: buildkite.Test{
+				ID:   "test",
+				Name: strings.Repeat("n", 2*failureSummaryEntryContentByteLimit),
+			}},
+			FailureReason: strings.Repeat("r", 2*failureSummaryEntryContentByteLimit),
+			FailureExpanded: []buildkite.FailureExpanded{{
+				Backtrace: []string{strings.Repeat("b", 2*failureSummaryEntryContentByteLimit)},
+			}},
+		}},
+	}
+
+	applyFailureSummaryContentLimits(summary)
+
+	require.True(t, summary.ContentTruncated)
+	require.True(t, summary.FailedTests[0].ContentTruncated)
+	require.LessOrEqual(t, len(summary.FailedTests[0].FailureReason), failureSummaryEntryContentByteLimit)
+	require.LessOrEqual(t, len(summary.FailedTests[0].Name), failureSummaryEntryContentByteLimit)
+	require.LessOrEqual(t, len(summary.FailedTests[0].FailureExpanded[0].Backtrace[0]), failureSummaryEntryContentByteLimit)
 }

--- a/pkg/buildkite/failure_summary_test.go
+++ b/pkg/buildkite/failure_summary_test.go
@@ -24,7 +24,7 @@ func TestGetBuildFailureSummaryToolDefinition(t *testing.T) {
 	require.Equal(t, "get_build_failure_summary", tool.Name)
 	require.True(t, tool.Annotations.ReadOnlyHint)
 	require.Contains(t, tool.Description, "one call")
-	require.Equal(t, []string{"read_builds", "read_build_logs", "read_suites"}, scopes)
+	require.Equal(t, []string{"read_builds", "read_build_logs"}, scopes)
 	require.NotNil(t, handler)
 }
 
@@ -41,7 +41,6 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 			require.Equal(t, "42", number)
 			require.True(t, options.ExcludeJobs)
 			require.True(t, options.ExcludePipeline)
-			require.True(t, options.IncludeTestEngine)
 			return buildkite.Build{
 				ID:      "build-id",
 				Number:  42,
@@ -53,10 +52,6 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 					Total:  5,
 					States: map[string]int{"passed": 2, "failed": 1, "running": 1, "broken": 1},
 				},
-				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
-					ID:    "run-1",
-					Suite: buildkite.TestEngineSuite{Slug: "suite-1"},
-				}}},
 			}, &buildkite.Response{Response: &http.Response{StatusCode: http.StatusOK}}, nil
 		},
 	}
@@ -109,25 +104,6 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 		},
 	}
 
-	type testExecutionCall struct {
-		org, suite, runID string
-		options           buildkite.FailedExecutionsOptions
-	}
-	var testExecutionCallsMu sync.Mutex
-	var testExecutionCalls []testExecutionCall
-	testExecutionsClient := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(_ context.Context, org, suite, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			testExecutionCallsMu.Lock()
-			testExecutionCalls = append(testExecutionCalls, testExecutionCall{org: org, suite: suite, runID: runID, options: *options})
-			testExecutionCallsMu.Unlock()
-			return []buildkite.FailedExecution{{
-				ExecutionID:   "execution-1",
-				TestName:      "TestWidgets",
-				FailureReason: "expected 2, got 3",
-			}}, &buildkite.Response{NextPage: 2}, nil
-		},
-	}
-
 	type logCall struct {
 		ttl          time.Duration
 		forceRefresh bool
@@ -151,20 +127,18 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	}
 
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{
-		BuildsClient:         buildsClient,
-		JobsClient:           jobsClient,
-		AnnotationsClient:    annotationsClient,
-		TestExecutionsClient: testExecutionsClient,
-		BuildkiteLogsClient:  logsClient,
+		BuildsClient:        buildsClient,
+		JobsClient:          jobsClient,
+		AnnotationsClient:   annotationsClient,
+		BuildkiteLogsClient: logsClient,
 	})
 
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-		OrgSlug:              "org",
-		PipelineSlug:         "pipeline",
-		BuildNumber:          "42",
-		LogTail:              2,
-		MaxFailedTestsPerRun: 7,
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "42",
+		LogTail:      2,
 	})
 	require.NoError(t, err)
 	require.False(t, callResult.IsError)
@@ -199,20 +173,6 @@ func TestGetBuildFailureSummaryAggregatesDiagnostics(t *testing.T) {
 	require.False(t, summary.AnnotationsTruncated)
 	require.Equal(t, "annotation-error", summary.Annotations[0].ID)
 	require.NotContains(t, getTextResult(t, callResult).Text, "coverage passed")
-
-	require.Len(t, summary.TestRuns, 1)
-	require.Equal(t, "suite-1", summary.TestRuns[0].TestSuiteSlug)
-	require.True(t, summary.TestRuns[0].Truncated)
-	require.Equal(t, "TestWidgets", summary.TestRuns[0].FailedExecutions[0].TestName)
-	require.False(t, summary.TestRunsTruncated)
-	require.True(t, summary.FailedTestsTruncated)
-
-	testExecutionCallsMu.Lock()
-	require.Equal(t, []testExecutionCall{{
-		org: "org", suite: "suite-1", runID: "run-1",
-		options: buildkite.FailedExecutionsOptions{Page: 1, PerPage: 7},
-	}}, testExecutionCalls)
-	testExecutionCallsMu.Unlock()
 
 	logCallsMu.Lock()
 	require.Equal(t, map[string][]logCall{
@@ -285,7 +245,7 @@ func TestGetBuildFailureSummaryPrioritizesFailuresAndCanceledJobsBeforeDownstrea
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 3,
-		IncludeLogs: &include, IncludeAnnotations: &include, IncludeFailedTests: &include,
+		IncludeLogs: &include, IncludeAnnotations: &include,
 	})
 	require.NoError(t, err)
 
@@ -338,7 +298,7 @@ func TestGetBuildFailureSummaryEnforcesServerJobLimit(t *testing.T) {
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1", MaxJobs: 50,
-		IncludeAnnotations: &include, IncludeFailedTests: &include,
+		IncludeAnnotations: &include,
 	})
 	require.NoError(t, err)
 
@@ -388,7 +348,7 @@ func TestGetBuildFailureSummaryIncludesTimedOutJobAndLog(t *testing.T) {
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
-		IncludeAnnotations: &include, IncludeFailedTests: &include,
+		IncludeAnnotations: &include,
 	})
 	require.NoError(t, err)
 
@@ -438,7 +398,7 @@ func TestGetBuildFailureSummaryIncludesExpiredAndDownstreamFailedJobsWithoutLogs
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
 		OrgSlug: "org", PipelineSlug: "pipeline", BuildNumber: "1",
-		IncludeAnnotations: &include, IncludeFailedTests: &include,
+		IncludeAnnotations: &include,
 	})
 	require.NoError(t, err)
 
@@ -504,7 +464,6 @@ func TestGetBuildFailureSummaryCanDisableOptionalSections(t *testing.T) {
 		BuildNumber:        "1",
 		IncludeLogs:        &include,
 		IncludeAnnotations: &include,
-		IncludeFailedTests: &include,
 	})
 
 	require.NoError(t, err)
@@ -514,7 +473,6 @@ func TestGetBuildFailureSummaryCanDisableOptionalSections(t *testing.T) {
 	require.Equal(t, "passed", summary.Build.State)
 	require.Empty(t, summary.Jobs)
 	require.Empty(t, summary.Annotations)
-	require.Empty(t, summary.TestRuns)
 }
 
 func TestGetBuildFailureSummaryLimitsFinalEscapedJSONPayload(t *testing.T) {
@@ -645,12 +603,11 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		requested := 6 * 1024
 		include := false
 		callResult, _, err := handler(logCtx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-			OrgSlug:            "org",
-			PipelineSlug:       "pipeline",
-			BuildNumber:        "1",
-			ContentLimitBytes:  requested,
+			OrgSlug:           "org",
+			PipelineSlug:      "pipeline",
+			BuildNumber:       "1",
+			ContentLimitBytes: requested,
 			IncludeAnnotations: &include,
-			IncludeFailedTests: &include,
 		})
 
 		require.NoError(t, err)
@@ -668,74 +625,6 @@ func TestGetBuildFailureSummaryHonorsContentLimitBytesArg(t *testing.T) {
 		// The semantic trim keeps the newest lines, so the final fetched line
 		// must survive.
 		require.Contains(t, job.LogTail[len(job.LogTail)-1].C, "line-59")
-	})
-
-	t.Run("trims failed-test collections semantically instead of erroring", func(t *testing.T) {
-		runs := make([]buildkite.TestEngineRun, 4)
-		for i := range runs {
-			runs[i] = buildkite.TestEngineRun{
-				ID:    fmt.Sprintf("run-%d", i+1),
-				Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
-			}
-		}
-		testCtx := ContextWithDeps(context.Background(), ToolDependencies{
-			BuildsClient: &MockBuildsClient{
-				GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-					return buildkite.Build{Number: 1, State: "failed", TestEngine: &buildkite.TestEngineProperty{Runs: runs}}, &buildkite.Response{}, nil
-				},
-			},
-			JobsClient: &MockJobsClient{
-				ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
-					return buildkite.JobsList{}, &buildkite.Response{}, nil
-				},
-			},
-			TestExecutionsClient: &MockTestExecutionsClient{
-				GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-					// Fully populated executions: even with every string
-					// emptied, the field keys alone put ~100 executions past
-					// the requested cap, forcing semantic item reduction.
-					executions := make([]buildkite.FailedExecution, options.PerPage)
-					for i := range executions {
-						executions[i] = buildkite.FailedExecution{
-							ExecutionID:      fmt.Sprintf("%s-execution-%d", runID, i+1),
-							RunID:            runID,
-							TestID:           fmt.Sprintf("test-%d", i+1),
-							RunName:          "nightly",
-							CommitSHA:        "abc123def456",
-							Branch:           "main",
-							TestName:         fmt.Sprintf("test %d", i+1),
-							FailureReason:    "expected true to be false",
-							Duration:         1.25,
-							Location:         "spec/widgets_spec.rb:42",
-							RunURL:           "https://buildkite.com/organizations/org/analytics/suites/suite/runs/run",
-							TestURL:          "https://buildkite.com/organizations/org/analytics/suites/suite/tests/test",
-							TestExecutionURL: "https://buildkite.com/organizations/org/analytics/suites/suite/tests/test/executions/execution",
-						}
-					}
-					return executions, &buildkite.Response{}, nil
-				},
-			},
-		})
-
-		requested := 8 * 1024
-		include := false
-		callResult, _, err := handler(testCtx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-			OrgSlug:            "org",
-			PipelineSlug:       "pipeline",
-			BuildNumber:        "1",
-			ContentLimitBytes:  requested,
-			IncludeAnnotations: &include,
-		})
-
-		require.NoError(t, err)
-		require.False(t, callResult.IsError)
-		text := getTextResult(t, callResult).Text
-		require.LessOrEqual(t, len(text), requested)
-
-		var summary BuildFailureSummary
-		require.NoError(t, json.Unmarshal([]byte(text), &summary))
-		require.True(t, summary.FailedTestsTruncated)
-		require.True(t, summary.ContentTruncated)
 	})
 
 	t.Run("clamps values above the server maximum", func(t *testing.T) {
@@ -761,8 +650,16 @@ func TestGetBuildFailureSummaryDefaultLimitPreservesCollectionsForStringOverage(
 	// An escape-heavy build message pushes the serialized payload past the
 	// default limit while the strings-emptied structure stays tiny. The
 	// generic limiter can fix that by shortening strings alone, so the
-	// semantic pass must not sacrifice failed-test items for it.
+	// semantic pass must not sacrifice annotation items for it.
 	escapeHeavy := strings.Repeat("\"\\\n", failureSummaryContentByteLimit)
+	annotationsClient := &MockAnnotationsClient{
+		ListByBuildFunc: func(_ context.Context, _, _, _ string, options *buildkite.AnnotationListOptions) ([]buildkite.Annotation, *buildkite.Response, error) {
+			if options.Page == 1 {
+				return []buildkite.Annotation{{ID: "ann-1", Style: "error", BodyHTML: "test failed"}}, &buildkite.Response{}, nil
+			}
+			return nil, &buildkite.Response{}, nil
+		},
+	}
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{
 		BuildsClient: &MockBuildsClient{
 			GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
@@ -770,10 +667,6 @@ func TestGetBuildFailureSummaryDefaultLimitPreservesCollectionsForStringOverage(
 					Number:  1,
 					State:   "failed",
 					Message: escapeHeavy,
-					TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
-						ID:    "run-1",
-						Suite: buildkite.TestEngineSuite{Slug: "suite-1"},
-					}}},
 				}, &buildkite.Response{}, nil
 			},
 		},
@@ -782,24 +675,14 @@ func TestGetBuildFailureSummaryDefaultLimitPreservesCollectionsForStringOverage(
 				return buildkite.JobsList{}, &buildkite.Response{}, nil
 			},
 		},
-		TestExecutionsClient: &MockTestExecutionsClient{
-			GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-				return []buildkite.FailedExecution{{
-					ExecutionID:   "execution-1",
-					TestName:      "TestWidgets",
-					FailureReason: "expected 2, got 3",
-				}}, &buildkite.Response{}, nil
-			},
-		},
+		AnnotationsClient: annotationsClient,
 	})
 
-	include := false
 	_, handler, _ := GetBuildFailureSummary()
 	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-		OrgSlug:            "org",
-		PipelineSlug:       "pipeline",
-		BuildNumber:        "1",
-		IncludeAnnotations: &include,
+		OrgSlug:      "org",
+		PipelineSlug: "pipeline",
+		BuildNumber:  "1",
 	})
 
 	require.NoError(t, err)
@@ -811,148 +694,7 @@ func TestGetBuildFailureSummaryDefaultLimitPreservesCollectionsForStringOverage(
 	require.NoError(t, json.Unmarshal([]byte(text), &summary))
 	require.True(t, summary.ContentTruncated)
 	require.Less(t, len(summary.Build.Message), len(escapeHeavy))
-	require.Len(t, summary.TestRuns, 1)
-	require.Len(t, summary.TestRuns[0].FailedExecutions, 1)
-	require.False(t, summary.FailedTestsTruncated)
-}
-
-func TestGetBuildFailureSummaryBoundsTestEngineWork(t *testing.T) {
-	runs := make([]buildkite.TestEngineRun, 4)
-	for i := range runs {
-		runs[i] = buildkite.TestEngineRun{
-			ID:    fmt.Sprintf("run-%d", i+1),
-			Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
-		}
-	}
-
-	buildsClient := &MockBuildsClient{
-		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			return buildkite.Build{Number: 1, State: "failed", TestEngine: &buildkite.TestEngineProperty{Runs: runs}}, &buildkite.Response{}, nil
-		},
-	}
-	jobsClient := &MockJobsClient{
-		ListByBuildFunc: func(context.Context, string, string, string, *buildkite.JobsListOptions) (buildkite.JobsList, *buildkite.Response, error) {
-			return buildkite.JobsList{}, &buildkite.Response{}, nil
-		},
-	}
-
-	var callsMu sync.Mutex
-	calls := map[string]int{}
-	testExecutionsClient := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			callsMu.Lock()
-			calls[runID] = options.PerPage
-			callsMu.Unlock()
-
-			executions := make([]buildkite.FailedExecution, options.PerPage)
-			for i := range executions {
-				executions[i] = buildkite.FailedExecution{ExecutionID: fmt.Sprintf("%s-execution-%d", runID, i+1)}
-			}
-			response := &buildkite.Response{}
-			if runID == "run-1" {
-				response.NextPage = 2
-			}
-			return executions, response, nil
-		},
-	}
-
-	include := false
-	ctx := ContextWithDeps(context.Background(), ToolDependencies{
-		BuildsClient:         buildsClient,
-		JobsClient:           jobsClient,
-		TestExecutionsClient: testExecutionsClient,
-	})
-	_, handler, _ := GetBuildFailureSummary()
-	callResult, _, err := handler(ctx, createMCPRequest(t, map[string]any{}), GetBuildFailureSummaryArgs{
-		OrgSlug:              "org",
-		PipelineSlug:         "pipeline",
-		BuildNumber:          "1",
-		IncludeLogs:          &include,
-		IncludeAnnotations:   &include,
-		MaxTestRuns:          2,
-		MaxFailedTests:       3,
-		MaxFailedTestsPerRun: 2,
-	})
-	require.NoError(t, err)
-
-	var summary BuildFailureSummary
-	require.NoError(t, json.Unmarshal([]byte(getTextResult(t, callResult).Text), &summary))
-	require.Len(t, summary.TestRuns, 2)
-	require.True(t, summary.TestRunsTruncated)
-	require.True(t, summary.FailedTestsTruncated)
-	require.Len(t, summary.TestRuns[0].FailedExecutions, 2)
-	require.Len(t, summary.TestRuns[1].FailedExecutions, 1)
-
-	callsMu.Lock()
-	require.Equal(t, map[string]int{"run-1": 2, "run-2": 2}, calls)
-	callsMu.Unlock()
-}
-
-func TestLoadFailureTestRunsInspectsMaxRunsIndependentlyOfMaxTotal(t *testing.T) {
-	runs := make([]buildkite.TestEngineRun, 20)
-	for i := range runs {
-		runs[i] = buildkite.TestEngineRun{
-			ID:    fmt.Sprintf("run-%d", i+1),
-			Suite: buildkite.TestEngineSuite{Slug: fmt.Sprintf("suite-%d", i+1)},
-		}
-	}
-
-	var callsMu sync.Mutex
-	calls := map[string]int{}
-	client := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			callsMu.Lock()
-			calls[runID] = options.PerPage
-			callsMu.Unlock()
-			if runID == "run-20" {
-				return []buildkite.FailedExecution{{ExecutionID: "execution-1"}}, &buildkite.Response{}, nil
-			}
-			return nil, &buildkite.Response{}, nil
-		},
-	}
-
-	results, runsTruncated, failedTestsTruncated, err := loadFailureTestRuns(
-		context.Background(), client, GetBuildFailureSummaryArgs{OrgSlug: "org"}, runs, 20, 20, 1,
-	)
-
-	require.NoError(t, err)
-	require.Len(t, results, 20)
-	require.False(t, runsTruncated)
-	require.False(t, failedTestsTruncated)
-	require.Empty(t, results[0].FailedExecutions)
-	require.Equal(t, "execution-1", results[19].FailedExecutions[0].ExecutionID)
-	callsMu.Lock()
-	require.Len(t, calls, 20)
-	for _, perPage := range calls {
-		require.Equal(t, 1, perPage)
-	}
-	callsMu.Unlock()
-}
-
-func TestLoadFailureTestRunsRedistributesUnusedCapacity(t *testing.T) {
-	client := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(_ context.Context, _, _, runID string, options *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			require.Equal(t, 2, options.PerPage)
-			if runID == "run-1" {
-				return nil, &buildkite.Response{}, nil
-			}
-			return []buildkite.FailedExecution{{ExecutionID: "execution-1"}, {ExecutionID: "execution-2"}}, &buildkite.Response{}, nil
-		},
-	}
-	runs := []buildkite.TestEngineRun{
-		{ID: "run-1", Suite: buildkite.TestEngineSuite{Slug: "suite-1"}},
-		{ID: "run-2", Suite: buildkite.TestEngineSuite{Slug: "suite-2"}},
-	}
-
-	results, runsTruncated, failedTestsTruncated, err := loadFailureTestRuns(
-		context.Background(), client, GetBuildFailureSummaryArgs{OrgSlug: "org"}, runs, 2, 2, 3,
-	)
-
-	require.NoError(t, err)
-	require.False(t, runsTruncated)
-	require.False(t, failedTestsTruncated)
-	require.Empty(t, results[0].FailedExecutions)
-	require.Len(t, results[1].FailedExecutions, 2)
+	require.Len(t, summary.Annotations, 1)
 }
 
 func TestGetBuildFailureSummaryPreservesPartialResultForForbiddenOptionalSections(t *testing.T) {
@@ -968,13 +710,7 @@ func TestGetBuildFailureSummaryPreservesPartialResultForForbiddenOptionalSection
 	}
 	buildsClient := &MockBuildsClient{
 		GetFunc: func(context.Context, string, string, string, *buildkite.BuildGetOptions) (buildkite.Build, *buildkite.Response, error) {
-			return buildkite.Build{
-				Number: 1,
-				State:  "failed",
-				TestEngine: &buildkite.TestEngineProperty{Runs: []buildkite.TestEngineRun{{
-					ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"},
-				}}},
-			}, &buildkite.Response{}, nil
+			return buildkite.Build{Number: 1, State: "failed"}, &buildkite.Response{}, nil
 		},
 	}
 	jobsClient := &MockJobsClient{
@@ -995,17 +731,11 @@ func TestGetBuildFailureSummaryPreservesPartialResultForForbiddenOptionalSection
 			return nil, nil, forbidden
 		},
 	}
-	testExecutionsClient := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			return nil, nil, forbidden
-		},
-	}
 	ctx := ContextWithDeps(context.Background(), ToolDependencies{
-		BuildsClient:         buildsClient,
-		JobsClient:           jobsClient,
-		BuildkiteLogsClient:  logsClient,
-		AnnotationsClient:    annotationsClient,
-		TestExecutionsClient: testExecutionsClient,
+		BuildsClient:        buildsClient,
+		JobsClient:          jobsClient,
+		BuildkiteLogsClient: logsClient,
+		AnnotationsClient:   annotationsClient,
 	})
 
 	_, handler, _ := GetBuildFailureSummary()
@@ -1021,8 +751,6 @@ func TestGetBuildFailureSummaryPreservesPartialResultForForbiddenOptionalSection
 	require.Contains(t, summary.Jobs[0].LogError, forbidden.Message)
 	require.Len(t, summary.Warnings, 1)
 	require.Contains(t, summary.Warnings[0], forbidden.Message)
-	require.Len(t, summary.TestRuns, 1)
-	require.Contains(t, summary.TestRuns[0].Error, forbidden.Message)
 }
 
 func TestFailureSummaryOptionalLoadersPropagateUnauthorized(t *testing.T) {
@@ -1061,17 +789,6 @@ func TestFailureSummaryOptionalLoadersPropagateUnauthorized(t *testing.T) {
 		require.Empty(t, jobs[0].LogError)
 	})
 
-	t.Run("test executions", func(t *testing.T) {
-		client := &MockTestExecutionsClient{
-			GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-				return nil, nil, unauthorized
-			},
-		}
-		runs := []buildkite.TestEngineRun{{ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"}}}
-
-		_, _, _, err := loadFailureTestRuns(context.Background(), client, args, runs, 1, 1, 1)
-		require.ErrorIs(t, err, ErrUnauthorized)
-	})
 }
 
 func TestFailureSummaryOptionalLoadersPreserveOrdinaryErrors(t *testing.T) {
@@ -1085,17 +802,6 @@ func TestFailureSummaryOptionalLoadersPreserveOrdinaryErrors(t *testing.T) {
 	jobs := []FailureSummaryJob{{}}
 	require.NoError(t, loadFailureLogs(context.Background(), logsClient, args, []buildkite.Job{{ID: "job", State: "failed"}}, jobs, 1))
 	require.Contains(t, jobs[0].LogError, "logs unavailable")
-
-	testClient := &MockTestExecutionsClient{
-		GetFailedExecutionsFunc: func(context.Context, string, string, string, *buildkite.FailedExecutionsOptions) ([]buildkite.FailedExecution, *buildkite.Response, error) {
-			return nil, nil, errors.New("tests unavailable")
-		},
-	}
-	runs, _, failedTestsTruncated, err := loadFailureTestRuns(context.Background(), testClient, args, []buildkite.TestEngineRun{{ID: "run", Suite: buildkite.TestEngineSuite{Slug: "suite"}}}, 1, 1, 1)
-	require.NoError(t, err)
-	require.Contains(t, runs[0].Error, "tests unavailable")
-	require.True(t, runs[0].Truncated)
-	require.True(t, failedTestsTruncated)
 }
 
 func TestReadFailureLogTailBoundsEntryContent(t *testing.T) {
@@ -1131,16 +837,13 @@ func TestBoundFailureLogEntriesReportsPartialEntryTruncation(t *testing.T) {
 	require.LessOrEqual(t, len(entries[0].C), 5)
 }
 
-func TestApplyFailureSummaryContentLimitsBoundsAggregateAndExpandedFailures(t *testing.T) {
+func TestApplyFailureSummaryContentLimitsBoundsAggregateContent(t *testing.T) {
 	const jobs = 10
 	const entriesPerJob = 50
 	content := strings.Repeat("x", failureSummaryEntryContentByteLimit)
 	result := BuildFailureSummary{
 		Jobs:        make([]FailureSummaryJob, jobs),
 		Annotations: make([]FailureSummaryAnnotation, 20),
-		TestRuns: []FailureSummaryTestRun{{
-			FailedExecutions: make([]FailureSummaryFailedExecution, 10),
-		}},
 	}
 	for i := range result.Jobs {
 		result.Jobs[i].LogTail = make([]FailureSummaryLogEntry, entriesPerJob)
@@ -1150,14 +853,6 @@ func TestApplyFailureSummaryContentLimitsBoundsAggregateAndExpandedFailures(t *t
 	}
 	for i := range result.Annotations {
 		result.Annotations[i].BodyHTML = content
-	}
-	for i := range result.TestRuns[0].FailedExecutions {
-		execution := &result.TestRuns[0].FailedExecutions[i]
-		execution.FailureReason = content
-		execution.FailureExpanded = []buildkite.FailureExpanded{{
-			Backtrace: []string{content, content},
-			Expanded:  []string{content, content},
-		}}
 	}
 
 	applyFailureSummaryContentLimits(&result)
@@ -1173,38 +868,8 @@ func TestApplyFailureSummaryContentLimitsBoundsAggregateAndExpandedFailures(t *t
 		}
 	}
 	require.True(t, result.Annotations[len(result.Annotations)-1].BodyTruncated)
-	require.True(t, result.TestRuns[0].ContentTruncated)
-	for _, execution := range result.TestRuns[0].FailedExecutions {
-		require.True(t, execution.ContentTruncated)
-	}
 }
 
-func TestLimitFailureExpandedBoundsEmptyArrayStructure(t *testing.T) {
-	tests := map[string][]buildkite.FailureExpanded{
-		"failure expanded items": make([]buildkite.FailureExpanded, failureSummaryContentByteLimit),
-		"backtrace items": {{
-			Backtrace: make([]string, failureSummaryContentByteLimit),
-		}},
-		"expanded items": {{
-			Expanded: make([]string, failureSummaryContentByteLimit),
-		}},
-	}
-
-	for name, values := range tests {
-		t.Run(name, func(t *testing.T) {
-			entryRemaining := failureSummaryExecutionByteLimit
-			sectionRemaining := failureSummaryTestContentByteLimit
-			limited, truncated := limitFailureExpanded(values, &entryRemaining, &sectionRemaining)
-
-			require.True(t, truncated)
-			require.GreaterOrEqual(t, entryRemaining, 0)
-			require.GreaterOrEqual(t, sectionRemaining, 0)
-			payload, err := json.Marshal(limited)
-			require.NoError(t, err)
-			require.LessOrEqual(t, len(payload), failureSummaryExecutionByteLimit)
-		})
-	}
-}
 
 func TestLimitFailureSummaryLogCollectionsRetainsNewestRowsAndUpdatesMetadata(t *testing.T) {
 	const jobCount = 50

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -85,7 +85,7 @@ func TestGetBuildFailureSummaryArgsSchema(t *testing.T) {
 	s := schemaFor[GetBuildFailureSummaryArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[GetBuildFailureSummaryArgs](t))
 
-	for _, opt := range []string{"log_tail", "max_jobs", "max_annotations", "include_logs", "include_annotations"} {
+	for _, opt := range []string{"log_tail", "max_jobs", "max_annotations", "max_test_runs", "max_failed_tests", "include_logs", "include_annotations", "include_failed_tests", "include_failure_expanded"} {
 		require.Contains(t, s.Properties, opt)
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -85,7 +85,7 @@ func TestGetBuildFailureSummaryArgsSchema(t *testing.T) {
 	s := schemaFor[GetBuildFailureSummaryArgs](t)
 	require.Equal(t, []string{"build_number", "org_slug", "pipeline_slug"}, sortedRequired[GetBuildFailureSummaryArgs](t))
 
-	for _, opt := range []string{"log_tail", "max_jobs", "max_annotations", "max_test_runs", "max_failed_tests", "max_failed_tests_per_run", "include_logs", "include_annotations", "include_failed_tests", "include_failure_expanded"} {
+	for _, opt := range []string{"log_tail", "max_jobs", "max_annotations", "include_logs", "include_annotations"} {
 		require.Contains(t, s.Properties, opt)
 		require.NotContains(t, s.Required, opt, "%s should be optional", opt)
 	}


### PR DESCRIPTION

Linear: https://linear.app/buildkite/issue/PB-3259/tweak-mcpapi-mismatch-between-fail-definition-pipelines-and-test