### PR TITLE
Select post-push builds by commit

### DIFF
--- a/pkg/buildkite/builds.go
+++ b/pkg/buildkite/builds.go
@@ -99,7 +99,7 @@ type ListBuildsArgs struct {
 	PipelineSlug string `json:"pipeline_slug,omitempty" jsonschema:"Filter builds by pipeline. When omitted, lists builds across all pipelines in the organization"`
 	Branch       string `json:"branch,omitempty" jsonschema:"Filter builds by git branch name"`
 	State        string `json:"state,omitempty" jsonschema:"Filter builds by state (scheduled, running, passed, failed, canceled, skipped)"`
-	Commit       string `json:"commit,omitempty" jsonschema:"Filter builds by specific commit SHA"`
+	Commit       string `json:"commit,omitempty" jsonschema:"Full commit SHA to match exactly; shortened SHAs are not supported"`
 	Creator      string `json:"creator,omitempty" jsonschema:"Filter builds by build creator"`
 	Page         int    `json:"page,omitempty" jsonschema:"Page number for pagination (min 1)"`
 	PerPage      int    `json:"per_page,omitempty" jsonschema:"Results per page for pagination (min 1, max 100)"`

--- a/pkg/buildkite/schema_test.go
+++ b/pkg/buildkite/schema_test.go
@@ -67,6 +67,7 @@ func TestListBuildsArgsSchema(t *testing.T) {
 
 	// Verify descriptions are set for fields that have non-obvious info
 	require.Equal(t, "Filter builds by git branch name", s.Properties["branch"].Description)
+	require.Equal(t, "Full commit SHA to match exactly; shortened SHAs are not supported", s.Properties["commit"].Description)
 	// org_slug should have no description (field name is self-explanatory)
 	require.Empty(t, s.Properties["org_slug"].Description)
 }

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -99,6 +99,10 @@ var instructionSections = []instructionSection{
 	},
 	{
 		toolset: toolsets.ToolsetBuilds,
+		text:    "Build selection after a push: resolve the pushed commit's full SHA and call list_builds with pipeline_slug and commit. Do not assume the newest build on the branch is for that push. Webhook-created builds may not appear immediately; if no exact commit match is returned, retry before concluding no build exists. Once found, use its build number with wait_for_build.",
+	},
+	{
+		toolset: toolsets.ToolsetBuilds,
 		text:    "Dynamic pipeline uploads: steps added at runtime via `buildkite-agent pipeline upload` do not appear in the pipeline's static configuration. To inspect what was dynamically uploaded, call list_step_uploads (returns each upload's state, source_job_id, created_jobs_count, and rejection details), then get_step_upload with an upload_uuid to read its dynamic pipeline definition YAML (definition_yaml field). Large definitions are omitted from get_step_upload. Step-upload data is only available while the build is within its maximum lifetime (~30 days).",
 	},
 	{

--- a/pkg/server/mcp_test.go
+++ b/pkg/server/mcp_test.go
@@ -20,6 +20,7 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		buildNumber      = "build_number is a sequential"
 		jobStateBroken   = `Job state "broken"`
 		jobOutputLinks   = "Job output links:"
+		buildSelection   = "Build selection after a push:"
 		dynamicUploads   = "Dynamic pipeline uploads:"
 		logInvestigation = "Log investigation order:"
 		annotationScope  = "Annotation scope:"
@@ -38,45 +39,45 @@ func TestBuildkiteServerInstructions(t *testing.T) {
 		{
 			name:    "all toolsets includes every section",
 			enabled: []string{"all"},
-			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope),
+			want:    append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads, logInvestigation, annotationScope),
 		},
 		{
 			name:    "builds alone",
 			enabled: []string{"builds"},
-			want:    append(append([]string{}, always...), jobStateBroken, jobOutputLinks, dynamicUploads),
+			want:    append(append([]string{}, always...), jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads),
 			notWant: []string{startHere, skillDiscovery, failureSummary, logInvestigation, annotationScope},
 		},
 		{
 			name:    "skills alone",
 			enabled: []string{"skills"},
 			want:    append(append([]string{}, always...), skillDiscovery),
-			notWant: []string{startHere, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
+			notWant: []string{startHere, failureSummary, jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:    "user alone",
 			enabled: []string{"user"},
 			want:    append(append([]string{}, always...), startHere),
-			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
+			notWant: []string{skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:     "all toolsets, read-only, omits annotation scope",
 			enabled:  []string{"all"},
 			readOnly: true,
-			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation),
+			want:     append(append([]string{}, always...), startHere, skillDiscovery, failureSummary, jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads, logInvestigation),
 			notWant:  []string{annotationScope},
 		},
 		{
 			name:    "investigations alone",
 			enabled: []string{"investigations"},
 			want:    append(append([]string{}, always...), failureSummary),
-			notWant: []string{startHere, skillDiscovery, jobStateBroken, jobOutputLinks, dynamicUploads, logInvestigation, annotationScope},
+			notWant: []string{startHere, skillDiscovery, jobStateBroken, jobOutputLinks, buildSelection, dynamicUploads, logInvestigation, annotationScope},
 		},
 		{
 			name:     "annotations toolset, read-only, omits annotation scope",
 			enabled:  []string{"annotations"},
 			readOnly: true,
 			want:     append([]string{}, always...),
-			notWant:  []string{jobOutputLinks, dynamicUploads, annotationScope},
+			notWant:  []string{jobOutputLinks, buildSelection, dynamicUploads, annotationScope},
 		},
 	}
 


### PR DESCRIPTION
Guide agents to identify webhook-created builds using the pushed commit’s full SHA instead of assuming the newest branch build is correct. Clarify that shortened SHAs are unsupported and that discovery may require retries.